### PR TITLE
Bug/wfslayer custom sld removal

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -30,6 +30,11 @@ bundle ids. If the payload from the browser has a configuration to a bundle that
 to the published map view using the default startup from portti_bundle database table. The configuration and state for 
 the bundle are merged with the values from the browser before saving to the database.
 
+### WFS-layer removal fix
+
+The link between a custom SLD-style and a WFS-layer is now removed by database constraint when a layer is removed.
+This fixes an issue where the link prevented a WFS-layer with custom style being removed properly.
+
 ## 1.41
 
 ### CSW Metadata improvements

--- a/content-resources/src/main/resources/flyway/oskari/V1_42_1__alter_wfslayer_custom_style_constraints.sql
+++ b/content-resources/src/main/resources/flyway/oskari/V1_42_1__alter_wfslayer_custom_style_constraints.sql
@@ -1,0 +1,6 @@
+-- drop wfslayer/style mappings when user or role is deleted;
+ALTER TABLE IF EXISTS portti_wfs_layers_styles DROP CONSTRAINT portti_wfs_layers_styles_wfs_layer_fkey;
+
+ALTER TABLE IF EXISTS portti_wfs_layers_styles ADD CONSTRAINT portti_wfs_layers_styles_wfs_layer_fkey FOREIGN KEY (wfs_layer_id)
+REFERENCES portti_wfs_layer (id) MATCH SIMPLE
+ON UPDATE NO ACTION ON DELETE CASCADE;


### PR DESCRIPTION
Resolves this issue: https://github.com/oskariorg/oskari-docs/issues/24.

The link between a style and layer is now deleted by db constraint when the layer is removed.