### PR TITLE
Secure layer url via GetLayerTile action route

### DIFF
--- a/MigrationGuide.md
+++ b/MigrationGuide.md
@@ -1,5 +1,16 @@
 # Migration guide
 
+## 1.42.3
+
+
+### Layer urls handling for https-services
+
+Layers with http:// urls are now proxied using the GetLayerTile action route by default.
+Previously the protocol was replaced with https:// and to preserve this functionality you can add a property
+ for oskari-ext.properties:
+
+    maplayer.wmsurl.secure=https://
+
 ## 1.42.0
 
 ### Thematic maps regionsets

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -6,6 +6,18 @@
 
 Fixed an issue where data quality fields were not parsed correctly from CSW response.
 
+### Layer urls handling for https-services
+
+Layer urls are modified for the frontend if the Oskari instance is running in a secure URL (https://). Most services only provide 
+ http urls and won't work properly if the map is loaded using https. For any layer that doesn't have a url starting
+  with https:// or / the url is modified so that the protocol part is replaced with a prefix configured with this
+   property:
+
+    maplayer.wmsurl.secure=https://
+
+If the service doesn't provide https-support you can define an empty value for the property in oskari-ext.properties.
+This will use the GetLayerTile action route to proxy the request properly via oskari-server.
+
 ## 1.42
 
 ### Default published JSP-file

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -9,14 +9,12 @@ Fixed an issue where data quality fields were not parsed correctly from CSW resp
 ### Layer urls handling for https-services
 
 Layer urls are modified for the frontend if the Oskari instance is running in a secure URL (https://). Most services only provide 
- http urls and won't work properly if the map is loaded using https. For any layer that doesn't have a url starting
-  with https:// or / the url is modified so that the protocol part is replaced with a prefix configured with this
-   property:
+ http urls and won't work properly if the map is loaded using https. For any layer where url doesn't start
+  with https:// or / the url is modified to use a proxied url with GetLayerTile action route.
+  Previously the protocol was replaced with https:// and to preserve this functionality you can add a property
+   for oskari-ext.properties:
 
     maplayer.wmsurl.secure=https://
-
-If the service doesn't provide https-support you can define an empty value for the property in oskari-ext.properties.
-This will use the GetLayerTile action route to proxy the request properly via oskari-server.
 
 ## 1.42
 

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/OskariLayer.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/OskariLayer.java
@@ -2,6 +2,7 @@ package fi.nls.oskari.domain.map;
 
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.util.IOHelper;
 import fi.nls.oskari.util.PropertyUtil;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -11,6 +12,7 @@ import java.util.*;
 public class OskariLayer extends JSONLocalizedNameAndTitle implements Comparable<OskariLayer> {
 
     private static Logger log = LogFactory.getLogger(OskariLayer.class);
+    public static final String PROPERTY_AJAXURL = "oskari.ajax.url.prefix";
 
     private static final String TYPE_COLLECTION = "collection";
     public static final String TYPE_WMS = "wmslayer";
@@ -33,7 +35,7 @@ public class OskariLayer extends JSONLocalizedNameAndTitle implements Comparable
     private String url;
 
     // simplied url is just for caching so we don't need to create it but once
-    private final static String secureBaseUrl = PropertyUtil.get("maplayer.wmsurl.secure");
+    private String secureBaseUrl = PropertyUtil.get("maplayer.wmsurl.secure", "");
     private String simplifiedUrl;
 
     // defaults
@@ -308,7 +310,14 @@ public class OskariLayer extends JSONLocalizedNameAndTitle implements Comparable
             return url;
         }
         if(isSecure) {
-            return secureBaseUrl + getSimplifiedUrl();
+            if(!secureBaseUrl.isEmpty()) {
+                return secureBaseUrl + getSimplifiedUrl();
+            }
+            // proxy layer url
+            Map<String, String> urlParams = new HashMap<String, String>();
+            urlParams.put("action_route", "GetLayerTile");
+            urlParams.put("id", Integer.toString(getId()));
+            return IOHelper.constructUrl(PropertyUtil.get(PROPERTY_AJAXURL), urlParams);
         }
         return url;
     }

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/OskariLayer.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/OskariLayer.java
@@ -4,7 +4,6 @@ import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.util.IOHelper;
 import fi.nls.oskari.util.PropertyUtil;
-import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.util.*;
@@ -314,7 +313,7 @@ public class OskariLayer extends JSONLocalizedNameAndTitle implements Comparable
                 return secureBaseUrl + getSimplifiedUrl();
             }
             // proxy layer url
-            Map<String, String> urlParams = new HashMap<String, String>();
+            Map<String, String> urlParams = new LinkedHashMap<String, String>();
             urlParams.put("action_route", "GetLayerTile");
             urlParams.put("id", Integer.toString(getId()));
             return IOHelper.constructUrl(PropertyUtil.get(PROPERTY_AJAXURL), urlParams);

--- a/service-base/src/test/java/fi/nls/oskari/domain/map/wms/OskariLayerTest.java
+++ b/service-base/src/test/java/fi/nls/oskari/domain/map/wms/OskariLayerTest.java
@@ -1,6 +1,8 @@
 package fi.nls.oskari.domain.map.wms;
 
 import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.util.PropertyUtil;
+import org.junit.After;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -12,6 +14,11 @@ import static org.junit.Assert.assertEquals;
  * @author SMAKINEN
  */
 public class OskariLayerTest {
+
+    @After
+    public void teardown() {
+        PropertyUtil.clearProperties();
+    }
 
     @Test
     public void testSimplifiedWmsURL() {
@@ -49,5 +56,32 @@ public class OskariLayerTest {
             layer.setUrl(wmsurl);
             assertEquals("Simplified wms url should be '" + tests.get(wmsurl) + "' if wms url is '" + wmsurl + "'", tests.get(wmsurl), layer.getSimplifiedUrl());
         }
+    }
+
+    @Test
+    public void testGetURL() throws Exception {
+        PropertyUtil.addProperty("maplayer.wmsurl.secure", "https://", true);
+        OskariLayer layer = new OskariLayer();
+        final String url = "http://oskari.org";
+
+        layer.setUrl(url);
+        assertEquals("Url should be '" + url + "' if url is '" + url + "'", url, layer.getUrl());
+        assertEquals("Secure url should be 'https://oskari.org' if url is '" + url + "'", "https://oskari.org", layer.getUrl(true));
+
+        PropertyUtil.addProperty("maplayer.wmsurl.secure", "/tiles/", true);
+        layer = new OskariLayer();
+        layer.setUrl(url);
+        assertEquals("Url should be '" + url + "' if url is '" + url + "'", url, layer.getUrl());
+        assertEquals("Secure url should be '/tiles/oskari.org' if url is '" + url + "'", "/tiles/oskari.org", layer.getUrl(true));
+
+        PropertyUtil.addProperty("maplayer.wmsurl.secure", "", true);
+        PropertyUtil.addProperty("oskari.ajax.url.prefix", "/action?", true);
+        layer = new OskariLayer();
+        layer.setUrl(url);
+        layer.setId(37);
+        final String proxyUrl = "/action?id=37&action_route=GetLayerTile";
+        assertEquals("Url should be '" + url + "' if url is '" + url + "'", url, layer.getUrl());
+        assertEquals("Secure url should be '" + proxyUrl + "' if url is '" + url + "'", proxyUrl, layer.getUrl(true));
+
     }
 }

--- a/service-base/src/test/java/fi/nls/oskari/domain/map/wms/OskariLayerTest.java
+++ b/service-base/src/test/java/fi/nls/oskari/domain/map/wms/OskariLayerTest.java
@@ -79,7 +79,7 @@ public class OskariLayerTest {
         layer = new OskariLayer();
         layer.setUrl(url);
         layer.setId(37);
-        final String proxyUrl = "/action?id=37&action_route=GetLayerTile";
+        final String proxyUrl = "/action?action_route=GetLayerTile&id=37";
         assertEquals("Url should be '" + url + "' if url is '" + url + "'", url, layer.getUrl());
         assertEquals("Secure url should be '" + proxyUrl + "' if url is '" + url + "'", proxyUrl, layer.getUrl(true));
 

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWMS.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWMS.java
@@ -1,7 +1,6 @@
 package fi.nls.oskari.map.layer.formatters;
 
 import fi.mml.map.mapwindow.service.wms.WebMapService;
-import fi.mml.map.mapwindow.service.wms.WebMapServiceV1_3_0_Impl;
 import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;

--- a/servlet-map/src/main/resources/oskari.properties
+++ b/servlet-map/src/main/resources/oskari.properties
@@ -80,8 +80,8 @@ oskari.logger=fi.nls.oskari.log.SystemLogger
 oskari.user.service=fi.nls.oskari.user.DatabaseUserService
 
 # Default prefix for maplayer urls when using 'secure' urls (layer url is prefixed with this after removing original protocol)
-# change to something like /secure/ to enable proxying http-only services with apache/nginx
-maplayer.wmsurl.secure=https://
+# change to something like /secure/ to enable proxying http-only services with apache/nginx or https:// to just replace the protocol
+maplayer.wmsurl.secure=
 
 # redis configuration
 redis.hostname=localhost


### PR DESCRIPTION
Added a way to proxy non-secure layers using GetLayerTile action route in addition to nginx etc proxying.