### PR TITLE
UserLayerProcessor for property_json

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -40,6 +40,13 @@ This fixes an issue where the link prevented a WFS-layer with custom style being
 The GetRegions action route now returns the geometry as GeoJSON and reference point for the region in addition to id and name. 
 The action route now requires srs-parameter to be sent and any statslayer rows in the database should include the srs_name value.
 
+### UserLayerProcessor for property_json
+The UserLayerProcessor parses features' property_json JSONObject to new actual properties. Now GFI popup and Feature Data table show user data correctly.
+
+selected_feature_params and feature_params_locales are set empty from portti_wfs_layer table to get all non-geometry feature properties.
+
+Properties: uuid, user_layer_id, feature_id, created, updated and attention_text comes from user_layer_data table and are excluded from feature properties.
+
 ## 1.41
 
 ### CSW Metadata improvements

--- a/content-resources/src/main/java/flyway/userlayer/V1_0_5__remove_selected_params_and_locales.java
+++ b/content-resources/src/main/java/flyway/userlayer/V1_0_5__remove_selected_params_and_locales.java
@@ -1,0 +1,26 @@
+package flyway.userlayer;
+
+import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
+import fi.nls.oskari.util.PropertyUtil;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+
+/**
+ * Delete content from selected_feature_params and feature_params_locales
+ */
+public class V1_0_5__remove_selected_params_and_locales implements JdbcMigration {
+
+	public void migrate(Connection connection) throws Exception {
+		final String sql = "UPDATE portti_wfs_layer SET " +
+                "selected_feature_params = '{}', feature_params_locales = '{}' " +
+                " WHERE maplayer_id=?";
+				
+	int maplayerId = PropertyUtil.getOptional("userlayer.baselayer.id", -1);
+	
+	try (final PreparedStatement statement = connection.prepareStatement(sql)) {
+	    statement.setInt(1, maplayerId);
+	    statement.execute();
+}
+	
+	}
+}

--- a/servlet-transport/src/main/java/fi/nls/oskari/wfs/LayerProcessor.java
+++ b/servlet-transport/src/main/java/fi/nls/oskari/wfs/LayerProcessor.java
@@ -1,0 +1,14 @@
+package fi.nls.oskari.wfs;
+
+import fi.nls.oskari.wfs.pojo.WFSLayerStore;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.geotools.feature.FeatureCollection;
+
+public interface LayerProcessor {
+	boolean isProcessable(WFSLayerStore layer);
+	FeatureCollection<SimpleFeatureType, SimpleFeature> process (FeatureCollection<SimpleFeatureType, SimpleFeature> features, WFSLayerStore layer);
+		
+	
+	
+}

--- a/servlet-transport/src/main/java/fi/nls/oskari/wfs/extension/UserLayerProcessor.java
+++ b/servlet-transport/src/main/java/fi/nls/oskari/wfs/extension/UserLayerProcessor.java
@@ -1,0 +1,115 @@
+package fi.nls.oskari.wfs.extension;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.geotools.feature.DefaultFeatureCollection;
+import org.geotools.feature.FeatureCollection;
+import org.geotools.feature.FeatureIterator;
+import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.opengis.feature.Property;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.feature.type.AttributeDescriptor;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.service.ServiceRuntimeException;
+import fi.nls.oskari.util.PropertyUtil;
+import fi.nls.oskari.wfs.LayerProcessor;
+import fi.nls.oskari.wfs.pojo.WFSLayerStore;
+
+public class UserLayerProcessor implements LayerProcessor {
+		
+	private static Logger log = LogFactory.getLogger(UserLayerProcessor.class);
+	private static final String USERLAYER_PREFIX = "userlayer_";
+	
+	protected static Set<String> excludedProperties = new HashSet<String>();
+	static {		
+		excludedProperties.add("property_json");
+		excludedProperties.add("uuid");
+		excludedProperties.add("user_layer_id");
+		excludedProperties.add("feature_id");
+		excludedProperties.add("created");
+		excludedProperties.add("updated");
+		excludedProperties.add("attention_text");
+	}
+
+	public boolean isProcessable(WFSLayerStore layer) {
+		return layer.getLayerId().startsWith(USERLAYER_PREFIX);
+		//return layer.getId() == PropertyUtil.getOptional("userlayer.baselayer.id", -1); //layer.getId() == -1, should be userlayer.baselayer.id (e.g. 3 or 10)
+	}
+	
+	/**
+     * Parse features' property_json attribute and add parsed attributes to features
+     *
+     */
+    public FeatureCollection<SimpleFeatureType, SimpleFeature> process (FeatureCollection<SimpleFeatureType, SimpleFeature> features, WFSLayerStore layer){
+		
+		DefaultFeatureCollection parsedFeatures = null;
+		SimpleFeature simpleFeature;		
+		SimpleFeatureType simpleFeatureType = features.getSchema();
+		SimpleFeatureType parsedFeatureType = null;
+		SimpleFeatureBuilder featureBuilder = null;
+		SimpleFeatureTypeBuilder typeBuilder = new SimpleFeatureTypeBuilder();		
+		typeBuilder.setName(simpleFeatureType.getName());
+		typeBuilder.setNamespaceURI(layer.getFeatureNamespaceURI());
+		typeBuilder.setSRS(layer.getSRSName());
+		//typeBuilder.setCRS(layer.getCrs());
+		ObjectMapper mapper = new ObjectMapper();
+
+		//copy feature's attributes to new feature type builder
+		//do not add excludedProperties
+		for (AttributeDescriptor desc : simpleFeatureType.getAttributeDescriptors()){
+			if (!excludedProperties.contains(desc.getLocalName())){
+				typeBuilder.add(desc);
+			}
+		}
+		
+		FeatureIterator<SimpleFeature> iterator = features.features();
+		try {
+			while(iterator.hasNext()){
+				simpleFeature = iterator.next();
+				Property propertyJson = simpleFeature.getProperty("property_json");
+				Map <String,Object> jsonMap = mapper.readValue(propertyJson.getValue().toString(), new TypeReference<HashMap<String,Object>>() {});
+				
+				// only for first feature to build new processed/parsed feature type
+				if (parsedFeatureType == null){
+					// add new parsed attributes from property_json to new type builder
+					for (String attributeName : jsonMap.keySet()){
+						typeBuilder.add(attributeName, jsonMap.get(attributeName).getClass());
+						
+					}					
+					parsedFeatureType = typeBuilder.buildFeatureType();
+					parsedFeatures= new DefaultFeatureCollection(features.getID(), parsedFeatureType);
+					featureBuilder = new SimpleFeatureBuilder(parsedFeatureType);
+				}
+				//copy attribute values
+				//do not add excludedProperties
+				for (Property property : simpleFeature.getProperties()){
+					if (!excludedProperties.contains(property.getName().getLocalPart())){
+						featureBuilder.set(property.getName(), property.getValue());
+					}
+				}
+				
+				// add new attribute values (from property_json)
+				for (String attributeName : jsonMap.keySet()){
+					featureBuilder.set (attributeName, jsonMap.get(attributeName));
+				}
+				parsedFeatures.add(featureBuilder.buildFeature(simpleFeature.getID()));
+			}
+		}catch (Exception ex){
+			throw new ServiceRuntimeException("Userlayer processing failed", ex);
+		}
+		finally{
+			iterator.close();
+		}
+		return parsedFeatures;
+    }
+}

--- a/servlet-transport/src/main/java/fi/nls/oskari/work/WFSMapLayerJob.java
+++ b/servlet-transport/src/main/java/fi/nls/oskari/work/WFSMapLayerJob.java
@@ -14,6 +14,8 @@ import fi.nls.oskari.wfs.WFSFilter;
 import fi.nls.oskari.wfs.WFSParser;
 import fi.nls.oskari.wfs.pojo.WFSLayerStore;
 import fi.nls.oskari.wfs.util.HttpHelper;
+import fi.nls.oskari.wfs.extension.UserLayerProcessor;
+import fi.nls.oskari.wfs.LayerProcessor;
 import org.geotools.feature.FeatureCollection;
 import org.geotools.feature.FeatureIterator;
 import org.opengis.feature.Property;
@@ -28,6 +30,7 @@ import java.util.*;
  * Job for WFS Map Layer
  */
 public class WFSMapLayerJob extends OWSMapLayerJob {
+	LayerProcessor layerProcessor = new UserLayerProcessor ();
 
 	/**
 	 * Creates a new runnable job with own Jedis instance
@@ -112,6 +115,10 @@ public class WFSMapLayerJob extends OWSMapLayerJob {
             WFSLayerStore layer, RequestResponse requestResponse) {
         BufferedReader response = ((WFSRequestResponse) requestResponse).getResponse();
         FeatureCollection<SimpleFeatureType, SimpleFeature> features = WFSCommunicator.parseSimpleFeatures(response, layer);
+
+        if (layerProcessor.isProcessable(layer)) {
+			features = layerProcessor.process(features,layer);
+        }
 
         IOHelper.close(response);
 


### PR DESCRIPTION
The UserLayerProcessor parses features' property_json JSONObject to new actual properties. Now GFI popup and Feature Data table show user data correctly.

selected_feature_params and feature_params_locales are set empty from portti_wfs_layer table to get all non-geometry feature properties.

Properties: uuid, user_layer_id, feature_id, created, updated and attention_text comes from user_layer_data table and are excluded from feature properties.