### PR TITLE
Wfs data export functionality for writing common spatial file formats…

### DIFF
--- a/service-wfs/src/main/java/fi/nls/oskari/wfs/WFSExceptionHelper.java
+++ b/service-wfs/src/main/java/fi/nls/oskari/wfs/WFSExceptionHelper.java
@@ -23,6 +23,7 @@ public interface WFSExceptionHelper {
 
     public static String WARNING_GEOMETRY_PARSING_FAILED = "geometry_parsing_failed";
     public static String WARNING_SLDSTYLE_PARSING_FAILED = "sldstyle_parsing_failed";
+    public static String WARNING_GDAL_NOT_INSTALLED = "gdal_library_not_installed";
 
     public static String ERROR_INVALID_GEOMETRY_PROPERTY = "invalid_geometry_property";
     public static String ERROR_GETFEATURE_PAYLOAD_FAILED = "getfeature_payload_failed";

--- a/servlet-transport/src/main/java/fi/nls/oskari/pojo/SessionStore.java
+++ b/servlet-transport/src/main/java/fi/nls/oskari/pojo/SessionStore.java
@@ -53,6 +53,7 @@ public class SessionStore {
     private PropertyFilter propertyFilter; // passed parameter - not saved
 	private boolean keepPrevious = false; // passed parameter - not saved
     private boolean geomRequest = false; // passed parameter - geom property returned or not - not saved
+    private String exportFormat = "GEOJSON"; // passed parameter - Export file format in Expoer job - not saved
 
 	/**
 	 * Constructor with defined session key
@@ -419,6 +420,23 @@ public class SessionStore {
      */
     public void setGeomRequest(boolean geomRequest) {
         this.geomRequest = geomRequest;
+    }
+
+    /**
+     * Export file data format
+     * @return
+     */
+    @JsonIgnore
+    public String getExportFormat() {
+        return exportFormat;
+    }
+
+    /**
+     * Set export file data format in GDAL known names
+     * @param exportFormat  e.g. "GPX"
+     */
+    public void setExportFormat(String exportFormat) {
+        this.exportFormat = exportFormat;
     }
 
     /**

--- a/servlet-transport/src/main/java/fi/nls/oskari/wfs/WFSExport.java
+++ b/servlet-transport/src/main/java/fi/nls/oskari/wfs/WFSExport.java
@@ -1,0 +1,322 @@
+package fi.nls.oskari.wfs;
+
+import com.vividsolutions.jts.geom.*;
+import com.vividsolutions.jts.geom.Point;
+import com.vividsolutions.jts.geom.Polygon;
+
+import fi.nls.oskari.cache.JedisManager;
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.map.geometry.ProjectionHelper;
+
+import fi.nls.oskari.service.ServiceRuntimeException;
+import org.geotools.data.*;
+import org.geotools.data.ogr.OGRDataStore;
+import org.geotools.data.ogr.OGRDataStoreFactory;
+import org.geotools.data.ogr.bridj.BridjOGRDataStoreFactory;
+
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.feature.*;
+import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.geotools.feature.type.AttributeDescriptorImpl;
+import org.geotools.feature.type.AttributeTypeImpl;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+
+import org.geotools.referencing.CRS;
+
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.feature.type.AttributeDescriptor;
+import org.opengis.feature.type.AttributeType;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+
+import java.io.*;
+import java.util.*;
+import java.util.List;
+
+/**
+ * Feature export for WFS layer in the current location
+ */
+public class WFSExport {
+    private static final String KEY = "WFSExport_";
+    private static final String EXPORT_PATH = "export";
+    private static final String GDAL_CODE_ESRI_SHAPE = "ESRI SHAPEFILE";
+    private static final String GDAL_CODE_MAPINFO = "MAPINFO FILE";
+    private static final String GDAL_CODE_GPX = "GPX";
+    private static final String GDAL_CODE_KML = "KML";
+    private static final Logger log = LogFactory.getLogger(WFSExport.class);
+    private String format = null;
+    private String crsName = null;
+
+    private FeatureCollection<SimpleFeatureType, SimpleFeature> features;
+
+    protected WFSExport() {
+
+    }
+
+    /**
+     * @param format export file format
+     */
+    public WFSExport(
+            String format, String crsName) {
+        this.format = format;
+        this.crsName = crsName;
+
+    }
+
+
+    /**
+     * exports features to an export file
+     *
+     * @param {featureCollection} features
+     * @return fileid
+     */
+    public String export(
+            FeatureCollection<SimpleFeatureType, SimpleFeature> features) {
+        String fileName = null;
+
+        try {
+            OGRDataStoreFactory factory = new BridjOGRDataStoreFactory();
+            if (!factory.isAvailable()) {
+                log.info("GDAL library is not found for data export -> install gdal -- http://www.gdal.org/");
+                return fileName;
+            }
+            // OGR export doesn't work for features, which have object type properties -> trick:simplify to string type
+            CoordinateReferenceSystem crs = CRS.decode(this.crsName, true);
+            SimpleFeatureType schema = simplifyAttributes(features, crs, this.format);
+            // Add CRS for geometry descriptor
+            schema = DataUtilities.createSubType(schema, null, crs);
+            // Modify features according to new schema
+            FeatureCollection<SimpleFeatureType, SimpleFeature> sfeatures = modifiedFeatureCollection(schema, features);
+            // Get target format -> some formats (e.g. GPX, KML) support only EPSG:4326 CRS
+            // and transform in that case
+            String targetCrs = getTargetCrsName(this.format, this.crsName);
+            FeatureCollection<SimpleFeatureType, SimpleFeature> fc = ProjectionHelper.transformFeatureCollection(sfeatures, this.crsName, targetCrs);
+            // export file
+            File expFile = getExportFile(this.format, schema.getTypeName(), EXPORT_PATH);
+            Map<String, String> connectionParams = new HashMap<String, String>();
+            connectionParams.put("DriverName", this.format);
+            connectionParams.put("DatasourceName", expFile.getAbsolutePath());
+
+            fileName = expFile.getName();
+            log.debug("WFS features export - file name: ", expFile.getAbsolutePath());
+
+            OGRDataStore dataStore = (OGRDataStore) factory.createNewDataStore(connectionParams);
+
+            // Get GDAL extra options
+            String[] extra = getGdalOptions(this.format);
+
+            //write export file(s)
+            dataStore.createSchema((SimpleFeatureCollection) fc, true, extra);
+
+            dataStore.dispose();
+
+        } catch (Exception e) {
+            log.error("Feature export failed: ", e.getMessage());
+            throw new ServiceRuntimeException("WFS feature export failed for format "+this.format+ " - "+e.getMessage(), e.getCause());
+        }
+
+        return fileName;
+    }
+
+    /**
+     * Workarounds for OGR/gdal output process, because of the limits in the output formats
+     *
+     * @param fc     geotools featureCollection <-- wfs GetFeature response
+     * @param crs    source CRS
+     * @param format output format code (http://www.gdal.org/ogr_formats.html)
+     * @return
+     * @throws Exception
+     */
+    private static SimpleFeatureType simplifyAttributes(FeatureCollection<SimpleFeatureType, SimpleFeature> fc, CoordinateReferenceSystem crs, String format) throws Exception {
+
+        SimpleFeatureType schema = fc.getSchema();
+        SimpleFeatureTypeBuilder tb = new SimpleFeatureTypeBuilder();
+        tb.setName(schema.getTypeName());
+        tb.setNamespaceURI(schema.getName().getNamespaceURI());
+        tb.setCRS(crs);
+
+        for (int i = 0; i < schema.getAttributeCount(); i++) {
+            AttributeDescriptor ad = schema.getDescriptor(i);
+            ad = truncateFieldName(ad, format);
+            ad = truncateObjectProperty(ad, schema);
+            // mixed geometries in the source layer --> GPX supports only LINE, MULTILINE and POINT
+            if (ad == schema.getGeometryDescriptor() && Geometry.class.equals(ad.getType().getBinding()) && format.toUpperCase().equals("GPX")) {
+                SimpleFeature first = DataUtilities.first(fc);
+                if (first.getDefaultGeometry() instanceof MultiLineString) {
+                    tb.add(ad.getLocalName(), MultiLineString.class, crs);
+                } else if (first.getDefaultGeometry() instanceof LineString) {
+                    tb.add(ad.getLocalName(), LineString.class, crs);
+                } else if (first.getDefaultGeometry() instanceof Polygon || first.getDefaultGeometry() instanceof MultiPolygon) {
+                    tb.add(ad.getLocalName(), LineString.class, crs);
+                } else {
+                    tb.add(ad.getLocalName(), Point.class, crs);
+                }
+            } else {
+                tb.add(ad);
+            }
+        }
+
+        tb.setDefaultGeometry(schema.getGeometryDescriptor().getLocalName());
+        return tb.buildFeatureType();
+
+
+    }
+
+    /**
+     * Creates a new featurecollection
+     *
+     * @param modSchema new schema
+     * @param fc        source featureC>ollection
+     * @return
+     * @throws Exception
+     */
+    private static FeatureCollection modifiedFeatureCollection(SimpleFeatureType modSchema, FeatureCollection<SimpleFeatureType, SimpleFeature> fc) throws Exception {
+
+        FeatureCollection<SimpleFeatureType, SimpleFeature> fcnew = new DefaultFeatureCollection(fc.getID(), modSchema);
+
+        FeatureIterator<SimpleFeature> iterator = fc.features();
+        try {
+            while (iterator.hasNext()) {
+                SimpleFeature feature = iterator.next();
+                // simplify attributes
+                feature = simplifyFeatureAttributes(feature);
+                SimpleFeature changed = DataUtilities.reType(modSchema, feature);
+                if (fcnew instanceof Collection) {
+                    Collection<SimpleFeature> collection = (Collection) fcnew;
+                    collection.add(changed);
+                }
+            }
+        } finally {
+            iterator.close();
+        }
+
+        return fcnew;
+
+    }
+
+    /**
+     * Get export file name and path
+     *
+     * @param format
+     * @param typename
+     * @param path
+     * @return
+     * @throws java.io.IOException
+     */
+    private static File getExportFile(String format, String typename, String path) throws IOException {
+
+        String suffix = "." + format.toLowerCase();
+        // Is the result a fileset e.g. Mapinfo, Shape
+        if (format.toUpperCase().equals(GDAL_CODE_ESRI_SHAPE) || format.toUpperCase().equals(GDAL_CODE_MAPINFO)) {
+            suffix = "";
+        }
+        File tmpFile = File.createTempFile(typename, suffix, new File("./" + path));
+        tmpFile.delete();
+
+        return tmpFile;
+    }
+
+    /**
+     * Get target CRS name for the export data
+     *
+     * @param format  gdal format code
+     * @param crsName source CRS name
+     * @return
+     */
+    private static String getTargetCrsName(String format, String crsName) {
+
+        if (format.toUpperCase().equals(GDAL_CODE_GPX) || format.toUpperCase().equals(GDAL_CODE_KML)) {
+            return "EPSG:4326";
+        }
+        return crsName;
+    }
+
+    /**
+     * Set extra options for OGR/gdal export process (http://www.gdal.org/ogr_formats.html
+     *
+     * @param format
+     * @return
+     */
+    private static String[] getGdalOptions(String format) {
+
+        String[] extra = null;
+        if (format.equals(GDAL_CODE_GPX)) {
+            extra = new String[]{"GPX_USE_EXTENSIONS=YES"};
+        }
+        return extra;
+    }
+
+    /**
+     * Stringify complex attribute object values, which are not supported in Ogr/gdal
+     *
+     * @param fea source feature
+     * @return
+     */
+    private static SimpleFeature simplifyFeatureAttributes(SimpleFeature fea) {
+
+        List<Object> orgAttributes = fea.getAttributes();
+        List<Object> newAttributes = new ArrayList<Object>();
+
+        for (Object attr : orgAttributes) {
+            if (attr instanceof ReferencedEnvelope) {
+                newAttributes.add(((ReferencedEnvelope) attr).toString());
+            } else {
+                newAttributes.add(attr);
+            }
+        }
+        fea.setAttributes(newAttributes);
+
+        return fea;
+    }
+
+    /**
+     * Truncate property name for shape file - OGR library can't do it
+     * Maximum field name length in SHP is 10 ch ?
+     *
+     * @param ad
+     * @param format
+     * @return
+     */
+    private static AttributeDescriptor truncateFieldName(AttributeDescriptor ad, String format) {
+
+        if (format.toUpperCase().equals(GDAL_CODE_ESRI_SHAPE)) {
+            // field name truncate doesn't work in ogr -> do yourself
+            if (ad.getLocalName().length() > 10) {
+                //create the builder
+                AttributeTypeBuilder builder = new AttributeTypeBuilder();
+                builder.init(ad.getType());
+                //set truncated name for Shapefile
+                builder.setName(ad.getLocalName().substring(0, 9));
+                //build the descriptor
+                ad = builder.buildDescriptor(ad.getLocalName().substring(0, 9));
+            }
+        }
+        return ad;
+    }
+
+    /**
+     * Trick  object type property class to String class in the schema for ORG process
+     * - skip  geometry descriptor property
+     *
+     * @param ad
+     * @param schema
+     * @return
+     */
+    private static AttributeDescriptor truncateObjectProperty(AttributeDescriptor ad, SimpleFeatureType schema) {
+
+        if (Object.class.equals(ad.getType().getBinding()) ||
+                Envelope.class.equals(ad.getType().getBinding()) ||
+                ReferencedEnvelope.class.equals(ad.getType().getBinding()) ||
+                (Geometry.class.equals(ad.getType().getBinding()) && ad != schema.getGeometryDescriptor())) {
+            AttributeType at = new AttributeTypeImpl(new NameImpl("String"), String.class, false,
+                    false, Collections.EMPTY_LIST, null, null);
+            AttributeDescriptorImpl newDescriptor = new AttributeDescriptorImpl(
+                    at, new NameImpl(ad.getLocalName()), ad.getMinOccurs(),
+                    ad.getMaxOccurs(), ad.isNillable(),
+                    ad.getDefaultValue());
+            return newDescriptor;
+        }
+        return ad;
+    }
+}

--- a/servlet-transport/src/main/java/fi/nls/oskari/wfs/WFSExport.java
+++ b/servlet-transport/src/main/java/fi/nls/oskari/wfs/WFSExport.java
@@ -140,8 +140,8 @@ public class WFSExport {
             AttributeDescriptor ad = schema.getDescriptor(i);
             ad = truncateFieldName(ad, format);
             ad = truncateObjectProperty(ad, schema);
-            // mixed geometries in the source layer --> GPX supports only LINE, MULTILINE and POINT
-            if (ad == schema.getGeometryDescriptor() && Geometry.class.equals(ad.getType().getBinding()) && format.toUpperCase().equals("GPX")) {
+            // mixed geometries in the source layer or unsupported geom types ? --> GPX supports only LINE, MULTILINE and POINT
+            if (ad == schema.getGeometryDescriptor() && format.toUpperCase().equals("GPX")) {
                 SimpleFeature first = DataUtilities.first(fc);
                 if (first.getDefaultGeometry() instanceof MultiLineString) {
                     tb.add(ad.getLocalName(), MultiLineString.class, crs);
@@ -308,7 +308,8 @@ public class WFSExport {
         if (Object.class.equals(ad.getType().getBinding()) ||
                 Envelope.class.equals(ad.getType().getBinding()) ||
                 ReferencedEnvelope.class.equals(ad.getType().getBinding()) ||
-                (Geometry.class.equals(ad.getType().getBinding()) && ad != schema.getGeometryDescriptor())) {
+                HashMap.class.equals(ad.getType().getBinding()) ||
+                        (Geometry.class.equals(ad.getType().getBinding()) && ad != schema.getGeometryDescriptor())) {
             AttributeType at = new AttributeTypeImpl(new NameImpl("String"), String.class, false,
                     false, Collections.EMPTY_LIST, null, null);
             AttributeDescriptorImpl newDescriptor = new AttributeDescriptorImpl(

--- a/servlet-transport/src/main/java/fi/nls/oskari/wfs/WFSFilter.java
+++ b/servlet-transport/src/main/java/fi/nls/oskari/wfs/WFSFilter.java
@@ -165,7 +165,7 @@ public class WFSFilter {
         }else if(type == JobType.PROPERTY_FILTER) {
             LOG.debug("Filter: Property filter");
             filter = initPropertyFilter(session, bounds, layer);
-        } else if(type == JobType.NORMAL) {
+        } else if(type == JobType.NORMAL || type == JobType.EXPORT) {
             LOG.debug("Filter: normal");
             Location location;
             if(bounds != null) {

--- a/servlet-transport/src/main/java/fi/nls/oskari/wfs/extension/AdditionalIdFilter.java
+++ b/servlet-transport/src/main/java/fi/nls/oskari/wfs/extension/AdditionalIdFilter.java
@@ -62,8 +62,7 @@ public class AdditionalIdFilter extends WFSFilter {
             Filter idFilter = initIdFilter(layer, session);
             filter = ff.and(filter, idFilter);
 
-        } else if (type == JobType.NORMAL) {
-            // Analysis id
+        } else if (type == JobType.NORMAL || type == JobType.EXPORT) {
             Filter idFilter = initIdFilter(layer, session);
             filter = ff.and(filter, idFilter);
 

--- a/servlet-transport/src/main/java/fi/nls/oskari/work/JobType.java
+++ b/servlet-transport/src/main/java/fi/nls/oskari/work/JobType.java
@@ -4,7 +4,7 @@ package fi.nls.oskari.work;
  * Created by SMAKINEN on 10.3.2015.
  */
 public enum JobType {
-    NORMAL("normal"), HIGHLIGHT("highlight"), MAP_CLICK("mapClick"), GEOJSON(
+    NORMAL("normal"), EXPORT("export"), HIGHLIGHT("highlight"), MAP_CLICK("mapClick"), GEOJSON(
             "geoJSON"), PROPERTY_FILTER("property_filter");
 
     protected final String name;

--- a/servlet-transport/src/main/java/fi/nls/oskari/work/ResultProcessor.java
+++ b/servlet-transport/src/main/java/fi/nls/oskari/work/ResultProcessor.java
@@ -12,6 +12,7 @@ public interface ResultProcessor {
     public static final String CHANNEL_FEATURE = "/wfs/feature";
     public static final String CHANNEL_MAP_CLICK = "/wfs/mapClick";
     public static final String CHANNEL_FILTER = "/wfs/filter";
+    public static final String CHANNEL_EXPORT = "/wfs/export";
     public static final String CHANNEL_RESET = "/wfs/reset";
     public static final String CHANNEL_FEATURE_GEOMETRIES = "/wfs/featureGeometries";
     public static final String CHANNEL_STATUS = "/status";

--- a/servlet-transport/src/test/java/fi/nls/oskari/wfs/WFSExportTest.java
+++ b/servlet-transport/src/test/java/fi/nls/oskari/wfs/WFSExportTest.java
@@ -1,0 +1,83 @@
+package fi.nls.oskari.wfs;
+
+import fi.nls.oskari.transport.TransportJobException;
+import org.geotools.feature.FeatureCollection;
+import org.geotools.xml.Parser;
+import org.junit.Test;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+
+import static org.junit.Assert.fail;
+
+public class WFSExportTest {
+
+    String srespo = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+            "<wfs:FeatureCollection xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:oskari=\"http://www.oskari.org\" xmlns:wfs=\"http://www.opengis.net/wfs\" xmlns:gml=\"http://www.opengis.net/gml\" xmlns:ogc=\"http://www.opengis.net/ogc\" xmlns:ows=\"http://www.opengis.net/ows\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" numberOfFeatures=\"1\" timeStamp=\"2017-02-09T15:41:26.930Z\" xsi:schemaLocation=\"http://www.oskari.org http://localhost:8080/geoserver/oskari/wfs?service=WFS&amp;version=1.1.0&amp;request=DescribeFeatureType&amp;typeName=oskari%3Amy_places http://www.opengis.net/wfs http://localhost:8080/geoserver/schemas/wfs/1.1.0/wfs.xsd\">\n" +
+            "    <gml:featureMember>\n" +
+            "        <oskari:my_places gml:id=\"my_places.6\">\n" +
+            "            <gml:name>Espoo</gml:name>\n" +
+            "            <oskari:uuid>asdf-asdf-asdf-asdf-asdf</oskari:uuid>\n" +
+            "            <oskari:category_id>1</oskari:category_id>\n" +
+            "            <oskari:attention_text />\n" +
+            "            <oskari:created>2017-02-09T11:06:43.419Z</oskari:created>\n" +
+            "            <oskari:geometry>\n" +
+            "                <gml:MultiPoint srsDimension=\"2\" srsName=\"http://www.opengis.net/gml/srs/epsg.xml#3067\">\n" +
+            "                    <gml:pointMember>\n" +
+            "                        <gml:Point srsDimension=\"2\">\n" +
+            "                            <gml:pos>371384.5 6678808.5</gml:pos>\n" +
+            "                        </gml:Point>\n" +
+            "                    </gml:pointMember>\n" +
+            "                </gml:MultiPoint>\n" +
+            "            </oskari:geometry>\n" +
+            "            <oskari:place_desc>test1</oskari:place_desc>\n" +
+            "            <oskari:link />\n" +
+            "            <oskari:image_url />\n" +
+            "        </oskari:my_places>\n" +
+            "    </gml:featureMember>\n" +
+            "</wfs:FeatureCollection>";
+
+
+    @Test
+    public void testExportSimpleFeatures() throws ParserConfigurationException, SAXException, IOException {
+
+        Parser parser = GMLParser3.getParserWithoutSchemaLocator();
+
+        BufferedReader response = new BufferedReader(new StringReader(srespo));
+
+        Object obj;
+        FeatureCollection<SimpleFeatureType, SimpleFeature> featureCollection = null;
+        try {
+            obj = parser.parse(response);
+
+            if (obj instanceof FeatureCollection) {
+                featureCollection = (FeatureCollection<SimpleFeatureType, SimpleFeature>) obj;
+            } else {
+                fail("GML3 parser should result featureCollection");
+            }
+        } catch (Exception e) {
+            fail("GML3 parser should not throw exception");
+        }
+
+        //Export  featureCollection
+        try {
+            WFSExport export = new WFSExport("GPX", "EPSG:3067");
+            String filename = export.export(featureCollection);
+        }
+        catch (TransportJobException e) {
+            if(!e.getMessageKey().equals(WFSExceptionHelper.WARNING_GDAL_NOT_INSTALLED))
+            {
+                fail("WFSExport should not throw exception");
+            }
+        }
+        catch (Exception e) {
+
+            fail("WFSExport should not throw exception");
+        }
+    }
+}


### PR DESCRIPTION
Wfs data export functionality for writing common spatial file formats

::: Environmetnt Preparations :::

1. Install GDAL library for geotools in the Transport servlet platform
   - http://oskari.org/documentation/backend/configuring-dataset-import
   - version 2.1.2 is used in the tests
2. Setup security for GDAL library
   - https://www.identrust.com/certificates/trustid/root-download-x3.html
   - >keytool -importcert -alias identrust -keystore  
       .../Java/jdk1.8.0_60/jre/lib/security/cacerts" -file identrust.crt
3. Create "export" path under <Jetty home> with write access
    (Default temporary folder is used, if not created or folder is not available)

::: Test use :::

Remark: There is not yet UI in Oskari for this functionality

1. Open WFS layer in Oskari and find out its layer id
   - console> Oskari.getSandbox().findAllSelectedMapLayers();
2. Open browser console and execute below commands
   var event = Oskari.getSandbox().getEventBuilder('WFSSetExport')('<format>','<layerId>');
 
   Oskari.getSandbox().notifyAll(event);
   e.g.
   var event = Oskari.getSandbox().getEventBuilder('WFSSetExport')('GPX','26');
 
   Oskari.getSandbox().notifyAll(event);
3. Format value is OGR GDAL code (http://www.gdal.org/ogr_formats.html)
   - some formats tested succefully
     GEOJSON, Geopackage (GPKG), GPX, KML, ESRI Shapefile, Mapinfo file, PDF

4. Result file(s) are written into /export directory  in transport environment and file id is sent to Oskari
   - result is a single file  or file directory 

::: TODO :::
1. Set export UI into featuredata2 bundle ?
2. Add download permission check into frontend UI and also into Transport service
   - now there is only common view permission check in Transport
3. New action to deliver the export file(s) to the user
   - add copyright.txt file to result set files
   - zip result set
   - deliver the download link to the user

::: REMARKS :::
1. Each format in ORG Gdal library may have special limits for the result file
   - property field name length (Shape)
   - property fields (e.g. GPX)
   - supported property types
   - supported geometry types (e.g. GPX: Point,LineString and MultiLineString)
   - look at more details http://www.gdal.org/ogr_formats.html

2. Some workarounds has been made in WFSExport.java to handle those above mentioned limits
   - property field names has been truncated for Shape file (OGR truncate didn't work)
   - Object type properties are strigified ( not optimal solution)
   - Geometry type is retyped in GPX format in certain cases