### PR TITLE
Default JSP update for embedded maps fixing server-extension issue

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,6 +2,12 @@
 
 ## 1.42
 
+### Default published JSP-file
+
+The map element now includes the class "published" as some features detect "embedded mode" using it. It was already 
+present in the published JSP in webapp-map but missing from the default. This fixes an issue where some frontend
+ features were started in "geoportal mode" on published maps with oskari-server-extensions (namely statsgrid2016 and maplegend).
+
 ### SystemLogger
 
 The simple System.out/err logger can now be configured with environment variable "oskari.syslog.level" with a value of
@@ -50,10 +56,13 @@ Map clicks/GetFeatureInfo requests for my places layers should now properly work
 The link between a custom SLD-style and a WFS-layer is now removed by database constraint when a layer is removed.
 This fixes an issue where the link prevented a WFS-layer with custom style being removed properly.
 
-### Thematic maps regions
+### Thematic maps
 
 The GetRegions action route now returns the geometry as GeoJSON and reference point for the region in addition to id and name. 
 The action route now requires srs-parameter to be sent and any statslayer rows in the database should include the srs_name value.
+
+Datasources configuration can now have an info-object including a url key for more information about the datasource.
+The frontend will provide a link with the datasource name in attribution information when provided. 
 
 ### UserLayerProcessor for property_json
 

--- a/control-statistics/src/main/java/fi/nls/oskari/control/StatsgridHandler.java
+++ b/control-statistics/src/main/java/fi/nls/oskari/control/StatsgridHandler.java
@@ -24,7 +24,10 @@ import java.util.List;
      }, {
          "id" : 2,
          "name" : "SotkaNET",
-         "type" : "system"
+         "type" : "system",
+         "info" : {
+            "url" : "http://moreinfoaboutthis.here
+        }
      }, {
          "id" : 3,
          "name" : "KHR",
@@ -36,6 +39,7 @@ import java.util.List;
 public class StatsgridHandler extends BundleHandler {
 
     private static final String KEY_DATASOURCES = "sources";
+    private static final String KEY_INFO = "info";
 
     private static final StatisticalDatasourcePluginManager pluginManager = StatisticalDatasourcePluginManager.getInstance();
 
@@ -54,6 +58,8 @@ public class StatsgridHandler extends BundleHandler {
             JSONHelper.putValue(item, KEY_ID, src.getId());
             JSONHelper.putValue(item, KEY_NAME, src.getName(params.getLocale().getLanguage()));
             JSONHelper.putValue(item, KEY_TYPE, getType(src.getPlugin()));
+            JSONHelper.putValue(item, KEY_INFO, src.getConfigJSON().optJSONObject(KEY_INFO));
+
             sourcesList.put(item);
         }
         return false;

--- a/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/db/StatisticalDatasource.java
+++ b/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/db/StatisticalDatasource.java
@@ -111,7 +111,11 @@ public class StatisticalDatasource {
         return hints;
     }
     public JSONObject getConfigJSON() {
-        return JSONHelper.createJSONObject(config);
+        JSONObject obj = JSONHelper.createJSONObject(config);
+        if(obj != null) {
+            return obj;
+        }
+        return new JSONObject();
     }
 
     public String getConfig() {

--- a/servlet-map/src/main/resources/META-INF/resources/spring-map-jsp/published.jsp
+++ b/servlet-map/src/main/resources/META-INF/resources/spring-map-jsp/published.jsp
@@ -44,7 +44,7 @@
     <!-- ############# /css ################# -->
 </head>
 <body>
-<div id="contentMap" class="oskariui container-fluid">
+<div id="contentMap" class="oskariui container-fluid published">
     <div class="row-fluid" style="height: 100%; background-color:white;">
         <div class="oskariui-left"></div>
         <div class="span12 oskariui-center" style="height: 100%; margin: 0;">


### PR DESCRIPTION
- Fixes the default JSP-file for embedded maps for statsgrid2016 and maplegend bundles (added published class to map element)
- Datasources for statsgrid2016 now include an optional info-block containing url for more information about the datasource (to be shown on the attribution listing)