### PR TITLE
Initial Openlayers 3 geoportal view

### DIFF
--- a/MigrationGuide.md
+++ b/MigrationGuide.md
@@ -14,6 +14,26 @@ If you don't want it to be added to the sample you can add this property to oska
 
     flyway.sample.1_0_10.skip=true
 
+### Openlayers 3 version for geoportal view for development
+ 
+Initial Openlayers 3 geoportal view can be added for the sample application. To add it a property is required in oskari-ext.properties:
+
+    flyway.sample.1_0_11.skip=false
+
+The view is NOT added automatically if you don't opt in. The view to create can be further configured with optional properties:
+
+    flyway.sample.1_0_11.file=ol3-geoportal-view.json
+    flyway.sample.1_0_11.view=[id for view to use as config/state template]
+    
+File needs to point to a json-file similar to 
+https://github.com/oskariorg/oskari-server/blob/master/content-resources/src/main/resources/json/views/default-full-view.json.
+The file should be located in the server classpath under /json/views/[filename].
+Note that only bundle startup information is used while config/state is being copied from the default view of the Oskari-instance.
+If you want to use a custom view as config/state template you can use the flyway.sample.1_0_11.view-property to point such view.
+The log will show the uuid for the new view once it's added or you can check the database table
+ portti_view for the uuid of the latest view in the system.
+
+    
 ## 1.41.0
 
 ### Code refactoring

--- a/content-resources/src/main/java/flyway/sample/V1_0_11__add_initial_ol3_geoportal_view.java
+++ b/content-resources/src/main/java/flyway/sample/V1_0_11__add_initial_ol3_geoportal_view.java
@@ -1,0 +1,60 @@
+package flyway.sample;
+
+import fi.nls.oskari.db.ViewHelper;
+import fi.nls.oskari.domain.map.view.Bundle;
+import fi.nls.oskari.domain.map.view.View;
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.map.view.ViewService;
+import fi.nls.oskari.map.view.ViewServiceIbatisImpl;
+import fi.nls.oskari.util.PropertyUtil;
+import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
+import org.json.JSONObject;
+
+import java.sql.Connection;
+
+/**
+ * Creates a new view that can be used to start developing a new Openlayers 3 based geoportal view.
+ * Not for production use
+ */
+public class V1_0_11__add_initial_ol3_geoportal_view implements JdbcMigration {
+
+    private static final Logger LOG = LogFactory.getLogger(V1_0_11__add_initial_ol3_geoportal_view.class);
+    private ViewService service = null;
+
+    public void migrate(Connection connection) throws Exception {
+        if(PropertyUtil.getOptional("flyway.sample.1_0_11.skip", true)) {
+            // skip by default
+            return;
+        }
+        service = new ViewServiceIbatisImpl();
+
+        final String file = PropertyUtil.get("flyway.sample.1_0_11.file", "ol3-geoportal-view.json");
+        // configure the view that should be used as default options
+        final int defaultViewId = PropertyUtil.getOptional("flyway.sample.1_0_11.view", (int) service.getDefaultViewId());
+        try {
+            // load view from json and update startups for bundles
+            JSONObject json = ViewHelper.readViewFile(file);
+            View view = ViewHelper.createView(json);
+
+            View defaultView = service.getViewWithConf(defaultViewId);
+            for(Bundle bundle: defaultView.getBundles()) {
+                Bundle newBundle = view.getBundleByName(bundle.getName());
+                if(newBundle == null) {
+                    continue;
+                }
+                // copy the settings (state and config) from current default view
+                newBundle.setState(bundle.getState());
+                newBundle.setConfig(bundle.getConfig());
+            }
+            // save to db
+            service.addView(view);
+            LOG.info("Geoportal view with Openlayers 3 added with uuid", view.getUuid());
+        } catch (Exception e) {
+            LOG.warn(e, "Something went wrong while inserting the view!",
+                    "The update failed so to have an ol3 view you need to remove this update from the database table oskari_status_sample, " +
+                            "tune the template file:", file, " and restart the server to try again");
+            throw e;
+        }
+    }
+}

--- a/content-resources/src/main/resources/json/views/ol3-geoportal-view.json
+++ b/content-resources/src/main/resources/json/views/ol3-geoportal-view.json
@@ -1,0 +1,118 @@
+{
+  "name": "Geoportal OL3",
+  "type": "USER",
+  "default": false,
+  "public": true,
+  "oskari": {
+    "application": "servlet",
+    "page": "index",
+    "development_prefix": "/applications/sample"
+  },
+  "bundles": [
+    {
+      "id": "mapfull",
+      "startup": {
+        "bundlename": "mapfull",
+        "metadata": {
+          "Import-Bundle": {
+            "mapwmts": {
+              "bundlePath": "/Oskari/packages/mapping/ol3/"
+            },
+            "mapwfs2": {
+              "bundlePath": "/Oskari/packages/mapping/ol3/"
+            },
+            "mapanalysis": {
+              "bundlePath": "/Oskari/packages/mapping/ol3/"
+            },
+            "mapuserlayers": {
+              "bundlePath": "/Oskari/packages/mapping/ol3/"
+            },
+            "maparcgis": {
+              "bundlePath": "/Oskari/packages/mapping/ol3/"
+            },
+            "mapstats": {
+              "bundlePath": "/Oskari/packages/mapping/ol3/"
+            },
+            "mapmodule": {
+              "bundlePath": "/Oskari/packages/mapping/ol3/"
+            },
+            "mapfull": {
+              "bundlePath": "/Oskari/packages/framework/bundle/"
+            },
+            "ui-components": {
+              "bundlePath": "/Oskari/packages/framework/bundle/"
+            },
+            "oskariui": {
+              "bundlePath": "/Oskari/packages/framework/bundle/"
+            }
+          }
+        }
+      }
+    },
+    { "id" : "divmanazer" },
+    {
+      "id": "toolbar",
+      "startup": {
+        "bundlename": "toolbar",
+        "metadata": {
+          "Import-Bundle": {
+            "toolbar": {
+              "bundlePath": "/Oskari/packages/mapping/ol3/"
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "infobox",
+      "startup": {
+        "bundlename": "infobox",
+        "metadata": {
+          "Import-Bundle": {
+            "infobox": {
+              "bundlePath": "/Oskari/packages/mapping/ol3/"
+            }
+          }
+        }
+      }
+    },
+    { "id" : "statehandler" },
+    {
+      "id": "drawtools",
+      "startup": {
+        "bundlename": "drawtools",
+        "metadata": {
+          "Import-Bundle": {
+            "drawtools": {
+              "bundlePath": "/Oskari/packages/mapping/ol3/"
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "routingService"
+    },
+    { "id" : "search" },
+    { "id" : "metadatacatalogue" },
+    { "id" : "layerselector2" },
+    { "id" : "layerselection2" },
+    { "id" : "coordinatedisplay" },
+    { "id" : "metadataflyout" },
+    { "id" : "personaldata" },
+    { "id" : "publisher" },
+    { "id" : "maplegend" },
+    { "id" : "userguide" },
+    { "id" : "myplaces2" },
+    { "id" : "printout" },
+    { "id" : "analyse" },
+    { "id" : "myplacesimport" },
+    {
+      "id" : "featuredata2",
+      "config": {
+        "selectionTools": true
+      }
+    },
+    { "id" : "heatmap" }
+  ]
+}


### PR DESCRIPTION
Adds (needs config to opt-in, isn't added for every install) a new OpenLayers 3 based geoportal view with bundles that are already support for OpenLayers 3 and the rest as is (with possible OL2 implementations). This is can be used as a starting point for implementing OL3 versions for the rest of the geoportal components. Enable by adding a property to oskari-ext.properties:

     flyway.sample.1_0_11.skip=false

See MigrationGuide.md for details.