### PR TITLE
Terms of use config for publisher

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -7,7 +7,7 @@
 Separate terms of use for map publishing functionality can now be configured in oskari-ext.properties:
  
     oskari.map.terms.url=https://my.site/terms    
-    oskari.map.publish.terms.url=https://my.site/terms
+    oskari.map.publish.terms.url=https://my.site/terms-for-publishing
     
 The code will look for publish terms first and default to the generic terms config if not found. 
 Both properties can be localized by adding .fi/.en etc language code at the end of the key.

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,18 @@
 # Release Notes
 
+## 1.44.0
+
+### Terms of use for map publish functionality
+ 
+Separate terms of use for map publishing functionality can now be configured in oskari-ext.properties:
+ 
+    oskari.map.terms.url=https://my.site/terms    
+    oskari.map.publish.terms.url=https://my.site/terms
+    
+The code will look for publish terms first and default to the generic terms config if not found. 
+Both properties can be localized by adding .fi/.en etc language code at the end of the key.
+The value will be populated to publisher/publisher2 bundle configs.
+
 ## 1.43.0
 
 ### servlet-printout

--- a/control-base/src/main/java/fi/nls/oskari/control/view/modifier/bundle/PublisherHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/view/modifier/bundle/PublisherHandler.java
@@ -24,6 +24,7 @@ public class PublisherHandler extends BundleHandler {
     private static JSONArray DRAW_ENABLED_ROLES = new JSONArray();
     private static final String KEY_DRAW_ROLE_IDS = "drawRoleIds";
     private static final String KEY_TERMS_OF_USE_URL = "termsOfUseUrl";
+    public static final String PROPERTY_PUBLISH_TERMS_OF_USE_URL = "oskari.map.publish.terms.url";
     public static final String PROPERTY_TERMS_OF_USE_URL = "oskari.map.terms.url";
 
     public void init() {
@@ -57,7 +58,11 @@ public class PublisherHandler extends BundleHandler {
         if(config.has(KEY_TERMS_OF_USE_URL)) {
             return;
         }
-        final Object termsObj = PropertyUtil.getLocalizableProperty(PROPERTY_TERMS_OF_USE_URL);
+
+        Object termsObj = PropertyUtil.getLocalizableProperty(PROPERTY_PUBLISH_TERMS_OF_USE_URL);
+        if(termsObj == null) {
+            termsObj = PropertyUtil.getLocalizableProperty(PROPERTY_TERMS_OF_USE_URL);
+        }
         if(termsObj instanceof String) {
             JSONHelper.putValue(config, KEY_TERMS_OF_USE_URL, termsObj);
         } else if(termsObj instanceof Map) {


### PR DESCRIPTION
Separate terms of use for map publishing functionality can now be configured in oskari-ext.properties:
 
    oskari.map.terms.url=https://my.site/terms    
    oskari.map.publish.terms.url=https://my.site/terms-for-publishing
    
The code will look for publish terms first and default to the generic terms config if not found. 
Both properties can be localized by adding .fi/.en etc language code at the end of the key.
The value will be populated to publisher/publisher2 bundle configs.