### PR TITLE
Feature/search channel configurations

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -12,6 +12,13 @@ The simple System.out/err logger can now be configured with environment variable
 Removed fi.nls.oskari.util.PrintOutHelper as it's not used anywhere. 
 Use JSONHelper.isEqual(JSONArray jsonArray1, JSONArray jsonArray2) for comparing arrays instead.
 
+### Search configuration
+
+SearchOptions action route can now be configured to ignore some of the channels available in the system. This is done
+by configuring a comma-separated list of channel ids in oskari-ext.properties: 
+
+    actionhandler.SearchOptions.blacklist=METADATA_CATALOGUE_CHANNEL
+
 ## 1.41
 
 ### CSW Metadata improvements

--- a/control-base/src/main/java/fi/nls/oskari/control/data/SearchOptionsHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/data/SearchOptionsHandler.java
@@ -5,31 +5,42 @@ import fi.nls.oskari.annotation.OskariActionRoute;
 import fi.nls.oskari.control.ActionException;
 import fi.nls.oskari.control.ActionHandler;
 import fi.nls.oskari.control.ActionParameters;
+import fi.nls.oskari.domain.User;
 import fi.nls.oskari.search.channel.SearchableChannel;
 import fi.nls.oskari.service.OskariComponentManager;
 import fi.nls.oskari.util.JSONHelper;
+import fi.nls.oskari.util.PropertyUtil;
 import fi.nls.oskari.util.ResponseHelper;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 @OskariActionRoute("SearchOptions")
 public class SearchOptionsHandler extends ActionHandler {
 
     private SearchService searchService;
+    private Set<String> blacklist = new HashSet<>();
 
     @Override
     public void init() {
         super.init();
         searchService = OskariComponentManager.getComponentOfType(SearchService.class);
+        String[] blacklistedChannelIDs = PropertyUtil.getCommaSeparatedList("actionhandler.SearchOptions.blacklist");
+        if(blacklist.isEmpty()) {
+            for(String id : blacklistedChannelIDs) {
+                blacklist.add(id);
+            }
+        }
     }
     public void handleAction(final ActionParameters params) throws ActionException {
 
         Map<String, SearchableChannel> channels =  searchService.getAvailableChannels();
         JSONArray channelsJSONArray = new JSONArray();
         for(SearchableChannel channel : channels.values()) {
-            if(!channel.hasPermission(params.getUser()) || !channel.getCapabilities().canTextSearch()) {
+            if(!shouldBeIncluded(channel, params.getUser())) {
                 continue;
             }
             JSONObject json = new JSONObject();
@@ -46,5 +57,15 @@ public class SearchOptionsHandler extends ActionHandler {
         } catch (Exception ex) {
             throw new ActionException("Couldn't get WFS search channels", ex);
         }
+    }
+
+    protected boolean shouldBeIncluded(SearchableChannel channel, User user) {
+        if(!channel.getCapabilities().canTextSearch()) {
+            return false;
+        }
+        if(blacklist.contains(channel.getId())) {
+            return false;
+        }
+        return channel.hasPermission(user);
     }
 }

--- a/control-base/src/main/java/fi/nls/oskari/control/data/SearchOptionsHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/data/SearchOptionsHandler.java
@@ -29,7 +29,7 @@ public class SearchOptionsHandler extends ActionHandler {
         Map<String, SearchableChannel> channels =  searchService.getAvailableChannels();
         JSONArray channelsJSONArray = new JSONArray();
         for(SearchableChannel channel : channels.values()) {
-            if(!channel.hasPermission(params.getUser())) {
+            if(!channel.hasPermission(params.getUser()) || !channel.getCapabilities().canTextSearch()) {
                 continue;
             }
             JSONObject json = new JSONObject();

--- a/control-base/src/test/java/fi/nls/oskari/control/data/SearchOptionsHandlerTest.java
+++ b/control-base/src/test/java/fi/nls/oskari/control/data/SearchOptionsHandlerTest.java
@@ -1,0 +1,90 @@
+package fi.nls.oskari.control.data;
+
+import fi.nls.oskari.domain.User;
+import fi.nls.oskari.search.channel.SearchChannel;
+import fi.nls.oskari.search.channel.SearchableChannel;
+import fi.nls.oskari.util.PropertyUtil;
+import fi.nls.test.control.JSONActionRouteTest;
+import org.apache.poi.hpsf.Property;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Created by SMAKINEN on 27.3.2017.
+ */
+public class SearchOptionsHandlerTest extends JSONActionRouteTest {
+
+    @After
+    public void tearDown() throws Exception {
+        PropertyUtil.clearProperties();
+    }
+    private void mockCapabilities(SearchChannel channel, boolean hasTextualSearch) {
+        if(hasTextualSearch) {
+            doReturn(SearchChannel.Capabilities.TEXT).when(channel).getCapabilities();
+        } else {
+            doReturn(SearchChannel.Capabilities.COORD).when(channel).getCapabilities();
+        }
+    }
+
+    @Test
+    public void testShouldBeIncludedNonTextualSearch() throws Exception {
+        SearchChannel channel = mock(SearchChannel.class);
+        mockCapabilities(channel, false);
+        SearchOptionsHandler handler = new SearchOptionsHandler();
+        handler.init();
+        assertFalse("Channel should not permitted if there's no textual capabilities", handler.shouldBeIncluded(channel, getGuestUser()));
+    }
+    @Test
+    public void testShouldBeIncludedTextualSearch() throws Exception {
+        SearchChannel channel = mock(SearchChannel.class);
+        mockCapabilities(channel, true);
+        doReturn(true).when(channel).hasPermission(getGuestUser());
+        SearchOptionsHandler handler = new SearchOptionsHandler();
+        handler.init();
+        assertTrue("Channel should be permitted if there's textual capabilities, no blacklist and user is permitted", handler.shouldBeIncluded(channel, getGuestUser()));
+    }
+
+    @Test
+    public void testShouldBeIncludedPermission() throws Exception {
+        SearchChannel channel = mock(SearchChannel.class);
+
+        mockCapabilities(channel, true);
+        doReturn(false).when(channel).hasPermission(getGuestUser());
+        doReturn(true).when(channel).hasPermission(getLoggedInUser());
+        SearchOptionsHandler handler = new SearchOptionsHandler();
+        handler.init();
+        assertFalse("Channel should not permitted for guest", handler.shouldBeIncluded(channel, getGuestUser()));
+        assertTrue("Channel should be permitted for user", handler.shouldBeIncluded(channel, getLoggedInUser()));
+    }
+
+    @Test
+    public void testShouldBeIncludedBlacklist() throws Exception {
+        SearchChannel channel = mock(SearchChannel.class);
+
+        mockCapabilities(channel, true);
+        doReturn(true).when(channel).hasPermission(any(User.class));
+        doReturn("TestChannel").when(channel).getId();
+        // blacklisted - should not be allowed
+        PropertyUtil.addProperty("actionhandler.SearchOptions.blacklist", "TestChannel");
+
+        SearchOptionsHandler handler = new SearchOptionsHandler();
+        handler.init();
+        assertFalse("Channel should not permitted for guest", handler.shouldBeIncluded(channel, getGuestUser()));
+        assertFalse("Channel should be permitted for user", handler.shouldBeIncluded(channel, getLoggedInUser()));
+
+        // clear blacklist - should be allowed
+        PropertyUtil.clearProperties();
+        handler = new SearchOptionsHandler();
+        handler.init();
+        assertTrue("Channel should not permitted for guest", handler.shouldBeIncluded(channel, getGuestUser()));
+        assertTrue("Channel should be permitted for user", handler.shouldBeIncluded(channel, getLoggedInUser()));
+
+    }
+
+}


### PR DESCRIPTION
SearchOptions action route can now be configured to ignore some of the channels available in the system. This is done by configuring a comma-separated list of channel ids in oskari-ext.properties: 

    actionhandler.SearchOptions.blacklist=METADATA_CATALOGUE_CHANNEL