### PR TITLE
Polygon styles with no fill / no stroke

### DIFF
--- a/MigrationGuide.md
+++ b/MigrationGuide.md
@@ -1,5 +1,12 @@
 # Migration guide
 
+## Next release version
+
+### Transparent fill & stroke on polygons
+
+DefaultStyle SLDs needs to be manually updated on Geoserver from
+https://github.com/oskariorg/oskari-server/tree/master/content-resources/src/main/resources/sld
+
 ## 1.42.1
 
 ### User registration feature

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## Next release version
+
+### Transparent fill & stroke on polygons
+
+Polygon style now supports no fill and no stroke. The condition is expressed as allowed null color string values for "fill_color" and "border_color" in UserLayerStyle/AnalysisStyle/MyPlaceCategory/WFSLayerStore.
+
 ## 1.44.0
 
 ### State cookie handling

--- a/content-resources/src/main/resources/sld/analysis/AnalysisDefaultStyle.sld
+++ b/content-resources/src/main/resources/sld/analysis/AnalysisDefaultStyle.sld
@@ -646,6 +646,12 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -705,6 +711,12 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsNotEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -765,6 +777,12 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -813,6 +831,12 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsNotEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -862,6 +886,12 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -910,6 +940,12 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsNotEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -959,6 +995,12 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -1007,6 +1049,12 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsNotEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -1056,6 +1104,12 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -1104,6 +1158,12 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsNotEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -1130,6 +1190,194 @@
                     </PolygonSymbolizer>
                 </Rule>
 
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="in2">
+                                    <ogc:Function name="geometryType">
+                                        <ogc:PropertyName>geometry</ogc:PropertyName>
+                                    </ogc:Function>
+                                    <ogc:Literal>Polygon</ogc:Literal>
+                                    <ogc:Literal>MultiPolygon</ogc:Literal>
+                                </ogc:Function>
+                                <ogc:Literal>true</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
+                                <ogc:Literal>-1</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsNull>
+                                <ogc:PropertyName>border_color</ogc:PropertyName>
+                            </ogc:PropertyIsNull>
+                        </ogc:And>
+                    </ogc:Filter>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="in2">
+                                    <ogc:Function name="geometryType">
+                                        <ogc:PropertyName>geometry</ogc:PropertyName>
+                                    </ogc:Function>
+                                    <ogc:Literal>Polygon</ogc:Literal>
+                                    <ogc:Literal>MultiPolygon</ogc:Literal>
+                                </ogc:Function>
+                                <ogc:Literal>true</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
+                                <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsNull>
+                                <ogc:PropertyName>border_color</ogc:PropertyName>
+                            </ogc:PropertyIsNull>
+                        </ogc:And>
+                    </ogc:Filter>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <GraphicFill>
+                                <Graphic>
+                                    <Mark>
+                                        <WellKnownName>shape://slash</WellKnownName>
+                                        <Stroke>
+                                            <CssParameter name="stroke"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
+                                            <CssParameter name="stroke-width">1</CssParameter>
+                                        </Stroke>
+                                    </Mark>
+                                    <Size>4</Size>
+                                </Graphic>
+                            </GraphicFill>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="in2">
+                                    <ogc:Function name="geometryType">
+                                        <ogc:PropertyName>geometry</ogc:PropertyName>
+                                    </ogc:Function>
+                                    <ogc:Literal>Polygon</ogc:Literal>
+                                    <ogc:Literal>MultiPolygon</ogc:Literal>
+                                </ogc:Function>
+                                <ogc:Literal>true</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
+                                <ogc:Literal>1</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsNull>
+                                <ogc:PropertyName>border_color</ogc:PropertyName>
+                            </ogc:PropertyIsNull>
+                        </ogc:And>
+                    </ogc:Filter>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <GraphicFill>
+                                <Graphic>
+                                    <Mark>
+                                        <WellKnownName>shape://slash</WellKnownName>
+                                        <Stroke>
+                                            <CssParameter name="stroke"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
+                                            <CssParameter name="stroke-width">2</CssParameter>
+                                        </Stroke>
+                                    </Mark>
+                                    <Size>6</Size>
+                                </Graphic>
+                            </GraphicFill>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="in2">
+                                    <ogc:Function name="geometryType">
+                                        <ogc:PropertyName>geometry</ogc:PropertyName>
+                                    </ogc:Function>
+                                    <ogc:Literal>Polygon</ogc:Literal>
+                                    <ogc:Literal>MultiPolygon</ogc:Literal>
+                                </ogc:Function>
+                                <ogc:Literal>true</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
+                                <ogc:Literal>2</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsNull>
+                                <ogc:PropertyName>border_color</ogc:PropertyName>
+                            </ogc:PropertyIsNull>
+                        </ogc:And>
+                    </ogc:Filter>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <GraphicFill>
+                                <Graphic>
+                                    <Mark>
+                                        <WellKnownName>shape://horline</WellKnownName>
+                                        <Stroke>
+                                            <CssParameter name="stroke"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
+                                            <CssParameter name="stroke-width">0.4</CssParameter>
+                                        </Stroke>
+                                    </Mark>
+                                    <Size>4.5</Size>
+                                </Graphic>
+                            </GraphicFill>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="in2">
+                                    <ogc:Function name="geometryType">
+                                        <ogc:PropertyName>geometry</ogc:PropertyName>
+                                    </ogc:Function>
+                                    <ogc:Literal>Polygon</ogc:Literal>
+                                    <ogc:Literal>MultiPolygon</ogc:Literal>
+                                </ogc:Function>
+                                <ogc:Literal>true</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
+                                <ogc:Literal>3</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsNull>
+                                <ogc:PropertyName>border_color</ogc:PropertyName>
+                            </ogc:PropertyIsNull>
+                        </ogc:And>
+                    </ogc:Filter>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <GraphicFill>
+                                <Graphic>
+                                    <Mark>
+                                        <WellKnownName>shape://horline</WellKnownName>
+                                        <Stroke>
+                                            <CssParameter name="stroke"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
+                                            <CssParameter name="stroke-width">2</CssParameter>
+                                        </Stroke>
+                                    </Mark>
+                                    <Size>5.5</Size>
+                                </Graphic>
+                            </GraphicFill>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
             </FeatureTypeStyle>
             <!--FeatureTypeStyle>
               <Transformation>

--- a/content-resources/src/main/resources/sld/myplaces/MyPlacesDefaultStyle.sld
+++ b/content-resources/src/main/resources/sld/myplaces/MyPlacesDefaultStyle.sld
@@ -10,7 +10,7 @@
         <UserStyle>
             <Title>MyPlaces</Title>
             <FeatureTypeStyle>
-                <!--  Polygons: no fill pattern, no border dash, no attention text -->
+                <!--  Polygons: opaque stroke, no fill pattern, no border dash, no attention text -->
                 <Rule>
                     <ogc:Filter>
                         <ogc:And>
@@ -39,6 +39,12 @@
                                     <ogc:PropertyName>attention_text</ogc:PropertyName>
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                         </ogc:And>
                     </ogc:Filter>
@@ -87,7 +93,7 @@
                     </TextSymbolizer>
                 </Rule>
 
-                <!--  Polygons: no fill pattern, no border dash, attention text -->
+                <!--  Polygons: opaque stroke, no fill pattern, no border dash, attention text -->
                 <Rule>
                     <ogc:Filter>
                         <ogc:And>
@@ -117,6 +123,12 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsGreaterThan>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -164,7 +176,7 @@
                     </TextSymbolizer>
                 </Rule>
 
-                <!--  Polygons: no fill pattern, border dash, no attention text -->
+                <!--  Polygons: opaque stroke, no fill pattern, border dash, no attention text -->
                 <Rule>
                     <ogc:Filter>
                         <ogc:And>
@@ -193,6 +205,12 @@
                                     <ogc:PropertyName>attention_text</ogc:PropertyName>
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                         </ogc:And>
                     </ogc:Filter>
@@ -242,7 +260,7 @@
                     </TextSymbolizer>
                 </Rule>
 
-                <!--  Polygons: no fill pattern, border dash, attention text -->
+                <!--  Polygons: opaque stroke, no fill pattern, border dash, attention text -->
                 <Rule>
                     <ogc:Filter>
                         <ogc:And>
@@ -272,6 +290,12 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsGreaterThan>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -320,7 +344,7 @@
                     </TextSymbolizer>
                 </Rule>
 
-                <!--  Polygons: thin slash fill pattern, no border dash, no attention text -->
+                <!--  Polygons: opaque stroke, thin slash fill pattern, no border dash, no attention text -->
                 <Rule>
                     <ogc:Filter>
                         <ogc:And>
@@ -349,6 +373,12 @@
                                     <ogc:PropertyName>attention_text</ogc:PropertyName>
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                         </ogc:And>
                     </ogc:Filter>
@@ -408,7 +438,7 @@
                     </TextSymbolizer>
                 </Rule>
 
-                <!--  Polygons: thin slash fill pattern, no border dash, attention text -->
+                <!--  Polygons: opaque stroke, thin slash fill pattern, no border dash, attention text -->
                 <Rule>
                     <ogc:Filter>
                         <ogc:And>
@@ -438,6 +468,12 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsGreaterThan>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -496,7 +532,7 @@
                     </TextSymbolizer>
                 </Rule>
 
-                <!--  Polygons: thin slash fill pattern, border dash, no attention text -->
+                <!--  Polygons: opaque stroke, thin slash fill pattern, border dash, no attention text -->
                 <Rule>
                     <ogc:Filter>
                         <ogc:And>
@@ -525,6 +561,12 @@
                                     <ogc:PropertyName>attention_text</ogc:PropertyName>
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                         </ogc:And>
                     </ogc:Filter>
@@ -585,7 +627,7 @@
                     </TextSymbolizer>
                 </Rule>
 
-                <!--  Polygons: thin slash fill pattern, border dash, attention text -->
+                <!--  Polygons: opaque stroke, thin slash fill pattern, border dash, attention text -->
                 <Rule>
                     <ogc:Filter>
                         <ogc:And>
@@ -615,6 +657,12 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsGreaterThan>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -674,7 +722,7 @@
                     </TextSymbolizer>
                 </Rule>
 
-                <!--  Polygons: thick slash fill pattern, no border dash, no attention text -->
+                <!--  Polygons: opaque stroke, thick slash fill pattern, no border dash, no attention text -->
                 <Rule>
                     <ogc:Filter>
                         <ogc:And>
@@ -703,6 +751,12 @@
                                     <ogc:PropertyName>attention_text</ogc:PropertyName>
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                         </ogc:And>
                     </ogc:Filter>
@@ -762,7 +816,7 @@
                     </TextSymbolizer>
                 </Rule>
 
-                <!--  Polygons: thick slash fill pattern, no border dash, attention text -->
+                <!--  Polygons: opaque stroke, thick slash fill pattern, no border dash, attention text -->
                 <Rule>
                     <ogc:Filter>
                         <ogc:And>
@@ -792,6 +846,12 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsGreaterThan>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -850,7 +910,7 @@
                     </TextSymbolizer>
                 </Rule>
 
-                <!--  Polygons: thick slash fill pattern, border dash, no attention text -->
+                <!--  Polygons: opaque stroke, thick slash fill pattern, border dash, no attention text -->
                 <Rule>
                     <ogc:Filter>
                         <ogc:And>
@@ -879,6 +939,12 @@
                                     <ogc:PropertyName>attention_text</ogc:PropertyName>
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                         </ogc:And>
                     </ogc:Filter>
@@ -939,7 +1005,7 @@
                     </TextSymbolizer>
                 </Rule>
 
-                <!--  Polygons: thick slash fill pattern, border dash, attention text -->
+                <!--  Polygons: opaque stroke, thick slash fill pattern, border dash, attention text -->
                 <Rule>
                     <ogc:Filter>
                         <ogc:And>
@@ -969,6 +1035,12 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsGreaterThan>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -1028,7 +1100,7 @@
                     </TextSymbolizer>
                 </Rule>
 
-                <!--  Polygons: thin line fill pattern, no border dash, no attention text -->
+                <!--  Polygons: opaque stroke, thin line fill pattern, no border dash, no attention text -->
                 <Rule>
                     <ogc:Filter>
                         <ogc:And>
@@ -1057,6 +1129,12 @@
                                     <ogc:PropertyName>attention_text</ogc:PropertyName>
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                         </ogc:And>
                     </ogc:Filter>
@@ -1116,7 +1194,7 @@
                     </TextSymbolizer>
                 </Rule>
 
-                <!--  Polygons: thin line fill pattern, no border dash, attention text -->
+                <!--  Polygons: opaque stroke, thin line fill pattern, no border dash, attention text -->
                 <Rule>
                     <ogc:Filter>
                         <ogc:And>
@@ -1146,6 +1224,12 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsGreaterThan>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -1204,7 +1288,7 @@
                     </TextSymbolizer>
                 </Rule>
 
-                <!--  Polygons: thin line fill pattern, border dash, no attention text -->
+                <!--  Polygons: opaque stroke, thin line fill pattern, border dash, no attention text -->
                 <Rule>
                     <ogc:Filter>
                         <ogc:And>
@@ -1233,6 +1317,12 @@
                                     <ogc:PropertyName>attention_text</ogc:PropertyName>
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                         </ogc:And>
                     </ogc:Filter>
@@ -1293,7 +1383,7 @@
                     </TextSymbolizer>
                 </Rule>
 
-                <!--  Polygons: thin line fill pattern, border dash, attention text -->
+                <!--  Polygons: opaque stroke, thin line fill pattern, border dash, attention text -->
                 <Rule>
                     <ogc:Filter>
                         <ogc:And>
@@ -1323,6 +1413,12 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsGreaterThan>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -1382,7 +1478,7 @@
                     </TextSymbolizer>
                 </Rule>
 
-                <!--  Polygons: thick line fill pattern, no border dash, no attention text -->
+                <!--  Polygons: opaque stroke, thick line fill pattern, no border dash, no attention text -->
                 <Rule>
                     <ogc:Filter>
                         <ogc:And>
@@ -1411,6 +1507,12 @@
                                     <ogc:PropertyName>attention_text</ogc:PropertyName>
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                         </ogc:And>
                     </ogc:Filter>
@@ -1470,7 +1572,7 @@
                     </TextSymbolizer>
                 </Rule>
 
-                <!--  Polygons: thick line fill pattern, no border dash, attention text -->
+                <!--  Polygons: opaque stroke, thick line fill pattern, no border dash, attention text -->
                 <Rule>
                     <ogc:Filter>
                         <ogc:And>
@@ -1500,6 +1602,12 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsGreaterThan>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -1558,7 +1666,7 @@
                     </TextSymbolizer>
                 </Rule>
 
-                <!--  Polygons: thick line fill pattern, border dash, no attention text -->
+                <!--  Polygons: opaque stroke, thick line fill pattern, border dash, no attention text -->
                 <Rule>
                     <ogc:Filter>
                         <ogc:And>
@@ -1587,6 +1695,12 @@
                                     <ogc:PropertyName>attention_text</ogc:PropertyName>
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                         </ogc:And>
                     </ogc:Filter>
@@ -1647,7 +1761,7 @@
                     </TextSymbolizer>
                 </Rule>
 
-                <!--  Polygons: thick line fill pattern, border dash, attention text -->
+                <!--  Polygons: opaque stroke, thick line fill pattern, border dash, attention text -->
                 <Rule>
                     <ogc:Filter>
                         <ogc:And>
@@ -1677,6 +1791,12 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsGreaterThan>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -1700,6 +1820,786 @@
                             <CssParameter name="stroke-dasharray">5 2</CssParameter>
                             <CssParameter name="stroke-linejoin"><ogc:PropertyName>border_linejoin</ogc:PropertyName></CssParameter>
                         </Stroke>
+                    </PolygonSymbolizer>
+                    <TextSymbolizer>
+                        <Geometry>
+                            <ogc:Function name="centroid">
+                                <ogc:PropertyName>geometry</ogc:PropertyName>
+                            </ogc:Function>
+                        </Geometry>
+                        <Label><ogc:PropertyName>attention_text</ogc:PropertyName></Label>
+                        <Font>
+                            <CssParameter name="font-family">SansSerif.plain</CssParameter>
+                            <CssParameter name="font-size">14</CssParameter>
+                            <CssParameter name="font-style">normal</CssParameter>
+                            <CssParameter name="font-weight">bold</CssParameter>
+                        </Font>
+                        <LabelPlacement>
+                            <PointPlacement>
+                                <AnchorPoint>
+                                    <AnchorPointX>0.5</AnchorPointX>
+                                    <AnchorPointY>0.5</AnchorPointY>
+                                </AnchorPoint>
+                            </PointPlacement>
+                        </LabelPlacement>
+                        <Fill>
+                            <CssParameter name="fill">F000000</CssParameter>
+                        </Fill>
+                        <Halo>
+                            <Radius>1</Radius>
+                            <Fill>
+                                <CssParameter name="fill">#FFFFFF</CssParameter>
+                            </Fill>
+                        </Halo>
+                        <VendorOption name="autoWrap">60</VendorOption>
+                        <VendorOption name="maxDisplacement">150</VendorOption>
+                    </TextSymbolizer>
+                </Rule>
+
+                <!--  Polygons: transparent stroke, no fill pattern, no attention text -->
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="in2">
+                                    <ogc:Function name="geometryType">
+                                        <ogc:PropertyName>geometry</ogc:PropertyName>
+                                    </ogc:Function>
+                                    <ogc:Literal>Polygon</ogc:Literal>
+                                    <ogc:Literal>MultiPolygon</ogc:Literal>
+                                </ogc:Function>
+                                <ogc:Literal>true</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
+                                <ogc:Literal>-1</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="strLength">
+                                    <ogc:PropertyName>attention_text</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsNull>
+                                <ogc:PropertyName>border_color</ogc:PropertyName>
+                            </ogc:PropertyIsNull>
+                        </ogc:And>
+                    </ogc:Filter>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                    <TextSymbolizer>
+                        <Geometry>
+                            <ogc:Function name="centroid">
+                                <ogc:PropertyName>geometry</ogc:PropertyName>
+                            </ogc:Function>
+                        </Geometry>
+                        <Label><ogc:PropertyName>name</ogc:PropertyName></Label>
+                        <Font>
+                            <CssParameter name="font-family">SansSerif.plain</CssParameter>
+                            <CssParameter name="font-size">14</CssParameter>
+                            <CssParameter name="font-style">normal</CssParameter>
+                            <CssParameter name="font-weight">bold</CssParameter>
+                        </Font>
+                        <LabelPlacement>
+                            <PointPlacement>
+                                <AnchorPoint>
+                                    <AnchorPointX>0.5</AnchorPointX>
+                                    <AnchorPointY>0.5</AnchorPointY>
+                                </AnchorPoint>
+                            </PointPlacement>
+                        </LabelPlacement>
+                        <Fill>
+                            <CssParameter name="fill">F000000</CssParameter>
+                        </Fill>
+                        <Halo>
+                            <Radius>1</Radius>
+                            <Fill>
+                                <CssParameter name="fill">#FFFFFF</CssParameter>
+                            </Fill>
+                        </Halo>
+                        <VendorOption name="autoWrap">60</VendorOption>
+                        <VendorOption name="maxDisplacement">150</VendorOption>
+                    </TextSymbolizer>
+                </Rule>
+
+                <!--  Polygons: transparent stroke, no fill pattern, attention text -->
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="in2">
+                                    <ogc:Function name="geometryType">
+                                        <ogc:PropertyName>geometry</ogc:PropertyName>
+                                    </ogc:Function>
+                                    <ogc:Literal>Polygon</ogc:Literal>
+                                    <ogc:Literal>MultiPolygon</ogc:Literal>
+                                </ogc:Function>
+                                <ogc:Literal>true</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
+                                <ogc:Literal>-1</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsGreaterThan>
+                                <ogc:Function name="strLength">
+                                    <ogc:PropertyName>attention_text</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsGreaterThan>
+                            <ogc:PropertyIsNull>
+                                <ogc:PropertyName>border_color</ogc:PropertyName>
+                            </ogc:PropertyIsNull>
+                        </ogc:And>
+                    </ogc:Filter>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                    <TextSymbolizer>
+                        <Geometry>
+                            <ogc:Function name="centroid">
+                                <ogc:PropertyName>geometry</ogc:PropertyName>
+                            </ogc:Function>
+                        </Geometry>
+                        <Label><ogc:PropertyName>attention_text</ogc:PropertyName></Label>
+                        <Font>
+                            <CssParameter name="font-family">SansSerif.plain</CssParameter>
+                            <CssParameter name="font-size">14</CssParameter>
+                            <CssParameter name="font-style">normal</CssParameter>
+                            <CssParameter name="font-weight">bold</CssParameter>
+                        </Font>
+                        <LabelPlacement>
+                            <PointPlacement>
+                                <AnchorPoint>
+                                    <AnchorPointX>0.5</AnchorPointX>
+                                    <AnchorPointY>0.5</AnchorPointY>
+                                </AnchorPoint>
+                            </PointPlacement>
+                        </LabelPlacement>
+                        <Fill>
+                            <CssParameter name="fill">F000000</CssParameter>
+                        </Fill>
+                        <Halo>
+                            <Radius>1</Radius>
+                            <Fill>
+                                <CssParameter name="fill">#FFFFFF</CssParameter>
+                            </Fill>
+                        </Halo>
+                        <VendorOption name="autoWrap">60</VendorOption>
+                        <VendorOption name="maxDisplacement">150</VendorOption>
+                    </TextSymbolizer>
+                </Rule>
+
+                <!--  Polygons: transparent stroke, thin slash fill pattern, no attention text -->
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="in2">
+                                    <ogc:Function name="geometryType">
+                                        <ogc:PropertyName>geometry</ogc:PropertyName>
+                                    </ogc:Function>
+                                    <ogc:Literal>Polygon</ogc:Literal>
+                                    <ogc:Literal>MultiPolygon</ogc:Literal>
+                                </ogc:Function>
+                                <ogc:Literal>true</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
+                                <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="strLength">
+                                    <ogc:PropertyName>attention_text</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsNull>
+                                <ogc:PropertyName>border_color</ogc:PropertyName>
+                            </ogc:PropertyIsNull>
+                        </ogc:And>
+                    </ogc:Filter>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <GraphicFill>
+                                <Graphic>
+                                    <Mark>
+                                        <WellKnownName>shape://slash</WellKnownName>
+                                        <Stroke>
+                                            <CssParameter name="stroke"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
+                                            <CssParameter name="stroke-width">1</CssParameter>
+                                        </Stroke>
+                                    </Mark>
+                                    <Size>4</Size>
+                                </Graphic>
+                            </GraphicFill>
+                        </Fill>
+                    </PolygonSymbolizer>
+                    <TextSymbolizer>
+                        <Geometry>
+                            <ogc:Function name="centroid">
+                                <ogc:PropertyName>geometry</ogc:PropertyName>
+                            </ogc:Function>
+                        </Geometry>
+                        <Label><ogc:PropertyName>name</ogc:PropertyName></Label>
+                        <Font>
+                            <CssParameter name="font-family">SansSerif.plain</CssParameter>
+                            <CssParameter name="font-size">14</CssParameter>
+                            <CssParameter name="font-style">normal</CssParameter>
+                            <CssParameter name="font-weight">bold</CssParameter>
+                        </Font>
+                        <LabelPlacement>
+                            <PointPlacement>
+                                <AnchorPoint>
+                                    <AnchorPointX>0.5</AnchorPointX>
+                                    <AnchorPointY>0.5</AnchorPointY>
+                                </AnchorPoint>
+                            </PointPlacement>
+                        </LabelPlacement>
+                        <Fill>
+                            <CssParameter name="fill">F000000</CssParameter>
+                        </Fill>
+                        <Halo>
+                            <Radius>1</Radius>
+                            <Fill>
+                                <CssParameter name="fill">#FFFFFF</CssParameter>
+                            </Fill>
+                        </Halo>
+                        <VendorOption name="autoWrap">60</VendorOption>
+                        <VendorOption name="maxDisplacement">150</VendorOption>
+                    </TextSymbolizer>
+                </Rule>
+
+                <!--  Polygons: transparent stroke, thin slash fill pattern, attention text -->
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="in2">
+                                    <ogc:Function name="geometryType">
+                                        <ogc:PropertyName>geometry</ogc:PropertyName>
+                                    </ogc:Function>
+                                    <ogc:Literal>Polygon</ogc:Literal>
+                                    <ogc:Literal>MultiPolygon</ogc:Literal>
+                                </ogc:Function>
+                                <ogc:Literal>true</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
+                                <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsGreaterThan>
+                                <ogc:Function name="strLength">
+                                    <ogc:PropertyName>attention_text</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsGreaterThan>
+                            <ogc:PropertyIsNull>
+                                <ogc:PropertyName>border_color</ogc:PropertyName>
+                            </ogc:PropertyIsNull>
+                        </ogc:And>
+                    </ogc:Filter>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <GraphicFill>
+                                <Graphic>
+                                    <Mark>
+                                        <WellKnownName>shape://slash</WellKnownName>
+                                        <Stroke>
+                                            <CssParameter name="stroke"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
+                                            <CssParameter name="stroke-width">1</CssParameter>
+                                        </Stroke>
+                                    </Mark>
+                                    <Size>4</Size>
+                                </Graphic>
+                            </GraphicFill>
+                        </Fill>
+                    </PolygonSymbolizer>
+                    <TextSymbolizer>
+                        <Geometry>
+                            <ogc:Function name="centroid">
+                                <ogc:PropertyName>geometry</ogc:PropertyName>
+                            </ogc:Function>
+                        </Geometry>
+                        <Label><ogc:PropertyName>attention_text</ogc:PropertyName></Label>
+                        <Font>
+                            <CssParameter name="font-family">SansSerif.plain</CssParameter>
+                            <CssParameter name="font-size">14</CssParameter>
+                            <CssParameter name="font-style">normal</CssParameter>
+                            <CssParameter name="font-weight">bold</CssParameter>
+                        </Font>
+                        <LabelPlacement>
+                            <PointPlacement>
+                                <AnchorPoint>
+                                    <AnchorPointX>0.5</AnchorPointX>
+                                    <AnchorPointY>0.5</AnchorPointY>
+                                </AnchorPoint>
+                            </PointPlacement>
+                        </LabelPlacement>
+                        <Fill>
+                            <CssParameter name="fill">F000000</CssParameter>
+                        </Fill>
+                        <Halo>
+                            <Radius>1</Radius>
+                            <Fill>
+                                <CssParameter name="fill">#FFFFFF</CssParameter>
+                            </Fill>
+                        </Halo>
+                        <VendorOption name="autoWrap">60</VendorOption>
+                        <VendorOption name="maxDisplacement">150</VendorOption>
+                    </TextSymbolizer>
+                </Rule>
+
+                <!--  Polygons: transparent stroke, thick slash fill pattern, no attention text -->
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="in2">
+                                    <ogc:Function name="geometryType">
+                                        <ogc:PropertyName>geometry</ogc:PropertyName>
+                                    </ogc:Function>
+                                    <ogc:Literal>Polygon</ogc:Literal>
+                                    <ogc:Literal>MultiPolygon</ogc:Literal>
+                                </ogc:Function>
+                                <ogc:Literal>true</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
+                                <ogc:Literal>1</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="strLength">
+                                    <ogc:PropertyName>attention_text</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsNull>
+                                <ogc:PropertyName>border_color</ogc:PropertyName>
+                            </ogc:PropertyIsNull>
+                        </ogc:And>
+                    </ogc:Filter>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <GraphicFill>
+                                <Graphic>
+                                    <Mark>
+                                        <WellKnownName>shape://slash</WellKnownName>
+                                        <Stroke>
+                                            <CssParameter name="stroke"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
+                                            <CssParameter name="stroke-width">2</CssParameter>
+                                        </Stroke>
+                                    </Mark>
+                                    <Size>6</Size>
+                                </Graphic>
+                            </GraphicFill>
+                        </Fill>
+                    </PolygonSymbolizer>
+                    <TextSymbolizer>
+                        <Geometry>
+                            <ogc:Function name="centroid">
+                                <ogc:PropertyName>geometry</ogc:PropertyName>
+                            </ogc:Function>
+                        </Geometry>
+                        <Label><ogc:PropertyName>name</ogc:PropertyName></Label>
+                        <Font>
+                            <CssParameter name="font-family">SansSerif.plain</CssParameter>
+                            <CssParameter name="font-size">14</CssParameter>
+                            <CssParameter name="font-style">normal</CssParameter>
+                            <CssParameter name="font-weight">bold</CssParameter>
+                        </Font>
+                        <LabelPlacement>
+                            <PointPlacement>
+                                <AnchorPoint>
+                                    <AnchorPointX>0.5</AnchorPointX>
+                                    <AnchorPointY>0.5</AnchorPointY>
+                                </AnchorPoint>
+                            </PointPlacement>
+                        </LabelPlacement>
+                        <Fill>
+                            <CssParameter name="fill">F000000</CssParameter>
+                        </Fill>
+                        <Halo>
+                            <Radius>1</Radius>
+                            <Fill>
+                                <CssParameter name="fill">#FFFFFF</CssParameter>
+                            </Fill>
+                        </Halo>
+                        <VendorOption name="autoWrap">60</VendorOption>
+                        <VendorOption name="maxDisplacement">150</VendorOption>
+                    </TextSymbolizer>
+                </Rule>
+
+                <!--  Polygons: transparent stroke, thick slash fill pattern, attention text -->
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="in2">
+                                    <ogc:Function name="geometryType">
+                                        <ogc:PropertyName>geometry</ogc:PropertyName>
+                                    </ogc:Function>
+                                    <ogc:Literal>Polygon</ogc:Literal>
+                                    <ogc:Literal>MultiPolygon</ogc:Literal>
+                                </ogc:Function>
+                                <ogc:Literal>true</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
+                                <ogc:Literal>1</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsGreaterThan>
+                                <ogc:Function name="strLength">
+                                    <ogc:PropertyName>attention_text</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsGreaterThan>
+                            <ogc:PropertyIsNull>
+                                <ogc:PropertyName>border_color</ogc:PropertyName>
+                            </ogc:PropertyIsNull>
+                        </ogc:And>
+                    </ogc:Filter>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <GraphicFill>
+                                <Graphic>
+                                    <Mark>
+                                        <WellKnownName>shape://slash</WellKnownName>
+                                        <Stroke>
+                                            <CssParameter name="stroke"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
+                                            <CssParameter name="stroke-width">2</CssParameter>
+                                        </Stroke>
+                                    </Mark>
+                                    <Size>6</Size>
+                                </Graphic>
+                            </GraphicFill>
+                        </Fill>
+                    </PolygonSymbolizer>
+                    <TextSymbolizer>
+                        <Geometry>
+                            <ogc:Function name="centroid">
+                                <ogc:PropertyName>geometry</ogc:PropertyName>
+                            </ogc:Function>
+                        </Geometry>
+                        <Label><ogc:PropertyName>attention_text</ogc:PropertyName></Label>
+                        <Font>
+                            <CssParameter name="font-family">SansSerif.plain</CssParameter>
+                            <CssParameter name="font-size">14</CssParameter>
+                            <CssParameter name="font-style">normal</CssParameter>
+                            <CssParameter name="font-weight">bold</CssParameter>
+                        </Font>
+                        <LabelPlacement>
+                            <PointPlacement>
+                                <AnchorPoint>
+                                    <AnchorPointX>0.5</AnchorPointX>
+                                    <AnchorPointY>0.5</AnchorPointY>
+                                </AnchorPoint>
+                            </PointPlacement>
+                        </LabelPlacement>
+                        <Fill>
+                            <CssParameter name="fill">F000000</CssParameter>
+                        </Fill>
+                        <Halo>
+                            <Radius>1</Radius>
+                            <Fill>
+                                <CssParameter name="fill">#FFFFFF</CssParameter>
+                            </Fill>
+                        </Halo>
+                        <VendorOption name="autoWrap">60</VendorOption>
+                        <VendorOption name="maxDisplacement">150</VendorOption>
+                    </TextSymbolizer>
+                </Rule>
+
+
+                <!--  Polygons: transparent stroke, thin line fill pattern, no attention text -->
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="in2">
+                                    <ogc:Function name="geometryType">
+                                        <ogc:PropertyName>geometry</ogc:PropertyName>
+                                    </ogc:Function>
+                                    <ogc:Literal>Polygon</ogc:Literal>
+                                    <ogc:Literal>MultiPolygon</ogc:Literal>
+                                </ogc:Function>
+                                <ogc:Literal>true</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
+                                <ogc:Literal>2</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="strLength">
+                                    <ogc:PropertyName>attention_text</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsNull>
+                                <ogc:PropertyName>border_color</ogc:PropertyName>
+                            </ogc:PropertyIsNull>
+                        </ogc:And>
+                    </ogc:Filter>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <GraphicFill>
+                                <Graphic>
+                                    <Mark>
+                                        <WellKnownName>shape://horline</WellKnownName>
+                                        <Stroke>
+                                            <CssParameter name="stroke"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
+                                            <CssParameter name="stroke-width">0.4</CssParameter>
+                                        </Stroke>
+                                    </Mark>
+                                    <Size>4.5</Size>
+                                </Graphic>
+                            </GraphicFill>
+                        </Fill>
+                    </PolygonSymbolizer>
+                    <TextSymbolizer>
+                        <Geometry>
+                            <ogc:Function name="centroid">
+                                <ogc:PropertyName>geometry</ogc:PropertyName>
+                            </ogc:Function>
+                        </Geometry>
+                        <Label><ogc:PropertyName>name</ogc:PropertyName></Label>
+                        <Font>
+                            <CssParameter name="font-family">SansSerif.plain</CssParameter>
+                            <CssParameter name="font-size">14</CssParameter>
+                            <CssParameter name="font-style">normal</CssParameter>
+                            <CssParameter name="font-weight">bold</CssParameter>
+                        </Font>
+                        <LabelPlacement>
+                            <PointPlacement>
+                                <AnchorPoint>
+                                    <AnchorPointX>0.5</AnchorPointX>
+                                    <AnchorPointY>0.5</AnchorPointY>
+                                </AnchorPoint>
+                            </PointPlacement>
+                        </LabelPlacement>
+                        <Fill>
+                            <CssParameter name="fill">F000000</CssParameter>
+                        </Fill>
+                        <Halo>
+                            <Radius>1</Radius>
+                            <Fill>
+                                <CssParameter name="fill">#FFFFFF</CssParameter>
+                            </Fill>
+                        </Halo>
+                        <VendorOption name="autoWrap">60</VendorOption>
+                        <VendorOption name="maxDisplacement">150</VendorOption>
+                    </TextSymbolizer>
+                </Rule>
+
+                <!--  Polygons: transparent stroke, thin line fill pattern, attention text -->
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="in2">
+                                    <ogc:Function name="geometryType">
+                                        <ogc:PropertyName>geometry</ogc:PropertyName>
+                                    </ogc:Function>
+                                    <ogc:Literal>Polygon</ogc:Literal>
+                                    <ogc:Literal>MultiPolygon</ogc:Literal>
+                                </ogc:Function>
+                                <ogc:Literal>true</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
+                                <ogc:Literal>2</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsGreaterThan>
+                                <ogc:Function name="strLength">
+                                    <ogc:PropertyName>attention_text</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsGreaterThan>
+                            <ogc:PropertyIsNull>
+                                <ogc:PropertyName>border_color</ogc:PropertyName>
+                            </ogc:PropertyIsNull>
+                        </ogc:And>
+                    </ogc:Filter>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <GraphicFill>
+                                <Graphic>
+                                    <Mark>
+                                        <WellKnownName>shape://horline</WellKnownName>
+                                        <Stroke>
+                                            <CssParameter name="stroke"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
+                                            <CssParameter name="stroke-width">0.4</CssParameter>
+                                        </Stroke>
+                                    </Mark>
+                                    <Size>4.5</Size>
+                                </Graphic>
+                            </GraphicFill>
+                        </Fill>
+                    </PolygonSymbolizer>
+                    <TextSymbolizer>
+                        <Geometry>
+                            <ogc:Function name="centroid">
+                                <ogc:PropertyName>geometry</ogc:PropertyName>
+                            </ogc:Function>
+                        </Geometry>
+                        <Label><ogc:PropertyName>attention_text</ogc:PropertyName></Label>
+                        <Font>
+                            <CssParameter name="font-family">SansSerif.plain</CssParameter>
+                            <CssParameter name="font-size">14</CssParameter>
+                            <CssParameter name="font-style">normal</CssParameter>
+                            <CssParameter name="font-weight">bold</CssParameter>
+                        </Font>
+                        <LabelPlacement>
+                            <PointPlacement>
+                                <AnchorPoint>
+                                    <AnchorPointX>0.5</AnchorPointX>
+                                    <AnchorPointY>0.5</AnchorPointY>
+                                </AnchorPoint>
+                            </PointPlacement>
+                        </LabelPlacement>
+                        <Fill>
+                            <CssParameter name="fill">F000000</CssParameter>
+                        </Fill>
+                        <Halo>
+                            <Radius>1</Radius>
+                            <Fill>
+                                <CssParameter name="fill">#FFFFFF</CssParameter>
+                            </Fill>
+                        </Halo>
+                        <VendorOption name="autoWrap">60</VendorOption>
+                        <VendorOption name="maxDisplacement">150</VendorOption>
+                    </TextSymbolizer>
+                </Rule>
+
+
+                <!--  Polygons: transparent stroke, thick line fill pattern, no attention text -->
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="in2">
+                                    <ogc:Function name="geometryType">
+                                        <ogc:PropertyName>geometry</ogc:PropertyName>
+                                    </ogc:Function>
+                                    <ogc:Literal>Polygon</ogc:Literal>
+                                    <ogc:Literal>MultiPolygon</ogc:Literal>
+                                </ogc:Function>
+                                <ogc:Literal>true</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
+                                <ogc:Literal>3</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="strLength">
+                                    <ogc:PropertyName>attention_text</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsNull>
+                                <ogc:PropertyName>border_color</ogc:PropertyName>
+                            </ogc:PropertyIsNull>
+                        </ogc:And>
+                    </ogc:Filter>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <GraphicFill>
+                                <Graphic>
+                                    <Mark>
+                                        <WellKnownName>shape://horline</WellKnownName>
+                                        <Stroke>
+                                            <CssParameter name="stroke"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
+                                            <CssParameter name="stroke-width">2</CssParameter>
+                                        </Stroke>
+                                    </Mark>
+                                    <Size>5.5</Size>
+                                </Graphic>
+                            </GraphicFill>
+                        </Fill>
+                    </PolygonSymbolizer>
+                    <TextSymbolizer>
+                        <Geometry>
+                            <ogc:Function name="centroid">
+                                <ogc:PropertyName>geometry</ogc:PropertyName>
+                            </ogc:Function>
+                        </Geometry>
+                        <Label><ogc:PropertyName>name</ogc:PropertyName></Label>
+                        <Font>
+                            <CssParameter name="font-family">SansSerif.plain</CssParameter>
+                            <CssParameter name="font-size">14</CssParameter>
+                            <CssParameter name="font-style">normal</CssParameter>
+                            <CssParameter name="font-weight">bold</CssParameter>
+                        </Font>
+                        <LabelPlacement>
+                            <PointPlacement>
+                                <AnchorPoint>
+                                    <AnchorPointX>0.5</AnchorPointX>
+                                    <AnchorPointY>0.5</AnchorPointY>
+                                </AnchorPoint>
+                            </PointPlacement>
+                        </LabelPlacement>
+                        <Fill>
+                            <CssParameter name="fill">F000000</CssParameter>
+                        </Fill>
+                        <Halo>
+                            <Radius>1</Radius>
+                            <Fill>
+                                <CssParameter name="fill">#FFFFFF</CssParameter>
+                            </Fill>
+                        </Halo>
+                        <VendorOption name="autoWrap">60</VendorOption>
+                        <VendorOption name="maxDisplacement">150</VendorOption>
+                    </TextSymbolizer>
+                </Rule>
+
+                <!--  Polygons: transparent stroke, thick line fill pattern, attention text -->
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="in2">
+                                    <ogc:Function name="geometryType">
+                                        <ogc:PropertyName>geometry</ogc:PropertyName>
+                                    </ogc:Function>
+                                    <ogc:Literal>Polygon</ogc:Literal>
+                                    <ogc:Literal>MultiPolygon</ogc:Literal>
+                                </ogc:Function>
+                                <ogc:Literal>true</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
+                                <ogc:Literal>3</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsGreaterThan>
+                                <ogc:Function name="strLength">
+                                    <ogc:PropertyName>attention_text</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsGreaterThan>
+                            <ogc:PropertyIsNull>
+                                <ogc:PropertyName>border_color</ogc:PropertyName>
+                            </ogc:PropertyIsNull>
+                        </ogc:And>
+                    </ogc:Filter>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <GraphicFill>
+                                <Graphic>
+                                    <Mark>
+                                        <WellKnownName>shape://horline</WellKnownName>
+                                        <Stroke>
+                                            <CssParameter name="stroke"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
+                                            <CssParameter name="stroke-width">2</CssParameter>
+                                        </Stroke>
+                                    </Mark>
+                                    <Size>5.5</Size>
+                                </Graphic>
+                            </GraphicFill>
+                        </Fill>
                     </PolygonSymbolizer>
                     <TextSymbolizer>
                         <Geometry>

--- a/content-resources/src/main/resources/sld/userlayer/UserLayerDefaultStyle.sld
+++ b/content-resources/src/main/resources/sld/userlayer/UserLayerDefaultStyle.sld
@@ -1,1135 +1,1384 @@
 ﻿<?xml version="1.0" encoding="ISO-8859-1"?>
 <StyledLayerDescriptor version="1.0.0"
-    xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd"
-    xmlns="http://www.opengis.net/sld"
-    xmlns:ogc="http://www.opengis.net/ogc"
-    xmlns:xlink="http://www.w3.org/1999/xlink"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <NamedLayer>
-    <Name>user_data_style</Name>
-    <UserStyle>
-      <Title>user_data_style</Title>
-      <FeatureTypeStyle>              
-        <Rule>
-          <Name>PointScale1</Name>
-          <ogc:Filter>
-            <ogc:PropertyIsEqualTo>
-              <ogc:Function name="in2">
-                <ogc:Function name="geometryType">
-                  <ogc:PropertyName>geometry</ogc:PropertyName>
-                </ogc:Function>
-                <ogc:Literal>Point</ogc:Literal>
-                <ogc:Literal>MultiPoint</ogc:Literal>
-              </ogc:Function>
-              <ogc:Literal>true</ogc:Literal>
-            </ogc:PropertyIsEqualTo>
-          </ogc:Filter>     
-          <MaxScaleDenominator>1000</MaxScaleDenominator>
-          <PointSymbolizer>
-            <Graphic>
-              <Mark>
-                <WellKnownName>oskari://dot-markers#0xe00<ogc:PropertyName>dot_shape</ogc:PropertyName></WellKnownName>
-                <Fill>
-                  <CssParameter name="fill"><ogc:PropertyName>dot_color</ogc:PropertyName></CssParameter>
-                </Fill>
-                <Stroke>
-                  <CssParameter name="stroke">#B4B4B4</CssParameter>
-                </Stroke>
-              </Mark>
-              <Size>
-                <ogc:Mul>
-                  <ogc:PropertyName>dot_size</ogc:PropertyName>
-                  <ogc:Literal>42</ogc:Literal>
-                </ogc:Mul>
-              </Size>
-            </Graphic>
-          </PointSymbolizer>
-        </Rule>
+                       xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd"
+                       xmlns="http://www.opengis.net/sld"
+                       xmlns:ogc="http://www.opengis.net/ogc"
+                       xmlns:xlink="http://www.w3.org/1999/xlink"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <NamedLayer>
+        <Name>user_data_style</Name>
+        <UserStyle>
+            <Title>user_data_style</Title>
+            <FeatureTypeStyle>
+                <Rule>
+                    <Name>PointScale1</Name>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:Function name="in2">
+                                <ogc:Function name="geometryType">
+                                    <ogc:PropertyName>geometry</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>Point</ogc:Literal>
+                                <ogc:Literal>MultiPoint</ogc:Literal>
+                            </ogc:Function>
+                            <ogc:Literal>true</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>1000</MaxScaleDenominator>
+                    <PointSymbolizer>
+                        <Graphic>
+                            <Mark>
+                                <WellKnownName>oskari://dot-markers#0xe00<ogc:PropertyName>dot_shape</ogc:PropertyName></WellKnownName>
+                                <Fill>
+                                    <CssParameter name="fill"><ogc:PropertyName>dot_color</ogc:PropertyName></CssParameter>
+                                </Fill>
+                                <Stroke>
+                                    <CssParameter name="stroke">#B4B4B4</CssParameter>
+                                </Stroke>
+                            </Mark>
+                            <Size>
+                                <ogc:Mul>
+                                    <ogc:PropertyName>dot_size</ogc:PropertyName>
+                                    <ogc:Literal>42</ogc:Literal>
+                                </ogc:Mul>
+                            </Size>
+                        </Graphic>
+                    </PointSymbolizer>
+                </Rule>
 
-        <Rule>
-          <Name>PointScale2</Name>
-          <ogc:Filter>
-            <ogc:PropertyIsEqualTo>
-              <ogc:Function name="in2">
-                <ogc:Function name="geometryType">
-                  <ogc:PropertyName>geometry</ogc:PropertyName>
-                </ogc:Function>
-                <ogc:Literal>Point</ogc:Literal>
-                <ogc:Literal>MultiPoint</ogc:Literal>
-              </ogc:Function>
-              <ogc:Literal>true</ogc:Literal>
-            </ogc:PropertyIsEqualTo>       
-          </ogc:Filter>        
-          <MinScaleDenominator>1000</MinScaleDenominator>
-          <MaxScaleDenominator>3000</MaxScaleDenominator>        
-          <PointSymbolizer>          
-            <Graphic>
-              <Mark>
-                <WellKnownName>oskari://dot-markers#0xe00<ogc:PropertyName>dot_shape</ogc:PropertyName></WellKnownName>
-                <Fill>
-                  <CssParameter name="fill"><ogc:PropertyName>dot_color</ogc:PropertyName></CssParameter>
-                </Fill>
-                <Stroke>
-                  <CssParameter name="stroke">#B4B4B4</CssParameter>
-                </Stroke>
-              </Mark>
-              <Size>
-                <ogc:Mul>
-                  <ogc:PropertyName>dot_size</ogc:PropertyName>
-                  <ogc:Literal>40</ogc:Literal>
-                </ogc:Mul>
-              </Size>
-            </Graphic>
-          </PointSymbolizer>   
-        </Rule>
-  
-        <Rule>
-          <Name>PointScale3</Name>
-          <ogc:Filter>
-            <ogc:PropertyIsEqualTo>
-              <ogc:Function name="in2">
-                <ogc:Function name="geometryType">
-                  <ogc:PropertyName>geometry</ogc:PropertyName>
-                </ogc:Function>
-                <ogc:Literal>Point</ogc:Literal>
-                <ogc:Literal>MultiPoint</ogc:Literal>
-              </ogc:Function>
-              <ogc:Literal>true</ogc:Literal>
-            </ogc:PropertyIsEqualTo>       
-          </ogc:Filter>        
-          <MinScaleDenominator>3000</MinScaleDenominator>
-          <MaxScaleDenominator>6000</MaxScaleDenominator>        
-          <PointSymbolizer>
-            <Graphic>
-              <Mark>
-                <WellKnownName>oskari://dot-markers#0xe00<ogc:PropertyName>dot_shape</ogc:PropertyName></WellKnownName>
-                <Fill>
-                  <CssParameter name="fill"><ogc:PropertyName>dot_color</ogc:PropertyName></CssParameter>
-                </Fill>
-                <Stroke>
-                  <CssParameter name="stroke">#B4B4B4</CssParameter>
-                </Stroke>
-              </Mark>
-              <Size>
-                <ogc:Mul>
-                  <ogc:PropertyName>dot_size</ogc:PropertyName>
-                  <ogc:Literal>38</ogc:Literal>
-                </ogc:Mul>
-              </Size>
-            </Graphic>
-          </PointSymbolizer>
-        </Rule>
-          
-        <Rule>
-          <Name>PointScale4</Name>
-          <ogc:Filter>
-            <ogc:PropertyIsEqualTo>
-              <ogc:Function name="in2">
-                <ogc:Function name="geometryType">
-                  <ogc:PropertyName>geometry</ogc:PropertyName>
-                </ogc:Function>
-                <ogc:Literal>Point</ogc:Literal>
-                <ogc:Literal>MultiPoint</ogc:Literal>
-              </ogc:Function>
-              <ogc:Literal>true</ogc:Literal>
-            </ogc:PropertyIsEqualTo>       
-          </ogc:Filter>        
-          <MinScaleDenominator>6000</MinScaleDenominator>
-          <MaxScaleDenominator>12000</MaxScaleDenominator>        
-          <PointSymbolizer>
-            <Graphic>
-              <Mark>
-                <WellKnownName>oskari://dot-markers#0xe00<ogc:PropertyName>dot_shape</ogc:PropertyName></WellKnownName>
-                <Fill>
-                  <CssParameter name="fill"><ogc:PropertyName>dot_color</ogc:PropertyName></CssParameter>
-                </Fill>
-                <Stroke>
-                  <CssParameter name="stroke">#B4B4B4</CssParameter>
-                </Stroke>
-              </Mark>
-              <Size>
-                <ogc:Mul>
-                  <ogc:PropertyName>dot_size</ogc:PropertyName>
-                  <ogc:Literal>36</ogc:Literal>
-                </ogc:Mul>
-              </Size>
-            </Graphic>
-          </PointSymbolizer>
-        </Rule>
-          
-        <Rule>
-          <Name>PointScale5</Name>
-          <ogc:Filter>
-            <ogc:PropertyIsEqualTo>
-              <ogc:Function name="in2">
-                <ogc:Function name="geometryType">
-                  <ogc:PropertyName>geometry</ogc:PropertyName>
-                </ogc:Function>
-                <ogc:Literal>Point</ogc:Literal>
-                <ogc:Literal>MultiPoint</ogc:Literal>
-              </ogc:Function>
-              <ogc:Literal>true</ogc:Literal>
-            </ogc:PropertyIsEqualTo>       
-          </ogc:Filter>        
-          <MinScaleDenominator>12000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>        
-          <PointSymbolizer>
-            <Graphic>
-              <Mark>
-                <WellKnownName>oskari://dot-markers#0xe00<ogc:PropertyName>dot_shape</ogc:PropertyName></WellKnownName>
-                <Fill>
-                  <CssParameter name="fill"><ogc:PropertyName>dot_color</ogc:PropertyName></CssParameter>
-                </Fill>
-                <Stroke>
-                  <CssParameter name="stroke">#B4B4B4</CssParameter>
-                </Stroke>
-              </Mark>
-              <Size>
-                <ogc:Mul>
-                  <ogc:PropertyName>dot_size</ogc:PropertyName>
-                  <ogc:Literal>34</ogc:Literal>
-                </ogc:Mul>
-              </Size>
-            </Graphic>
-          </PointSymbolizer>
-        </Rule>
-  
-        <Rule>
-          <Name>PointScale6</Name>
-          <ogc:Filter>
-            <ogc:PropertyIsEqualTo>
-              <ogc:Function name="in2">
-                <ogc:Function name="geometryType">
-                  <ogc:PropertyName>geometry</ogc:PropertyName>
-                </ogc:Function>
-                <ogc:Literal>Point</ogc:Literal>
-                <ogc:Literal>MultiPoint</ogc:Literal>
-              </ogc:Function>
-              <ogc:Literal>true</ogc:Literal>
-            </ogc:PropertyIsEqualTo>       
-          </ogc:Filter>        
-          <MinScaleDenominator>25000</MinScaleDenominator>
-          <MaxScaleDenominator>50000</MaxScaleDenominator>        
-          <PointSymbolizer>
-            <Graphic>
-              <Mark>
-                <WellKnownName>oskari://dot-markers#0xe00<ogc:PropertyName>dot_shape</ogc:PropertyName></WellKnownName>
-                <Fill>
-                  <CssParameter name="fill"><ogc:PropertyName>dot_color</ogc:PropertyName></CssParameter>
-                </Fill>
-                <Stroke>
-                  <CssParameter name="stroke">#B4B4B4</CssParameter>
-                </Stroke>
-              </Mark>
-              <Size>
-                <ogc:Mul>
-                  <ogc:PropertyName>dot_size</ogc:PropertyName>
-                  <ogc:Literal>32</ogc:Literal>
-                </ogc:Mul>
-              </Size>
-            </Graphic>
-          </PointSymbolizer>
-        </Rule>
-  
-        <Rule>
-          <Name>PointScale7</Name>
-          <ogc:Filter>
-            <ogc:PropertyIsEqualTo>
-              <ogc:Function name="in2">
-                <ogc:Function name="geometryType">
-                  <ogc:PropertyName>geometry</ogc:PropertyName>
-                </ogc:Function>
-                <ogc:Literal>Point</ogc:Literal>
-                <ogc:Literal>MultiPoint</ogc:Literal>
-              </ogc:Function>
-              <ogc:Literal>true</ogc:Literal>
-            </ogc:PropertyIsEqualTo>       
-          </ogc:Filter>        
-          <MinScaleDenominator>50000</MinScaleDenominator>
-          <MaxScaleDenominator>100000</MaxScaleDenominator>        
-          <PointSymbolizer>
-            <Graphic>
-              <Mark>
-                <WellKnownName>oskari://dot-markers#0xe00<ogc:PropertyName>dot_shape</ogc:PropertyName></WellKnownName>
-                <Fill>
-                  <CssParameter name="fill"><ogc:PropertyName>dot_color</ogc:PropertyName></CssParameter>
-                </Fill>
-                <Stroke>
-                  <CssParameter name="stroke">#B4B4B4</CssParameter>
-                </Stroke>
-              </Mark>
-              <Size>
-                <ogc:Mul>
-                  <ogc:PropertyName>dot_size</ogc:PropertyName>
-                  <ogc:Literal>30</ogc:Literal>
-                </ogc:Mul>
-              </Size>
-            </Graphic>
-          </PointSymbolizer>
-        </Rule>
-  
-        <Rule>
-          <Name>PointScale8</Name>
-          <ogc:Filter>
-            <ogc:PropertyIsEqualTo>
-              <ogc:Function name="in2">
-                <ogc:Function name="geometryType">
-                  <ogc:PropertyName>geometry</ogc:PropertyName>
-                </ogc:Function>
-                <ogc:Literal>Point</ogc:Literal>
-                <ogc:Literal>MultiPoint</ogc:Literal>
-              </ogc:Function>
-              <ogc:Literal>true</ogc:Literal>
-            </ogc:PropertyIsEqualTo>       
-          </ogc:Filter>        
-          <MinScaleDenominator>100000</MinScaleDenominator>
-          <MaxScaleDenominator>300000</MaxScaleDenominator>        
-          <PointSymbolizer>
-            <Graphic>
-              <Mark>
-                <WellKnownName>oskari://dot-markers#0xe00<ogc:PropertyName>dot_shape</ogc:PropertyName></WellKnownName>
-                <Fill>
-                  <CssParameter name="fill"><ogc:PropertyName>dot_color</ogc:PropertyName></CssParameter>
-                </Fill>
-                <Stroke>
-                  <CssParameter name="stroke">#B4B4B4</CssParameter>
-                </Stroke>
-              </Mark>
-              <Size>
-                <ogc:Mul>
-                  <ogc:PropertyName>dot_size</ogc:PropertyName>
-                  <ogc:Literal>28</ogc:Literal>
-                </ogc:Mul>
-              </Size>
-            </Graphic>
-          </PointSymbolizer>
-        </Rule>
-  
-        <Rule>
-          <Name>PointScale9</Name>
-          <ogc:Filter>
-            <ogc:PropertyIsEqualTo>
-              <ogc:Function name="in2">
-                <ogc:Function name="geometryType">
-                  <ogc:PropertyName>geometry</ogc:PropertyName>
-                </ogc:Function>
-                <ogc:Literal>Point</ogc:Literal>
-                <ogc:Literal>MultiPoint</ogc:Literal>
-              </ogc:Function>
-              <ogc:Literal>true</ogc:Literal>
-            </ogc:PropertyIsEqualTo>       
-          </ogc:Filter>        
-          <MinScaleDenominator>300000</MinScaleDenominator>
-          <MaxScaleDenominator>600000</MaxScaleDenominator>        
-          <PointSymbolizer>
-            <Graphic>
-              <Mark>
-                <WellKnownName>oskari://dot-markers#0xe00<ogc:PropertyName>dot_shape</ogc:PropertyName></WellKnownName>
-                <Fill>
-                  <CssParameter name="fill"><ogc:PropertyName>dot_color</ogc:PropertyName></CssParameter>
-                </Fill>
-                <Stroke>
-                  <CssParameter name="stroke">#B4B4B4</CssParameter>
-                </Stroke>
-              </Mark>
-              <Size>
-                <ogc:Mul>
-                  <ogc:PropertyName>dot_size</ogc:PropertyName>
-                  <ogc:Literal>26</ogc:Literal>
-                </ogc:Mul>
-              </Size>
-            </Graphic>
-          </PointSymbolizer>
-        </Rule>
-  
-        <Rule>
-          <Name>PointScale10</Name>
-          <ogc:Filter>
-            <ogc:PropertyIsEqualTo>
-              <ogc:Function name="in2">
-                <ogc:Function name="geometryType">
-                  <ogc:PropertyName>geometry</ogc:PropertyName>
-                </ogc:Function>
-                <ogc:Literal>Point</ogc:Literal>
-                <ogc:Literal>MultiPoint</ogc:Literal>
-              </ogc:Function>
-              <ogc:Literal>true</ogc:Literal>
-            </ogc:PropertyIsEqualTo>       
-          </ogc:Filter>        
-          <MinScaleDenominator>600000</MinScaleDenominator>
-          <MaxScaleDenominator>1200000</MaxScaleDenominator>        
-          <PointSymbolizer>
-            <Graphic>
-              <Mark>
-                <WellKnownName>oskari://dot-markers#0xe00<ogc:PropertyName>dot_shape</ogc:PropertyName></WellKnownName>
-                <Fill>
-                  <CssParameter name="fill"><ogc:PropertyName>dot_color</ogc:PropertyName></CssParameter>
-                </Fill>
-                <Stroke>
-                  <CssParameter name="stroke">#B4B4B4</CssParameter>
-                </Stroke>
-              </Mark>
-              <Size>
-                <ogc:Mul>
-                  <ogc:PropertyName>dot_size</ogc:PropertyName>
-                  <ogc:Literal>24</ogc:Literal>
-                </ogc:Mul>
-              </Size>
-            </Graphic>
-          </PointSymbolizer>
-        </Rule>
-  
-        <Rule>
-          <Name>PointScale11</Name>
-          <ogc:Filter>
-            <ogc:PropertyIsEqualTo>
-              <ogc:Function name="in2">
-                <ogc:Function name="geometryType">
-                  <ogc:PropertyName>geometry</ogc:PropertyName>
-                </ogc:Function>
-                <ogc:Literal>Point</ogc:Literal>
-                <ogc:Literal>MultiPoint</ogc:Literal>
-              </ogc:Function>
-              <ogc:Literal>true</ogc:Literal>
-            </ogc:PropertyIsEqualTo>       
-          </ogc:Filter>        
-          <MinScaleDenominator>1200000</MinScaleDenominator>
-          <MaxScaleDenominator>2500000</MaxScaleDenominator>
-          <PointSymbolizer>
-            <Graphic>
-              <Mark>
-                <WellKnownName>oskari://dot-markers#0xe00<ogc:PropertyName>dot_shape</ogc:PropertyName></WellKnownName>
-                <Fill>
-                  <CssParameter name="fill"><ogc:PropertyName>dot_color</ogc:PropertyName></CssParameter>
-                </Fill>
-                <Stroke>
-                  <CssParameter name="stroke">#B4B4B4</CssParameter>
-                </Stroke>
-              </Mark>
-              <Size>
-                <ogc:Mul>
-                  <ogc:PropertyName>dot_size</ogc:PropertyName>
-                  <ogc:Literal>22</ogc:Literal>
-                </ogc:Mul>
-              </Size>
-            </Graphic>
-          </PointSymbolizer>
-        </Rule>
-  
-        <Rule>
-          <Name>PointScale12</Name>
-          <ogc:Filter>
-            <ogc:PropertyIsEqualTo>
-              <ogc:Function name="in2">
-                <ogc:Function name="geometryType">
-                  <ogc:PropertyName>geometry</ogc:PropertyName>
-                </ogc:Function>
-                <ogc:Literal>Point</ogc:Literal>
-                <ogc:Literal>MultiPoint</ogc:Literal>
-              </ogc:Function>
-              <ogc:Literal>true</ogc:Literal>
-            </ogc:PropertyIsEqualTo>       
-          </ogc:Filter>        
-          <MinScaleDenominator>2500000</MinScaleDenominator>
-          <MaxScaleDenominator>5000000</MaxScaleDenominator>
-          <PointSymbolizer>
-            <Graphic>
-              <Mark>
-                <WellKnownName>oskari://dot-markers#0xe00<ogc:PropertyName>dot_shape</ogc:PropertyName></WellKnownName>
-                <Fill>
-                  <CssParameter name="fill"><ogc:PropertyName>dot_color</ogc:PropertyName></CssParameter>
-                </Fill>
-                <Stroke>
-                  <CssParameter name="stroke">#B4B4B4</CssParameter>
-                </Stroke>
-              </Mark>
-              <Size>
-                <ogc:Mul>
-                  <ogc:PropertyName>dot_size</ogc:PropertyName>
-                  <ogc:Literal>20</ogc:Literal>
-                </ogc:Mul>
-              </Size>
-            </Graphic>
-          </PointSymbolizer>
-        </Rule>
-  
-        <Rule>
-          <Name>PointScale13</Name>
-          <ogc:Filter>
-            <ogc:PropertyIsEqualTo>
-              <ogc:Function name="in2">
-                <ogc:Function name="geometryType">
-                  <ogc:PropertyName>geometry</ogc:PropertyName>
-                </ogc:Function>
-                <ogc:Literal>Point</ogc:Literal>
-                <ogc:Literal>MultiPoint</ogc:Literal>
-              </ogc:Function>
-              <ogc:Literal>true</ogc:Literal>
-            </ogc:PropertyIsEqualTo>       
-          </ogc:Filter>        
-          <MinScaleDenominator>5000000</MinScaleDenominator>
-          <PointSymbolizer>
-            <Graphic>
-              <Mark>
-                <WellKnownName>oskari://dot-markers#0xe00<ogc:PropertyName>dot_shape</ogc:PropertyName></WellKnownName>
-                <Fill>
-                  <CssParameter name="fill"><ogc:PropertyName>dot_color</ogc:PropertyName></CssParameter>
-                </Fill>
-                <Stroke>
-                  <CssParameter name="stroke">#B4B4B4</CssParameter>
-                </Stroke>
-              </Mark>
-              <Size>
-                <ogc:Mul>
-                  <ogc:PropertyName>dot_size</ogc:PropertyName>
-                  <ogc:Literal>18</ogc:Literal>
-                </ogc:Mul>
-              </Size>
-            </Graphic>
-          </PointSymbolizer>
-        </Rule>
-          
-        <Rule>
-          <ogc:Filter>
-            <ogc:And>      
-              <ogc:PropertyIsEqualTo>
-                <ogc:Function name="in2">
-                  <ogc:Function name="geometryType">
-                    <ogc:PropertyName>geometry</ogc:PropertyName>
-                  </ogc:Function>
-                  <ogc:Literal>LineString</ogc:Literal>
-                  <ogc:Literal>MultiLineString</ogc:Literal>
-                </ogc:Function>
-                <ogc:Literal>true</ogc:Literal>
-              </ogc:PropertyIsEqualTo>            
-              <ogc:PropertyIsEqualTo>
-                <ogc:Function name="strLength">
-                  <ogc:PropertyName>stroke_dasharray</ogc:PropertyName>
-                </ogc:Function>
-                <ogc:Literal>0</ogc:Literal>
-              </ogc:PropertyIsEqualTo>
-            </ogc:And>                      
-          </ogc:Filter>          
-          <LineSymbolizer>
-            <Stroke>
-              <CssParameter name="stroke"><ogc:PropertyName>stroke_color</ogc:PropertyName></CssParameter>
-              <CssParameter name="stroke-width"><ogc:PropertyName>stroke_width</ogc:PropertyName></CssParameter>
-              <CssParameter name="stroke-linejoin"><ogc:PropertyName>stroke_linejoin</ogc:PropertyName></CssParameter>
-              <CssParameter name="stroke-linecap"><ogc:PropertyName>stroke_linecap</ogc:PropertyName></CssParameter>
-            </Stroke>
-          </LineSymbolizer>
-          <!--PointSymbolizer>
-            <Geometry><ogc:Function name="vertices"><ogc:PropertyName>geometry</ogc:PropertyName></ogc:Function></Geometry>
-            <Graphic>
-              <Mark>
-                <WellKnownName>square</WellKnownName>
-                <Fill>
-                  <CssParameter name="fill"><ogc:PropertyName>stroke_color</ogc:PropertyName></CssParameter>
-                </Fill>
-              </Mark>
-              <Size>6</Size>
-            </Graphic>
-          </PointSymbolizer-->
-          <!--TextSymbolizer>
-            <Label>
-              <ogc:PropertyName>name</ogc:PropertyName>
-            </Label>
-            <Font>
-              <CssParameter name="font-family">Arial</CssParameter>
-              <CssParameter name="font-size">11</CssParameter>
-              <CssParameter name="font-style">normal</CssParameter>
-              <CssParameter name="font-weight">bold</CssParameter>
-            </Font>
-            <LabelPlacement>
-              <PointPlacement>
-                <AnchorPoint>
-                  <AnchorPointX>0.5</AnchorPointX>
-                  <AnchorPointY>0.5</AnchorPointY>
-                </AnchorPoint>
-              </PointPlacement>
-            </LabelPlacement>
-            <Fill>
-              <CssParameter name="fill"><ogc:PropertyName>stroke_color</ogc:PropertyName></CssParameter>
-            </Fill>
-            <VendorOption name="autoWrap">60</VendorOption>
-            <VendorOption name="maxDisplacement">150</VendorOption>
-          </TextSymbolizer -->
-        </Rule>
-        
-        <Rule>
-          <ogc:Filter>
-            <ogc:And>      
-              <ogc:PropertyIsEqualTo>
-                <ogc:Function name="in2">
-                  <ogc:Function name="geometryType">
-                    <ogc:PropertyName>geometry</ogc:PropertyName>
-                  </ogc:Function>
-                  <ogc:Literal>LineString</ogc:Literal>
-                  <ogc:Literal>MultiLineString</ogc:Literal>
-                </ogc:Function>
-                <ogc:Literal>true</ogc:Literal>
-              </ogc:PropertyIsEqualTo>            
-              <ogc:PropertyIsNotEqualTo>
-                <ogc:Function name="strLength">
-                  <ogc:PropertyName>stroke_dasharray</ogc:PropertyName>
-                </ogc:Function>
-                <ogc:Literal>0</ogc:Literal>
-              </ogc:PropertyIsNotEqualTo>
-            </ogc:And>                      
-          </ogc:Filter>          
-          <LineSymbolizer>
-            <Stroke>
-              <CssParameter name="stroke"><ogc:PropertyName>stroke_color</ogc:PropertyName></CssParameter>
-              <CssParameter name="stroke-width"><ogc:PropertyName>stroke_width</ogc:PropertyName></CssParameter>
-              <CssParameter name="stroke-dasharray">5 2</CssParameter>
-              <CssParameter name="stroke-linejoin"><ogc:PropertyName>stroke_linejoin</ogc:PropertyName></CssParameter>
-            </Stroke>
-          </LineSymbolizer>
-          <!--PointSymbolizer>
-            <Geometry><ogc:Function name="vertices"><ogc:PropertyName>geometry</ogc:PropertyName></ogc:Function></Geometry>
-            <Graphic>
-              <Mark>
-                <WellKnownName>square</WellKnownName>
-                <Fill>
-                  <CssParameter name="fill"><ogc:PropertyName>stroke_color</ogc:PropertyName></CssParameter>
-                </Fill>
-              </Mark>
-              <Size>6</Size>
-            </Graphic>
-          </PointSymbolizer-->
-          <!--TextSymbolizer>
-            <Label>
-              <ogc:PropertyName>name</ogc:PropertyName>
-            </Label>
-            <Font>
-              <CssParameter name="font-family">Arial</CssParameter>
-              <CssParameter name="font-size">11</CssParameter>
-              <CssParameter name="font-style">normal</CssParameter>
-              <CssParameter name="font-weight">bold</CssParameter>
-            </Font>
-            <LabelPlacement>
-              <PointPlacement>
-                <AnchorPoint>
-                  <AnchorPointX>0.5</AnchorPointX>
-                  <AnchorPointY>0.5</AnchorPointY>
-                </AnchorPoint>
-              </PointPlacement>
-            </LabelPlacement>
-            <Fill>
-              <CssParameter name="fill"><ogc:PropertyName>stroke_color</ogc:PropertyName></CssParameter>
-            </Fill>
-            <VendorOption name="autoWrap">60</VendorOption>
-            <VendorOption name="maxDisplacement">150</VendorOption>
-          </TextSymbolizer -->
-        </Rule>        
-        
-        <Rule>
-          <ogc:Filter>
-            <ogc:And>
-              <ogc:PropertyIsEqualTo>
-                <ogc:Function name="in2">
-                   <ogc:Function name="geometryType">
-                    <ogc:PropertyName>geometry</ogc:PropertyName>
-                  </ogc:Function>
-                  <ogc:Literal>Polygon</ogc:Literal>
-                  <ogc:Literal>MultiPolygon</ogc:Literal>
-                </ogc:Function>
-                <ogc:Literal>true</ogc:Literal>
-              </ogc:PropertyIsEqualTo>             
-              <ogc:PropertyIsEqualTo>
-                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
-                <ogc:Literal>-1</ogc:Literal>
-              </ogc:PropertyIsEqualTo>  
-              <ogc:PropertyIsEqualTo>
-                <ogc:Function name="strLength">
-                  <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                </ogc:Function>
-                <ogc:Literal>0</ogc:Literal>
-              </ogc:PropertyIsEqualTo>
-           </ogc:And>
-          </ogc:Filter>
-          <PolygonSymbolizer>
-            <Fill>
-              <CssParameter name="fill"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
-            </Fill>          
-            <Stroke>
-              <CssParameter name="stroke"><ogc:PropertyName>border_color</ogc:PropertyName></CssParameter>
-              <CssParameter name="stroke-width"><ogc:PropertyName>border_width</ogc:PropertyName></CssParameter>
-              <CssParameter name="stroke-linejoin"><ogc:PropertyName>border_linejoin</ogc:PropertyName></CssParameter>
-            </Stroke>
-          </PolygonSymbolizer>
-          <!--TextSymbolizer>
-            <Label><ogc:PropertyName>name</ogc:PropertyName></Label>
-            <Font>
-              <CssParameter name="font-family">Arial</CssParameter>
-              <CssParameter name="font-size">20</CssParameter>
-              <CssParameter name="font-style">normal</CssParameter>
-              <CssParameter name="font-weight">bold</CssParameter>
-            </Font>
-            <LabelPlacement>
-              <PointPlacement>
-                <AnchorPoint>
-                  <AnchorPointX>0.5</AnchorPointX>
-                  <AnchorPointY>0.5</AnchorPointY>
-                </AnchorPoint>
-              </PointPlacement>
-            </LabelPlacement>
-            <Fill>
-              <CssParameter name="fill"><ogc:PropertyName>stroke_color</ogc:PropertyName></CssParameter>
-            </Fill>
-            <VendorOption name="autoWrap">60</VendorOption>
-            <VendorOption name="maxDisplacement">150</VendorOption>
-          </TextSymbolizer -->
-        </Rule>
-  
-        <Rule>
-          <ogc:Filter>
-            <ogc:And>
-              <ogc:PropertyIsEqualTo>
-                <ogc:Function name="in2">
-                   <ogc:Function name="geometryType">
-                    <ogc:PropertyName>geometry</ogc:PropertyName>
-                  </ogc:Function>
-                  <ogc:Literal>Polygon</ogc:Literal>
-                  <ogc:Literal>MultiPolygon</ogc:Literal>
-                </ogc:Function>
-                <ogc:Literal>true</ogc:Literal>
-              </ogc:PropertyIsEqualTo>             
-              <ogc:PropertyIsEqualTo>
-                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
-                <ogc:Literal>-1</ogc:Literal>
-              </ogc:PropertyIsEqualTo>  
-              <ogc:PropertyIsNotEqualTo>
-                <ogc:Function name="strLength">
-                  <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                </ogc:Function>
-                <ogc:Literal>0</ogc:Literal>
-              </ogc:PropertyIsNotEqualTo>
-           </ogc:And>
-          </ogc:Filter>
-          <PolygonSymbolizer>
-            <Fill>
-              <CssParameter name="fill"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
-            </Fill>          
-            <Stroke>
-              <CssParameter name="stroke"><ogc:PropertyName>border_color</ogc:PropertyName></CssParameter>
-              <CssParameter name="stroke-width"><ogc:PropertyName>border_width</ogc:PropertyName></CssParameter>
-              <CssParameter name="stroke-dasharray">5 2</CssParameter>
-              <CssParameter name="stroke-linejoin"><ogc:PropertyName>border_linejoin</ogc:PropertyName></CssParameter>
-            </Stroke>
-          </PolygonSymbolizer>
-          <!--TextSymbolizer>
-            <Label><ogc:PropertyName>name</ogc:PropertyName></Label>
-            <Font>
-              <CssParameter name="font-family">Arial</CssParameter>
-              <CssParameter name="font-size">20</CssParameter>
-              <CssParameter name="font-style">normal</CssParameter>
-              <CssParameter name="font-weight">bold</CssParameter>
-            </Font>
-            <LabelPlacement>
-              <PointPlacement>
-                <AnchorPoint>
-                  <AnchorPointX>0.5</AnchorPointX>
-                  <AnchorPointY>0.5</AnchorPointY>
-                </AnchorPoint>
-              </PointPlacement>
-            </LabelPlacement>
-            <Fill>
-              <CssParameter name="fill"><ogc:PropertyName>stroke_color</ogc:PropertyName></CssParameter>
-            </Fill>
-            <VendorOption name="autoWrap">60</VendorOption>
-            <VendorOption name="maxDisplacement">150</VendorOption>
-          </TextSymbolizer -->
-        </Rule>        
-        
-        <Rule>
-          <ogc:Filter>
-            <ogc:And>
-              <ogc:PropertyIsEqualTo>
-                <ogc:Function name="in2">
-                   <ogc:Function name="geometryType">
-                    <ogc:PropertyName>geometry</ogc:PropertyName>
-                  </ogc:Function>
-                  <ogc:Literal>Polygon</ogc:Literal>
-                  <ogc:Literal>MultiPolygon</ogc:Literal>
-                </ogc:Function>
-                <ogc:Literal>true</ogc:Literal>
-              </ogc:PropertyIsEqualTo>
-              <ogc:PropertyIsEqualTo>
-                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
-                <ogc:Literal>0</ogc:Literal>
-              </ogc:PropertyIsEqualTo>
-              <ogc:PropertyIsEqualTo>
-                <ogc:Function name="strLength">
-                  <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                </ogc:Function>
-                <ogc:Literal>0</ogc:Literal>
-              </ogc:PropertyIsEqualTo>
-            </ogc:And>
-          </ogc:Filter>
-          <PolygonSymbolizer>
-            <Fill>
-              <GraphicFill>
-                <Graphic>
-                  <Mark>
-                    <WellKnownName>shape://slash</WellKnownName>
-                    <Stroke>
-                      <CssParameter name="stroke"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
-                      <CssParameter name="stroke-width">1</CssParameter>
-                    </Stroke>
-                  </Mark>
-                  <Size>4</Size>
-                </Graphic>
-              </GraphicFill>
-            </Fill>                    
-            <Stroke>
-              <CssParameter name="stroke"><ogc:PropertyName>border_color</ogc:PropertyName></CssParameter>
-              <CssParameter name="stroke-width"><ogc:PropertyName>border_width</ogc:PropertyName></CssParameter>
-              <CssParameter name="stroke-linejoin"><ogc:PropertyName>border_linejoin</ogc:PropertyName></CssParameter>
-            </Stroke>
-          </PolygonSymbolizer>
-        </Rule>
-          
-        <Rule>
-          <ogc:Filter>
-            <ogc:And>
-              <ogc:PropertyIsEqualTo>
-                <ogc:Function name="in2">
-                   <ogc:Function name="geometryType">
-                    <ogc:PropertyName>geometry</ogc:PropertyName>
-                  </ogc:Function>
-                  <ogc:Literal>Polygon</ogc:Literal>
-                  <ogc:Literal>MultiPolygon</ogc:Literal>
-                </ogc:Function>
-                <ogc:Literal>true</ogc:Literal>
-              </ogc:PropertyIsEqualTo>
-              <ogc:PropertyIsEqualTo>
-                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
-                <ogc:Literal>0</ogc:Literal>
-              </ogc:PropertyIsEqualTo>
-              <ogc:PropertyIsNotEqualTo>
-                <ogc:Function name="strLength">
-                  <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                </ogc:Function>
-                <ogc:Literal>0</ogc:Literal>
-              </ogc:PropertyIsNotEqualTo>
-            </ogc:And>
-          </ogc:Filter>
-          <PolygonSymbolizer>
-            <Fill>
-              <GraphicFill>
-                <Graphic>
-                  <Mark>
-                    <WellKnownName>shape://slash</WellKnownName>
-                    <Stroke>
-                      <CssParameter name="stroke"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
-                      <CssParameter name="stroke-width">1</CssParameter>
-                    </Stroke>
-                  </Mark>
-                  <Size>4</Size>
-                </Graphic>
-              </GraphicFill>
-            </Fill>                    
-            <Stroke>
-              <CssParameter name="stroke"><ogc:PropertyName>border_color</ogc:PropertyName></CssParameter>
-              <CssParameter name="stroke-width"><ogc:PropertyName>border_width</ogc:PropertyName></CssParameter>
-              <CssParameter name="stroke-dasharray">5 2</CssParameter>
-              <CssParameter name="stroke-linejoin"><ogc:PropertyName>border_linejoin</ogc:PropertyName></CssParameter>
-            </Stroke>
-          </PolygonSymbolizer>
-        </Rule>
+                <Rule>
+                    <Name>PointScale2</Name>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:Function name="in2">
+                                <ogc:Function name="geometryType">
+                                    <ogc:PropertyName>geometry</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>Point</ogc:Literal>
+                                <ogc:Literal>MultiPoint</ogc:Literal>
+                            </ogc:Function>
+                            <ogc:Literal>true</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MinScaleDenominator>1000</MinScaleDenominator>
+                    <MaxScaleDenominator>3000</MaxScaleDenominator>
+                    <PointSymbolizer>
+                        <Graphic>
+                            <Mark>
+                                <WellKnownName>oskari://dot-markers#0xe00<ogc:PropertyName>dot_shape</ogc:PropertyName></WellKnownName>
+                                <Fill>
+                                    <CssParameter name="fill"><ogc:PropertyName>dot_color</ogc:PropertyName></CssParameter>
+                                </Fill>
+                                <Stroke>
+                                    <CssParameter name="stroke">#B4B4B4</CssParameter>
+                                </Stroke>
+                            </Mark>
+                            <Size>
+                                <ogc:Mul>
+                                    <ogc:PropertyName>dot_size</ogc:PropertyName>
+                                    <ogc:Literal>40</ogc:Literal>
+                                </ogc:Mul>
+                            </Size>
+                        </Graphic>
+                    </PointSymbolizer>
+                </Rule>
 
-        <Rule>
-          <ogc:Filter>
-            <ogc:And>
-              <ogc:PropertyIsEqualTo>
-                <ogc:Function name="in2">
-                   <ogc:Function name="geometryType">
-                    <ogc:PropertyName>geometry</ogc:PropertyName>
-                  </ogc:Function>
-                  <ogc:Literal>Polygon</ogc:Literal>
-                  <ogc:Literal>MultiPolygon</ogc:Literal>
-                </ogc:Function>
-                <ogc:Literal>true</ogc:Literal>
-              </ogc:PropertyIsEqualTo>
-              <ogc:PropertyIsEqualTo>
-                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
-                <ogc:Literal>1</ogc:Literal>
-              </ogc:PropertyIsEqualTo>
-              <ogc:PropertyIsEqualTo>
-                <ogc:Function name="strLength">
-                  <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                </ogc:Function>
-                <ogc:Literal>0</ogc:Literal>
-              </ogc:PropertyIsEqualTo>
-            </ogc:And>            
-          </ogc:Filter>
-          <PolygonSymbolizer>
-            <Fill>
-              <GraphicFill>
-                <Graphic>
-                  <Mark>
-                    <WellKnownName>shape://slash</WellKnownName>
-                    <Stroke>
-                      <CssParameter name="stroke"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
-                      <CssParameter name="stroke-width">2</CssParameter>
-                    </Stroke>
-                  </Mark>
-                  <Size>6</Size>
-                </Graphic>
-              </GraphicFill>
-            </Fill>                    
-            <Stroke>
-              <CssParameter name="stroke"><ogc:PropertyName>border_color</ogc:PropertyName></CssParameter>
-              <CssParameter name="stroke-width"><ogc:PropertyName>border_width</ogc:PropertyName></CssParameter>
-              <CssParameter name="stroke-linejoin"><ogc:PropertyName>border_linejoin</ogc:PropertyName></CssParameter>
-            </Stroke>
-          </PolygonSymbolizer>        
-        </Rule>
-  
-        <Rule>
-          <ogc:Filter>
-            <ogc:And>
-              <ogc:PropertyIsEqualTo>
-                <ogc:Function name="in2">
-                   <ogc:Function name="geometryType">
-                    <ogc:PropertyName>geometry</ogc:PropertyName>
-                  </ogc:Function>
-                  <ogc:Literal>Polygon</ogc:Literal>
-                  <ogc:Literal>MultiPolygon</ogc:Literal>
-                </ogc:Function>
-                <ogc:Literal>true</ogc:Literal>
-              </ogc:PropertyIsEqualTo>
-              <ogc:PropertyIsEqualTo>
-                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
-                <ogc:Literal>1</ogc:Literal>
-              </ogc:PropertyIsEqualTo>
-              <ogc:PropertyIsNotEqualTo>
-                <ogc:Function name="strLength">
-                  <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                </ogc:Function>
-                <ogc:Literal>0</ogc:Literal>
-              </ogc:PropertyIsNotEqualTo>
-            </ogc:And>            
-          </ogc:Filter>
-          <PolygonSymbolizer>
-            <Fill>
-              <GraphicFill>
-                <Graphic>
-                  <Mark>
-                    <WellKnownName>shape://slash</WellKnownName>
-                    <Stroke>
-                      <CssParameter name="stroke"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
-                      <CssParameter name="stroke-width">2</CssParameter>
-                    </Stroke>
-                  </Mark>
-                  <Size>6</Size>
-                </Graphic>
-              </GraphicFill>
-            </Fill>                    
-            <Stroke>
-              <CssParameter name="stroke"><ogc:PropertyName>border_color</ogc:PropertyName></CssParameter>
-              <CssParameter name="stroke-width"><ogc:PropertyName>border_width</ogc:PropertyName></CssParameter>
-              <CssParameter name="stroke-dasharray">5 2</CssParameter>
-              <CssParameter name="stroke-linejoin"><ogc:PropertyName>border_linejoin</ogc:PropertyName></CssParameter>
-            </Stroke>
-          </PolygonSymbolizer>        
-        </Rule>
+                <Rule>
+                    <Name>PointScale3</Name>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:Function name="in2">
+                                <ogc:Function name="geometryType">
+                                    <ogc:PropertyName>geometry</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>Point</ogc:Literal>
+                                <ogc:Literal>MultiPoint</ogc:Literal>
+                            </ogc:Function>
+                            <ogc:Literal>true</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MinScaleDenominator>3000</MinScaleDenominator>
+                    <MaxScaleDenominator>6000</MaxScaleDenominator>
+                    <PointSymbolizer>
+                        <Graphic>
+                            <Mark>
+                                <WellKnownName>oskari://dot-markers#0xe00<ogc:PropertyName>dot_shape</ogc:PropertyName></WellKnownName>
+                                <Fill>
+                                    <CssParameter name="fill"><ogc:PropertyName>dot_color</ogc:PropertyName></CssParameter>
+                                </Fill>
+                                <Stroke>
+                                    <CssParameter name="stroke">#B4B4B4</CssParameter>
+                                </Stroke>
+                            </Mark>
+                            <Size>
+                                <ogc:Mul>
+                                    <ogc:PropertyName>dot_size</ogc:PropertyName>
+                                    <ogc:Literal>38</ogc:Literal>
+                                </ogc:Mul>
+                            </Size>
+                        </Graphic>
+                    </PointSymbolizer>
+                </Rule>
 
-        <Rule>
-          <ogc:Filter>
-            <ogc:And>
-              <ogc:PropertyIsEqualTo>
-                <ogc:Function name="in2">
-                   <ogc:Function name="geometryType">
-                    <ogc:PropertyName>geometry</ogc:PropertyName>
-                  </ogc:Function>
-                  <ogc:Literal>Polygon</ogc:Literal>
-                  <ogc:Literal>MultiPolygon</ogc:Literal>
-                </ogc:Function>
-                <ogc:Literal>true</ogc:Literal>
-              </ogc:PropertyIsEqualTo>
-              <ogc:PropertyIsEqualTo>
-                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
-                <ogc:Literal>2</ogc:Literal>
-              </ogc:PropertyIsEqualTo>
-              <ogc:PropertyIsEqualTo>
-                <ogc:Function name="strLength">
-                  <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                </ogc:Function>
-                <ogc:Literal>0</ogc:Literal>
-              </ogc:PropertyIsEqualTo>
-            </ogc:And>
-          </ogc:Filter>
-          <PolygonSymbolizer>
-            <Fill>
-              <GraphicFill>
-                <Graphic>
-                  <Mark>
-                    <WellKnownName>shape://horline</WellKnownName>
-                    <Stroke>
-                      <CssParameter name="stroke"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
-                      <CssParameter name="stroke-width">0.4</CssParameter>
-                    </Stroke>
-                  </Mark>
-                  <Size>4.5</Size>
-                </Graphic>
-              </GraphicFill>
-            </Fill>                    
-            <Stroke>
-              <CssParameter name="stroke"><ogc:PropertyName>border_color</ogc:PropertyName></CssParameter>
-              <CssParameter name="stroke-width"><ogc:PropertyName>border_width</ogc:PropertyName></CssParameter>
-              <CssParameter name="stroke-linejoin"><ogc:PropertyName>border_linejoin</ogc:PropertyName></CssParameter>
-            </Stroke>
-          </PolygonSymbolizer>        
-        </Rule>
-  
-        <Rule>
-          <ogc:Filter>
-            <ogc:And>
-              <ogc:PropertyIsEqualTo>
-                <ogc:Function name="in2">
-                   <ogc:Function name="geometryType">
-                    <ogc:PropertyName>geometry</ogc:PropertyName>
-                  </ogc:Function>
-                  <ogc:Literal>Polygon</ogc:Literal>
-                  <ogc:Literal>MultiPolygon</ogc:Literal>
-                </ogc:Function>
-                <ogc:Literal>true</ogc:Literal>
-              </ogc:PropertyIsEqualTo>
-              <ogc:PropertyIsEqualTo>
-                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
-                <ogc:Literal>2</ogc:Literal>
-              </ogc:PropertyIsEqualTo>
-              <ogc:PropertyIsNotEqualTo>
-                <ogc:Function name="strLength">
-                  <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                </ogc:Function>
-                <ogc:Literal>0</ogc:Literal>
-              </ogc:PropertyIsNotEqualTo>
-            </ogc:And>
-          </ogc:Filter>
-          <PolygonSymbolizer>
-            <Fill>
-              <GraphicFill>
-                <Graphic>
-                  <Mark>
-                    <WellKnownName>shape://horline</WellKnownName>
-                    <Stroke>
-                      <CssParameter name="stroke"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
-                      <CssParameter name="stroke-width">0.4</CssParameter>
-                    </Stroke>
-                  </Mark>
-                  <Size>4.5</Size>
-                </Graphic>
-              </GraphicFill>
-            </Fill>                    
-            <Stroke>
-              <CssParameter name="stroke"><ogc:PropertyName>border_color</ogc:PropertyName></CssParameter>
-              <CssParameter name="stroke-width"><ogc:PropertyName>border_width</ogc:PropertyName></CssParameter>
-              <CssParameter name="stroke-dasharray">5 2</CssParameter>
-              <CssParameter name="stroke-linejoin"><ogc:PropertyName>border_linejoin</ogc:PropertyName></CssParameter>
-            </Stroke>
-          </PolygonSymbolizer>        
-        </Rule>
-        
-        <Rule>
-          <ogc:Filter>
-            <ogc:And>
-              <ogc:PropertyIsEqualTo>
-                <ogc:Function name="in2">
-                   <ogc:Function name="geometryType">
-                    <ogc:PropertyName>geometry</ogc:PropertyName>
-                  </ogc:Function>
-                  <ogc:Literal>Polygon</ogc:Literal>
-                  <ogc:Literal>MultiPolygon</ogc:Literal>
-                </ogc:Function>
-                <ogc:Literal>true</ogc:Literal>
-              </ogc:PropertyIsEqualTo>
-              <ogc:PropertyIsEqualTo>
-                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
-                <ogc:Literal>3</ogc:Literal>
-              </ogc:PropertyIsEqualTo>
-              <ogc:PropertyIsEqualTo>
-                <ogc:Function name="strLength">
-                  <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                </ogc:Function>
-                <ogc:Literal>0</ogc:Literal>
-              </ogc:PropertyIsEqualTo>
-            </ogc:And>
-          </ogc:Filter>
-          <PolygonSymbolizer>
-            <Fill>
-              <GraphicFill>
-                <Graphic>
-                  <Mark>
-                    <WellKnownName>shape://horline</WellKnownName>
-                    <Stroke>
-                      <CssParameter name="stroke"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
-                      <CssParameter name="stroke-width">2</CssParameter>
-                    </Stroke>
-                  </Mark>
-                  <Size>5.5</Size>
-                </Graphic>
-              </GraphicFill>
-            </Fill>                    
-            <Stroke>
-              <CssParameter name="stroke"><ogc:PropertyName>border_color</ogc:PropertyName></CssParameter>
-              <CssParameter name="stroke-width"><ogc:PropertyName>border_width</ogc:PropertyName></CssParameter>
-              <CssParameter name="stroke-linejoin"><ogc:PropertyName>border_linejoin</ogc:PropertyName></CssParameter>
-            </Stroke>
-          </PolygonSymbolizer>        
-        </Rule>        
-        
-        <Rule>
-          <ogc:Filter>
-            <ogc:And>
-              <ogc:PropertyIsEqualTo>
-                <ogc:Function name="in2">
-                   <ogc:Function name="geometryType">
-                    <ogc:PropertyName>geometry</ogc:PropertyName>
-                  </ogc:Function>
-                  <ogc:Literal>Polygon</ogc:Literal>
-                  <ogc:Literal>MultiPolygon</ogc:Literal>
-                </ogc:Function>
-                <ogc:Literal>true</ogc:Literal>
-              </ogc:PropertyIsEqualTo>
-              <ogc:PropertyIsEqualTo>
-                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
-                <ogc:Literal>3</ogc:Literal>
-              </ogc:PropertyIsEqualTo>
-              <ogc:PropertyIsNotEqualTo>
-                <ogc:Function name="strLength">
-                  <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                </ogc:Function>
-                <ogc:Literal>0</ogc:Literal>
-              </ogc:PropertyIsNotEqualTo>
-            </ogc:And>
-          </ogc:Filter>
-          <PolygonSymbolizer>
-            <Fill>
-              <GraphicFill>
-                <Graphic>
-                  <Mark>
-                    <WellKnownName>shape://horline</WellKnownName>
-                    <Stroke>
-                      <CssParameter name="stroke"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
-                      <CssParameter name="stroke-width">2</CssParameter>
-                    </Stroke>
-                  </Mark>
-                  <Size>5.5</Size>
-                </Graphic>
-              </GraphicFill>
-            </Fill>                    
-            <Stroke>
-              <CssParameter name="stroke"><ogc:PropertyName>border_color</ogc:PropertyName></CssParameter>
-              <CssParameter name="stroke-width"><ogc:PropertyName>border_width</ogc:PropertyName></CssParameter>
-              <CssParameter name="stroke-dasharray">5 2</CssParameter>
-              <CssParameter name="stroke-linejoin"><ogc:PropertyName>border_linejoin</ogc:PropertyName></CssParameter>
-            </Stroke>
-          </PolygonSymbolizer>        
-        </Rule>        
-      </FeatureTypeStyle>
-    </UserStyle>
-  </NamedLayer>
+                <Rule>
+                    <Name>PointScale4</Name>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:Function name="in2">
+                                <ogc:Function name="geometryType">
+                                    <ogc:PropertyName>geometry</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>Point</ogc:Literal>
+                                <ogc:Literal>MultiPoint</ogc:Literal>
+                            </ogc:Function>
+                            <ogc:Literal>true</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MinScaleDenominator>6000</MinScaleDenominator>
+                    <MaxScaleDenominator>12000</MaxScaleDenominator>
+                    <PointSymbolizer>
+                        <Graphic>
+                            <Mark>
+                                <WellKnownName>oskari://dot-markers#0xe00<ogc:PropertyName>dot_shape</ogc:PropertyName></WellKnownName>
+                                <Fill>
+                                    <CssParameter name="fill"><ogc:PropertyName>dot_color</ogc:PropertyName></CssParameter>
+                                </Fill>
+                                <Stroke>
+                                    <CssParameter name="stroke">#B4B4B4</CssParameter>
+                                </Stroke>
+                            </Mark>
+                            <Size>
+                                <ogc:Mul>
+                                    <ogc:PropertyName>dot_size</ogc:PropertyName>
+                                    <ogc:Literal>36</ogc:Literal>
+                                </ogc:Mul>
+                            </Size>
+                        </Graphic>
+                    </PointSymbolizer>
+                </Rule>
+
+                <Rule>
+                    <Name>PointScale5</Name>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:Function name="in2">
+                                <ogc:Function name="geometryType">
+                                    <ogc:PropertyName>geometry</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>Point</ogc:Literal>
+                                <ogc:Literal>MultiPoint</ogc:Literal>
+                            </ogc:Function>
+                            <ogc:Literal>true</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MinScaleDenominator>12000</MinScaleDenominator>
+                    <MaxScaleDenominator>25000</MaxScaleDenominator>
+                    <PointSymbolizer>
+                        <Graphic>
+                            <Mark>
+                                <WellKnownName>oskari://dot-markers#0xe00<ogc:PropertyName>dot_shape</ogc:PropertyName></WellKnownName>
+                                <Fill>
+                                    <CssParameter name="fill"><ogc:PropertyName>dot_color</ogc:PropertyName></CssParameter>
+                                </Fill>
+                                <Stroke>
+                                    <CssParameter name="stroke">#B4B4B4</CssParameter>
+                                </Stroke>
+                            </Mark>
+                            <Size>
+                                <ogc:Mul>
+                                    <ogc:PropertyName>dot_size</ogc:PropertyName>
+                                    <ogc:Literal>34</ogc:Literal>
+                                </ogc:Mul>
+                            </Size>
+                        </Graphic>
+                    </PointSymbolizer>
+                </Rule>
+
+                <Rule>
+                    <Name>PointScale6</Name>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:Function name="in2">
+                                <ogc:Function name="geometryType">
+                                    <ogc:PropertyName>geometry</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>Point</ogc:Literal>
+                                <ogc:Literal>MultiPoint</ogc:Literal>
+                            </ogc:Function>
+                            <ogc:Literal>true</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MinScaleDenominator>25000</MinScaleDenominator>
+                    <MaxScaleDenominator>50000</MaxScaleDenominator>
+                    <PointSymbolizer>
+                        <Graphic>
+                            <Mark>
+                                <WellKnownName>oskari://dot-markers#0xe00<ogc:PropertyName>dot_shape</ogc:PropertyName></WellKnownName>
+                                <Fill>
+                                    <CssParameter name="fill"><ogc:PropertyName>dot_color</ogc:PropertyName></CssParameter>
+                                </Fill>
+                                <Stroke>
+                                    <CssParameter name="stroke">#B4B4B4</CssParameter>
+                                </Stroke>
+                            </Mark>
+                            <Size>
+                                <ogc:Mul>
+                                    <ogc:PropertyName>dot_size</ogc:PropertyName>
+                                    <ogc:Literal>32</ogc:Literal>
+                                </ogc:Mul>
+                            </Size>
+                        </Graphic>
+                    </PointSymbolizer>
+                </Rule>
+
+                <Rule>
+                    <Name>PointScale7</Name>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:Function name="in2">
+                                <ogc:Function name="geometryType">
+                                    <ogc:PropertyName>geometry</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>Point</ogc:Literal>
+                                <ogc:Literal>MultiPoint</ogc:Literal>
+                            </ogc:Function>
+                            <ogc:Literal>true</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MinScaleDenominator>50000</MinScaleDenominator>
+                    <MaxScaleDenominator>100000</MaxScaleDenominator>
+                    <PointSymbolizer>
+                        <Graphic>
+                            <Mark>
+                                <WellKnownName>oskari://dot-markers#0xe00<ogc:PropertyName>dot_shape</ogc:PropertyName></WellKnownName>
+                                <Fill>
+                                    <CssParameter name="fill"><ogc:PropertyName>dot_color</ogc:PropertyName></CssParameter>
+                                </Fill>
+                                <Stroke>
+                                    <CssParameter name="stroke">#B4B4B4</CssParameter>
+                                </Stroke>
+                            </Mark>
+                            <Size>
+                                <ogc:Mul>
+                                    <ogc:PropertyName>dot_size</ogc:PropertyName>
+                                    <ogc:Literal>30</ogc:Literal>
+                                </ogc:Mul>
+                            </Size>
+                        </Graphic>
+                    </PointSymbolizer>
+                </Rule>
+
+                <Rule>
+                    <Name>PointScale8</Name>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:Function name="in2">
+                                <ogc:Function name="geometryType">
+                                    <ogc:PropertyName>geometry</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>Point</ogc:Literal>
+                                <ogc:Literal>MultiPoint</ogc:Literal>
+                            </ogc:Function>
+                            <ogc:Literal>true</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MinScaleDenominator>100000</MinScaleDenominator>
+                    <MaxScaleDenominator>300000</MaxScaleDenominator>
+                    <PointSymbolizer>
+                        <Graphic>
+                            <Mark>
+                                <WellKnownName>oskari://dot-markers#0xe00<ogc:PropertyName>dot_shape</ogc:PropertyName></WellKnownName>
+                                <Fill>
+                                    <CssParameter name="fill"><ogc:PropertyName>dot_color</ogc:PropertyName></CssParameter>
+                                </Fill>
+                                <Stroke>
+                                    <CssParameter name="stroke">#B4B4B4</CssParameter>
+                                </Stroke>
+                            </Mark>
+                            <Size>
+                                <ogc:Mul>
+                                    <ogc:PropertyName>dot_size</ogc:PropertyName>
+                                    <ogc:Literal>28</ogc:Literal>
+                                </ogc:Mul>
+                            </Size>
+                        </Graphic>
+                    </PointSymbolizer>
+                </Rule>
+
+                <Rule>
+                    <Name>PointScale9</Name>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:Function name="in2">
+                                <ogc:Function name="geometryType">
+                                    <ogc:PropertyName>geometry</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>Point</ogc:Literal>
+                                <ogc:Literal>MultiPoint</ogc:Literal>
+                            </ogc:Function>
+                            <ogc:Literal>true</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MinScaleDenominator>300000</MinScaleDenominator>
+                    <MaxScaleDenominator>600000</MaxScaleDenominator>
+                    <PointSymbolizer>
+                        <Graphic>
+                            <Mark>
+                                <WellKnownName>oskari://dot-markers#0xe00<ogc:PropertyName>dot_shape</ogc:PropertyName></WellKnownName>
+                                <Fill>
+                                    <CssParameter name="fill"><ogc:PropertyName>dot_color</ogc:PropertyName></CssParameter>
+                                </Fill>
+                                <Stroke>
+                                    <CssParameter name="stroke">#B4B4B4</CssParameter>
+                                </Stroke>
+                            </Mark>
+                            <Size>
+                                <ogc:Mul>
+                                    <ogc:PropertyName>dot_size</ogc:PropertyName>
+                                    <ogc:Literal>26</ogc:Literal>
+                                </ogc:Mul>
+                            </Size>
+                        </Graphic>
+                    </PointSymbolizer>
+                </Rule>
+
+                <Rule>
+                    <Name>PointScale10</Name>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:Function name="in2">
+                                <ogc:Function name="geometryType">
+                                    <ogc:PropertyName>geometry</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>Point</ogc:Literal>
+                                <ogc:Literal>MultiPoint</ogc:Literal>
+                            </ogc:Function>
+                            <ogc:Literal>true</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MinScaleDenominator>600000</MinScaleDenominator>
+                    <MaxScaleDenominator>1200000</MaxScaleDenominator>
+                    <PointSymbolizer>
+                        <Graphic>
+                            <Mark>
+                                <WellKnownName>oskari://dot-markers#0xe00<ogc:PropertyName>dot_shape</ogc:PropertyName></WellKnownName>
+                                <Fill>
+                                    <CssParameter name="fill"><ogc:PropertyName>dot_color</ogc:PropertyName></CssParameter>
+                                </Fill>
+                                <Stroke>
+                                    <CssParameter name="stroke">#B4B4B4</CssParameter>
+                                </Stroke>
+                            </Mark>
+                            <Size>
+                                <ogc:Mul>
+                                    <ogc:PropertyName>dot_size</ogc:PropertyName>
+                                    <ogc:Literal>24</ogc:Literal>
+                                </ogc:Mul>
+                            </Size>
+                        </Graphic>
+                    </PointSymbolizer>
+                </Rule>
+
+                <Rule>
+                    <Name>PointScale11</Name>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:Function name="in2">
+                                <ogc:Function name="geometryType">
+                                    <ogc:PropertyName>geometry</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>Point</ogc:Literal>
+                                <ogc:Literal>MultiPoint</ogc:Literal>
+                            </ogc:Function>
+                            <ogc:Literal>true</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MinScaleDenominator>1200000</MinScaleDenominator>
+                    <MaxScaleDenominator>2500000</MaxScaleDenominator>
+                    <PointSymbolizer>
+                        <Graphic>
+                            <Mark>
+                                <WellKnownName>oskari://dot-markers#0xe00<ogc:PropertyName>dot_shape</ogc:PropertyName></WellKnownName>
+                                <Fill>
+                                    <CssParameter name="fill"><ogc:PropertyName>dot_color</ogc:PropertyName></CssParameter>
+                                </Fill>
+                                <Stroke>
+                                    <CssParameter name="stroke">#B4B4B4</CssParameter>
+                                </Stroke>
+                            </Mark>
+                            <Size>
+                                <ogc:Mul>
+                                    <ogc:PropertyName>dot_size</ogc:PropertyName>
+                                    <ogc:Literal>22</ogc:Literal>
+                                </ogc:Mul>
+                            </Size>
+                        </Graphic>
+                    </PointSymbolizer>
+                </Rule>
+
+                <Rule>
+                    <Name>PointScale12</Name>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:Function name="in2">
+                                <ogc:Function name="geometryType">
+                                    <ogc:PropertyName>geometry</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>Point</ogc:Literal>
+                                <ogc:Literal>MultiPoint</ogc:Literal>
+                            </ogc:Function>
+                            <ogc:Literal>true</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MinScaleDenominator>2500000</MinScaleDenominator>
+                    <MaxScaleDenominator>5000000</MaxScaleDenominator>
+                    <PointSymbolizer>
+                        <Graphic>
+                            <Mark>
+                                <WellKnownName>oskari://dot-markers#0xe00<ogc:PropertyName>dot_shape</ogc:PropertyName></WellKnownName>
+                                <Fill>
+                                    <CssParameter name="fill"><ogc:PropertyName>dot_color</ogc:PropertyName></CssParameter>
+                                </Fill>
+                                <Stroke>
+                                    <CssParameter name="stroke">#B4B4B4</CssParameter>
+                                </Stroke>
+                            </Mark>
+                            <Size>
+                                <ogc:Mul>
+                                    <ogc:PropertyName>dot_size</ogc:PropertyName>
+                                    <ogc:Literal>20</ogc:Literal>
+                                </ogc:Mul>
+                            </Size>
+                        </Graphic>
+                    </PointSymbolizer>
+                </Rule>
+
+                <Rule>
+                    <Name>PointScale13</Name>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:Function name="in2">
+                                <ogc:Function name="geometryType">
+                                    <ogc:PropertyName>geometry</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>Point</ogc:Literal>
+                                <ogc:Literal>MultiPoint</ogc:Literal>
+                            </ogc:Function>
+                            <ogc:Literal>true</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MinScaleDenominator>5000000</MinScaleDenominator>
+                    <PointSymbolizer>
+                        <Graphic>
+                            <Mark>
+                                <WellKnownName>oskari://dot-markers#0xe00<ogc:PropertyName>dot_shape</ogc:PropertyName></WellKnownName>
+                                <Fill>
+                                    <CssParameter name="fill"><ogc:PropertyName>dot_color</ogc:PropertyName></CssParameter>
+                                </Fill>
+                                <Stroke>
+                                    <CssParameter name="stroke">#B4B4B4</CssParameter>
+                                </Stroke>
+                            </Mark>
+                            <Size>
+                                <ogc:Mul>
+                                    <ogc:PropertyName>dot_size</ogc:PropertyName>
+                                    <ogc:Literal>18</ogc:Literal>
+                                </ogc:Mul>
+                            </Size>
+                        </Graphic>
+                    </PointSymbolizer>
+                </Rule>
+
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="in2">
+                                    <ogc:Function name="geometryType">
+                                        <ogc:PropertyName>geometry</ogc:PropertyName>
+                                    </ogc:Function>
+                                    <ogc:Literal>LineString</ogc:Literal>
+                                    <ogc:Literal>MultiLineString</ogc:Literal>
+                                </ogc:Function>
+                                <ogc:Literal>true</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="strLength">
+                                    <ogc:PropertyName>stroke_dasharray</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:And>
+                    </ogc:Filter>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke"><ogc:PropertyName>stroke_color</ogc:PropertyName></CssParameter>
+                            <CssParameter name="stroke-width"><ogc:PropertyName>stroke_width</ogc:PropertyName></CssParameter>
+                            <CssParameter name="stroke-linejoin"><ogc:PropertyName>stroke_linejoin</ogc:PropertyName></CssParameter>
+                            <CssParameter name="stroke-linecap"><ogc:PropertyName>stroke_linecap</ogc:PropertyName></CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                    <!--PointSymbolizer>
+                      <Geometry><ogc:Function name="vertices"><ogc:PropertyName>geometry</ogc:PropertyName></ogc:Function></Geometry>
+                      <Graphic>
+                        <Mark>
+                          <WellKnownName>square</WellKnownName>
+                          <Fill>
+                            <CssParameter name="fill"><ogc:PropertyName>stroke_color</ogc:PropertyName></CssParameter>
+                          </Fill>
+                        </Mark>
+                        <Size>6</Size>
+                      </Graphic>
+                    </PointSymbolizer-->
+                    <!--TextSymbolizer>
+                      <Label>
+                        <ogc:PropertyName>name</ogc:PropertyName>
+                      </Label>
+                      <Font>
+                        <CssParameter name="font-family">Arial</CssParameter>
+                        <CssParameter name="font-size">11</CssParameter>
+                        <CssParameter name="font-style">normal</CssParameter>
+                        <CssParameter name="font-weight">bold</CssParameter>
+                      </Font>
+                      <LabelPlacement>
+                        <PointPlacement>
+                          <AnchorPoint>
+                            <AnchorPointX>0.5</AnchorPointX>
+                            <AnchorPointY>0.5</AnchorPointY>
+                          </AnchorPoint>
+                        </PointPlacement>
+                      </LabelPlacement>
+                      <Fill>
+                        <CssParameter name="fill"><ogc:PropertyName>stroke_color</ogc:PropertyName></CssParameter>
+                      </Fill>
+                      <VendorOption name="autoWrap">60</VendorOption>
+                      <VendorOption name="maxDisplacement">150</VendorOption>
+                    </TextSymbolizer -->
+                </Rule>
+
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="in2">
+                                    <ogc:Function name="geometryType">
+                                        <ogc:PropertyName>geometry</ogc:PropertyName>
+                                    </ogc:Function>
+                                    <ogc:Literal>LineString</ogc:Literal>
+                                    <ogc:Literal>MultiLineString</ogc:Literal>
+                                </ogc:Function>
+                                <ogc:Literal>true</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsNotEqualTo>
+                                <ogc:Function name="strLength">
+                                    <ogc:PropertyName>stroke_dasharray</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsNotEqualTo>
+                        </ogc:And>
+                    </ogc:Filter>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke"><ogc:PropertyName>stroke_color</ogc:PropertyName></CssParameter>
+                            <CssParameter name="stroke-width"><ogc:PropertyName>stroke_width</ogc:PropertyName></CssParameter>
+                            <CssParameter name="stroke-dasharray">5 2</CssParameter>
+                            <CssParameter name="stroke-linejoin"><ogc:PropertyName>stroke_linejoin</ogc:PropertyName></CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                    <!--PointSymbolizer>
+                      <Geometry><ogc:Function name="vertices"><ogc:PropertyName>geometry</ogc:PropertyName></ogc:Function></Geometry>
+                      <Graphic>
+                        <Mark>
+                          <WellKnownName>square</WellKnownName>
+                          <Fill>
+                            <CssParameter name="fill"><ogc:PropertyName>stroke_color</ogc:PropertyName></CssParameter>
+                          </Fill>
+                        </Mark>
+                        <Size>6</Size>
+                      </Graphic>
+                    </PointSymbolizer-->
+                    <!--TextSymbolizer>
+                      <Label>
+                        <ogc:PropertyName>name</ogc:PropertyName>
+                      </Label>
+                      <Font>
+                        <CssParameter name="font-family">Arial</CssParameter>
+                        <CssParameter name="font-size">11</CssParameter>
+                        <CssParameter name="font-style">normal</CssParameter>
+                        <CssParameter name="font-weight">bold</CssParameter>
+                      </Font>
+                      <LabelPlacement>
+                        <PointPlacement>
+                          <AnchorPoint>
+                            <AnchorPointX>0.5</AnchorPointX>
+                            <AnchorPointY>0.5</AnchorPointY>
+                          </AnchorPoint>
+                        </PointPlacement>
+                      </LabelPlacement>
+                      <Fill>
+                        <CssParameter name="fill"><ogc:PropertyName>stroke_color</ogc:PropertyName></CssParameter>
+                      </Fill>
+                      <VendorOption name="autoWrap">60</VendorOption>
+                      <VendorOption name="maxDisplacement">150</VendorOption>
+                    </TextSymbolizer -->
+                </Rule>
+
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="in2">
+                                    <ogc:Function name="geometryType">
+                                        <ogc:PropertyName>geometry</ogc:PropertyName>
+                                    </ogc:Function>
+                                    <ogc:Literal>Polygon</ogc:Literal>
+                                    <ogc:Literal>MultiPolygon</ogc:Literal>
+                                </ogc:Function>
+                                <ogc:Literal>true</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
+                                <ogc:Literal>-1</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="strLength">
+                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:And>
+                    </ogc:Filter>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke"><ogc:PropertyName>border_color</ogc:PropertyName></CssParameter>
+                            <CssParameter name="stroke-width"><ogc:PropertyName>border_width</ogc:PropertyName></CssParameter>
+                            <CssParameter name="stroke-linejoin"><ogc:PropertyName>border_linejoin</ogc:PropertyName></CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                    <!--TextSymbolizer>
+                      <Label><ogc:PropertyName>name</ogc:PropertyName></Label>
+                      <Font>
+                        <CssParameter name="font-family">Arial</CssParameter>
+                        <CssParameter name="font-size">20</CssParameter>
+                        <CssParameter name="font-style">normal</CssParameter>
+                        <CssParameter name="font-weight">bold</CssParameter>
+                      </Font>
+                      <LabelPlacement>
+                        <PointPlacement>
+                          <AnchorPoint>
+                            <AnchorPointX>0.5</AnchorPointX>
+                            <AnchorPointY>0.5</AnchorPointY>
+                          </AnchorPoint>
+                        </PointPlacement>
+                      </LabelPlacement>
+                      <Fill>
+                        <CssParameter name="fill"><ogc:PropertyName>stroke_color</ogc:PropertyName></CssParameter>
+                      </Fill>
+                      <VendorOption name="autoWrap">60</VendorOption>
+                      <VendorOption name="maxDisplacement">150</VendorOption>
+                    </TextSymbolizer -->
+                </Rule>
+
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="in2">
+                                    <ogc:Function name="geometryType">
+                                        <ogc:PropertyName>geometry</ogc:PropertyName>
+                                    </ogc:Function>
+                                    <ogc:Literal>Polygon</ogc:Literal>
+                                    <ogc:Literal>MultiPolygon</ogc:Literal>
+                                </ogc:Function>
+                                <ogc:Literal>true</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
+                                <ogc:Literal>-1</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsNotEqualTo>
+                                <ogc:Function name="strLength">
+                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsNotEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:And>
+                    </ogc:Filter>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke"><ogc:PropertyName>border_color</ogc:PropertyName></CssParameter>
+                            <CssParameter name="stroke-width"><ogc:PropertyName>border_width</ogc:PropertyName></CssParameter>
+                            <CssParameter name="stroke-dasharray">5 2</CssParameter>
+                            <CssParameter name="stroke-linejoin"><ogc:PropertyName>border_linejoin</ogc:PropertyName></CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                    <!--TextSymbolizer>
+                      <Label><ogc:PropertyName>name</ogc:PropertyName></Label>
+                      <Font>
+                        <CssParameter name="font-family">Arial</CssParameter>
+                        <CssParameter name="font-size">20</CssParameter>
+                        <CssParameter name="font-style">normal</CssParameter>
+                        <CssParameter name="font-weight">bold</CssParameter>
+                      </Font>
+                      <LabelPlacement>
+                        <PointPlacement>
+                          <AnchorPoint>
+                            <AnchorPointX>0.5</AnchorPointX>
+                            <AnchorPointY>0.5</AnchorPointY>
+                          </AnchorPoint>
+                        </PointPlacement>
+                      </LabelPlacement>
+                      <Fill>
+                        <CssParameter name="fill"><ogc:PropertyName>stroke_color</ogc:PropertyName></CssParameter>
+                      </Fill>
+                      <VendorOption name="autoWrap">60</VendorOption>
+                      <VendorOption name="maxDisplacement">150</VendorOption>
+                    </TextSymbolizer -->
+                </Rule>
+
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="in2">
+                                    <ogc:Function name="geometryType">
+                                        <ogc:PropertyName>geometry</ogc:PropertyName>
+                                    </ogc:Function>
+                                    <ogc:Literal>Polygon</ogc:Literal>
+                                    <ogc:Literal>MultiPolygon</ogc:Literal>
+                                </ogc:Function>
+                                <ogc:Literal>true</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
+                                <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="strLength">
+                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:And>
+                    </ogc:Filter>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <GraphicFill>
+                                <Graphic>
+                                    <Mark>
+                                        <WellKnownName>shape://slash</WellKnownName>
+                                        <Stroke>
+                                            <CssParameter name="stroke"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
+                                            <CssParameter name="stroke-width">1</CssParameter>
+                                        </Stroke>
+                                    </Mark>
+                                    <Size>4</Size>
+                                </Graphic>
+                            </GraphicFill>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke"><ogc:PropertyName>border_color</ogc:PropertyName></CssParameter>
+                            <CssParameter name="stroke-width"><ogc:PropertyName>border_width</ogc:PropertyName></CssParameter>
+                            <CssParameter name="stroke-linejoin"><ogc:PropertyName>border_linejoin</ogc:PropertyName></CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="in2">
+                                    <ogc:Function name="geometryType">
+                                        <ogc:PropertyName>geometry</ogc:PropertyName>
+                                    </ogc:Function>
+                                    <ogc:Literal>Polygon</ogc:Literal>
+                                    <ogc:Literal>MultiPolygon</ogc:Literal>
+                                </ogc:Function>
+                                <ogc:Literal>true</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
+                                <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsNotEqualTo>
+                                <ogc:Function name="strLength">
+                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsNotEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:And>
+                    </ogc:Filter>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <GraphicFill>
+                                <Graphic>
+                                    <Mark>
+                                        <WellKnownName>shape://slash</WellKnownName>
+                                        <Stroke>
+                                            <CssParameter name="stroke"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
+                                            <CssParameter name="stroke-width">1</CssParameter>
+                                        </Stroke>
+                                    </Mark>
+                                    <Size>4</Size>
+                                </Graphic>
+                            </GraphicFill>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke"><ogc:PropertyName>border_color</ogc:PropertyName></CssParameter>
+                            <CssParameter name="stroke-width"><ogc:PropertyName>border_width</ogc:PropertyName></CssParameter>
+                            <CssParameter name="stroke-dasharray">5 2</CssParameter>
+                            <CssParameter name="stroke-linejoin"><ogc:PropertyName>border_linejoin</ogc:PropertyName></CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="in2">
+                                    <ogc:Function name="geometryType">
+                                        <ogc:PropertyName>geometry</ogc:PropertyName>
+                                    </ogc:Function>
+                                    <ogc:Literal>Polygon</ogc:Literal>
+                                    <ogc:Literal>MultiPolygon</ogc:Literal>
+                                </ogc:Function>
+                                <ogc:Literal>true</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
+                                <ogc:Literal>1</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="strLength">
+                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:And>
+                    </ogc:Filter>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <GraphicFill>
+                                <Graphic>
+                                    <Mark>
+                                        <WellKnownName>shape://slash</WellKnownName>
+                                        <Stroke>
+                                            <CssParameter name="stroke"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
+                                            <CssParameter name="stroke-width">2</CssParameter>
+                                        </Stroke>
+                                    </Mark>
+                                    <Size>6</Size>
+                                </Graphic>
+                            </GraphicFill>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke"><ogc:PropertyName>border_color</ogc:PropertyName></CssParameter>
+                            <CssParameter name="stroke-width"><ogc:PropertyName>border_width</ogc:PropertyName></CssParameter>
+                            <CssParameter name="stroke-linejoin"><ogc:PropertyName>border_linejoin</ogc:PropertyName></CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="in2">
+                                    <ogc:Function name="geometryType">
+                                        <ogc:PropertyName>geometry</ogc:PropertyName>
+                                    </ogc:Function>
+                                    <ogc:Literal>Polygon</ogc:Literal>
+                                    <ogc:Literal>MultiPolygon</ogc:Literal>
+                                </ogc:Function>
+                                <ogc:Literal>true</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
+                                <ogc:Literal>1</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsNotEqualTo>
+                                <ogc:Function name="strLength">
+                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsNotEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:And>
+                    </ogc:Filter>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <GraphicFill>
+                                <Graphic>
+                                    <Mark>
+                                        <WellKnownName>shape://slash</WellKnownName>
+                                        <Stroke>
+                                            <CssParameter name="stroke"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
+                                            <CssParameter name="stroke-width">2</CssParameter>
+                                        </Stroke>
+                                    </Mark>
+                                    <Size>6</Size>
+                                </Graphic>
+                            </GraphicFill>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke"><ogc:PropertyName>border_color</ogc:PropertyName></CssParameter>
+                            <CssParameter name="stroke-width"><ogc:PropertyName>border_width</ogc:PropertyName></CssParameter>
+                            <CssParameter name="stroke-dasharray">5 2</CssParameter>
+                            <CssParameter name="stroke-linejoin"><ogc:PropertyName>border_linejoin</ogc:PropertyName></CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="in2">
+                                    <ogc:Function name="geometryType">
+                                        <ogc:PropertyName>geometry</ogc:PropertyName>
+                                    </ogc:Function>
+                                    <ogc:Literal>Polygon</ogc:Literal>
+                                    <ogc:Literal>MultiPolygon</ogc:Literal>
+                                </ogc:Function>
+                                <ogc:Literal>true</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
+                                <ogc:Literal>2</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="strLength">
+                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:And>
+                    </ogc:Filter>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <GraphicFill>
+                                <Graphic>
+                                    <Mark>
+                                        <WellKnownName>shape://horline</WellKnownName>
+                                        <Stroke>
+                                            <CssParameter name="stroke"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
+                                            <CssParameter name="stroke-width">0.4</CssParameter>
+                                        </Stroke>
+                                    </Mark>
+                                    <Size>4.5</Size>
+                                </Graphic>
+                            </GraphicFill>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke"><ogc:PropertyName>border_color</ogc:PropertyName></CssParameter>
+                            <CssParameter name="stroke-width"><ogc:PropertyName>border_width</ogc:PropertyName></CssParameter>
+                            <CssParameter name="stroke-linejoin"><ogc:PropertyName>border_linejoin</ogc:PropertyName></CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="in2">
+                                    <ogc:Function name="geometryType">
+                                        <ogc:PropertyName>geometry</ogc:PropertyName>
+                                    </ogc:Function>
+                                    <ogc:Literal>Polygon</ogc:Literal>
+                                    <ogc:Literal>MultiPolygon</ogc:Literal>
+                                </ogc:Function>
+                                <ogc:Literal>true</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
+                                <ogc:Literal>2</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsNotEqualTo>
+                                <ogc:Function name="strLength">
+                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsNotEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:And>
+                    </ogc:Filter>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <GraphicFill>
+                                <Graphic>
+                                    <Mark>
+                                        <WellKnownName>shape://horline</WellKnownName>
+                                        <Stroke>
+                                            <CssParameter name="stroke"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
+                                            <CssParameter name="stroke-width">0.4</CssParameter>
+                                        </Stroke>
+                                    </Mark>
+                                    <Size>4.5</Size>
+                                </Graphic>
+                            </GraphicFill>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke"><ogc:PropertyName>border_color</ogc:PropertyName></CssParameter>
+                            <CssParameter name="stroke-width"><ogc:PropertyName>border_width</ogc:PropertyName></CssParameter>
+                            <CssParameter name="stroke-dasharray">5 2</CssParameter>
+                            <CssParameter name="stroke-linejoin"><ogc:PropertyName>border_linejoin</ogc:PropertyName></CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="in2">
+                                    <ogc:Function name="geometryType">
+                                        <ogc:PropertyName>geometry</ogc:PropertyName>
+                                    </ogc:Function>
+                                    <ogc:Literal>Polygon</ogc:Literal>
+                                    <ogc:Literal>MultiPolygon</ogc:Literal>
+                                </ogc:Function>
+                                <ogc:Literal>true</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
+                                <ogc:Literal>3</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="strLength">
+                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:And>
+                    </ogc:Filter>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <GraphicFill>
+                                <Graphic>
+                                    <Mark>
+                                        <WellKnownName>shape://horline</WellKnownName>
+                                        <Stroke>
+                                            <CssParameter name="stroke"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
+                                            <CssParameter name="stroke-width">2</CssParameter>
+                                        </Stroke>
+                                    </Mark>
+                                    <Size>5.5</Size>
+                                </Graphic>
+                            </GraphicFill>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke"><ogc:PropertyName>border_color</ogc:PropertyName></CssParameter>
+                            <CssParameter name="stroke-width"><ogc:PropertyName>border_width</ogc:PropertyName></CssParameter>
+                            <CssParameter name="stroke-linejoin"><ogc:PropertyName>border_linejoin</ogc:PropertyName></CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="in2">
+                                    <ogc:Function name="geometryType">
+                                        <ogc:PropertyName>geometry</ogc:PropertyName>
+                                    </ogc:Function>
+                                    <ogc:Literal>Polygon</ogc:Literal>
+                                    <ogc:Literal>MultiPolygon</ogc:Literal>
+                                </ogc:Function>
+                                <ogc:Literal>true</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
+                                <ogc:Literal>3</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsNotEqualTo>
+                                <ogc:Function name="strLength">
+                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsNotEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="isNull">
+                                    <ogc:PropertyName>border_color</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>false</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:And>
+                    </ogc:Filter>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <GraphicFill>
+                                <Graphic>
+                                    <Mark>
+                                        <WellKnownName>shape://horline</WellKnownName>
+                                        <Stroke>
+                                            <CssParameter name="stroke"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
+                                            <CssParameter name="stroke-width">2</CssParameter>
+                                        </Stroke>
+                                    </Mark>
+                                    <Size>5.5</Size>
+                                </Graphic>
+                            </GraphicFill>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke"><ogc:PropertyName>border_color</ogc:PropertyName></CssParameter>
+                            <CssParameter name="stroke-width"><ogc:PropertyName>border_width</ogc:PropertyName></CssParameter>
+                            <CssParameter name="stroke-dasharray">5 2</CssParameter>
+                            <CssParameter name="stroke-linejoin"><ogc:PropertyName>border_linejoin</ogc:PropertyName></CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="in2">
+                                    <ogc:Function name="geometryType">
+                                        <ogc:PropertyName>geometry</ogc:PropertyName>
+                                    </ogc:Function>
+                                    <ogc:Literal>Polygon</ogc:Literal>
+                                    <ogc:Literal>MultiPolygon</ogc:Literal>
+                                </ogc:Function>
+                                <ogc:Literal>true</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
+                                <ogc:Literal>-1</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsNull>
+                                <ogc:PropertyName>border_color</ogc:PropertyName>
+                            </ogc:PropertyIsNull>
+                        </ogc:And>
+                    </ogc:Filter>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="in2">
+                                    <ogc:Function name="geometryType">
+                                        <ogc:PropertyName>geometry</ogc:PropertyName>
+                                    </ogc:Function>
+                                    <ogc:Literal>Polygon</ogc:Literal>
+                                    <ogc:Literal>MultiPolygon</ogc:Literal>
+                                </ogc:Function>
+                                <ogc:Literal>true</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
+                                <ogc:Literal>0</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsNull>
+                                <ogc:PropertyName>border_color</ogc:PropertyName>
+                            </ogc:PropertyIsNull>
+                        </ogc:And>
+                    </ogc:Filter>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <GraphicFill>
+                                <Graphic>
+                                    <Mark>
+                                        <WellKnownName>shape://slash</WellKnownName>
+                                        <Stroke>
+                                            <CssParameter name="stroke"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
+                                            <CssParameter name="stroke-width">1</CssParameter>
+                                        </Stroke>
+                                    </Mark>
+                                    <Size>4</Size>
+                                </Graphic>
+                            </GraphicFill>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="in2">
+                                    <ogc:Function name="geometryType">
+                                        <ogc:PropertyName>geometry</ogc:PropertyName>
+                                    </ogc:Function>
+                                    <ogc:Literal>Polygon</ogc:Literal>
+                                    <ogc:Literal>MultiPolygon</ogc:Literal>
+                                </ogc:Function>
+                                <ogc:Literal>true</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
+                                <ogc:Literal>1</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsNull>
+                                <ogc:PropertyName>border_color</ogc:PropertyName>
+                            </ogc:PropertyIsNull>
+                        </ogc:And>
+                    </ogc:Filter>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <GraphicFill>
+                                <Graphic>
+                                    <Mark>
+                                        <WellKnownName>shape://slash</WellKnownName>
+                                        <Stroke>
+                                            <CssParameter name="stroke"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
+                                            <CssParameter name="stroke-width">2</CssParameter>
+                                        </Stroke>
+                                    </Mark>
+                                    <Size>6</Size>
+                                </Graphic>
+                            </GraphicFill>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="in2">
+                                    <ogc:Function name="geometryType">
+                                        <ogc:PropertyName>geometry</ogc:PropertyName>
+                                    </ogc:Function>
+                                    <ogc:Literal>Polygon</ogc:Literal>
+                                    <ogc:Literal>MultiPolygon</ogc:Literal>
+                                </ogc:Function>
+                                <ogc:Literal>true</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
+                                <ogc:Literal>2</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsNull>
+                                <ogc:PropertyName>border_color</ogc:PropertyName>
+                            </ogc:PropertyIsNull>
+                        </ogc:And>
+                    </ogc:Filter>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <GraphicFill>
+                                <Graphic>
+                                    <Mark>
+                                        <WellKnownName>shape://horline</WellKnownName>
+                                        <Stroke>
+                                            <CssParameter name="stroke"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
+                                            <CssParameter name="stroke-width">0.4</CssParameter>
+                                        </Stroke>
+                                    </Mark>
+                                    <Size>4.5</Size>
+                                </Graphic>
+                            </GraphicFill>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:Function name="in2">
+                                    <ogc:Function name="geometryType">
+                                        <ogc:PropertyName>geometry</ogc:PropertyName>
+                                    </ogc:Function>
+                                    <ogc:Literal>Polygon</ogc:Literal>
+                                    <ogc:Literal>MultiPolygon</ogc:Literal>
+                                </ogc:Function>
+                                <ogc:Literal>true</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>fill_pattern</ogc:PropertyName>
+                                <ogc:Literal>3</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsNull>
+                                <ogc:PropertyName>border_color</ogc:PropertyName>
+                            </ogc:PropertyIsNull>
+                        </ogc:And>
+                    </ogc:Filter>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <GraphicFill>
+                                <Graphic>
+                                    <Mark>
+                                        <WellKnownName>shape://horline</WellKnownName>
+                                        <Stroke>
+                                            <CssParameter name="stroke"><ogc:PropertyName>fill_color</ogc:PropertyName></CssParameter>
+                                            <CssParameter name="stroke-width">2</CssParameter>
+                                        </Stroke>
+                                    </Mark>
+                                    <Size>5.5</Size>
+                                </Graphic>
+                            </GraphicFill>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
 </StyledLayerDescriptor>

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/analysis/AnalysisStyle.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/analysis/AnalysisStyle.java
@@ -25,20 +25,22 @@ public class AnalysisStyle {
     public void populateFromJSON(final JSONObject stylejs) throws JSONException {
         try {
             // {"area":{"fillColor":"FFDC00","lineColor":"CC9900","size":"2"},"line":{"color":"CC9900","size":"2"},"dot":{"color":"CC9900","size":"4"}}
-            setBorder_color(stylejs.getJSONObject("area").optString("lineColor"));
-            setBorder_width(stylejs.getJSONObject("area").optInt("size"));
+            JSONObject areaSubObject = stylejs.getJSONObject("area");
+
+            setBorder_color(areaSubObject.isNull("lineColor") ? null : areaSubObject.optString("lineColor")); // null is valid color value for "no stroke"
+            setBorder_width(areaSubObject.optInt("size"));
             setDot_color(stylejs.getJSONObject("dot").optString("color"));
             setDot_size(stylejs.getJSONObject("dot").optInt("size"));
-            setFill_color(stylejs.getJSONObject("area").optString("fillColor"));
+            setFill_color(areaSubObject.isNull("fillColor") ? null : areaSubObject.optString("fillColor")); // null is valid color value for "no fill"
             setStroke_color(stylejs.getJSONObject("line").optString("color"));
             setStroke_width(stylejs.getJSONObject("line").optInt("size"));
             setDot_shape(stylejs.getJSONObject("dot").optString("shape"));
             setStroke_linejoin(stylejs.getJSONObject("line").optString("corner"));
-            setFill_pattern(ConversionHelper.getInt(stylejs.getJSONObject("area").optString("fillStyle"), -1));
+            setFill_pattern(ConversionHelper.getInt(areaSubObject.optString("fillStyle"), -1));
             setStroke_linecap(stylejs.getJSONObject("line").optString("cap"));
             setStroke_dasharray(stylejs.getJSONObject("line").optString("style"));
-            setBorder_linejoin(stylejs.getJSONObject("area").optString("lineCorner"));
-            setBorder_dasharray(stylejs.getJSONObject("area").optString("lineStyle"));
+            setBorder_linejoin(areaSubObject.optString("lineCorner"));
+            setBorder_dasharray(areaSubObject.optString("lineStyle"));
         } catch (Exception ex) {
             throw new JSONException(ex);
         }

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/userlayer/UserLayerStyle.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/userlayer/UserLayerStyle.java
@@ -25,20 +25,22 @@ public class UserLayerStyle {
     public void populateFromJSON(final JSONObject stylejs) throws JSONException {
         try {
             // {"area":{"fillColor":"FFDC00","lineColor":"CC9900","size":"2"},"line":{"color":"CC9900","size":"2"},"dot":{"color":"CC9900","size":"4"}}
-            setBorder_color(stylejs.getJSONObject("area").optString("lineColor"));
-            setBorder_width(stylejs.getJSONObject("area").optInt("size"));
+            JSONObject areaSubObject = stylejs.getJSONObject("area");
+
+            setBorder_color(areaSubObject.isNull("lineColor") ? null : areaSubObject.optString("lineColor")); // null is valid color value for "no stroke"
+            setBorder_width(areaSubObject.optInt("size"));
             setDot_color(stylejs.getJSONObject("dot").optString("color"));
             setDot_size(stylejs.getJSONObject("dot").optInt("size"));
-            setFill_color(stylejs.getJSONObject("area").optString("fillColor"));
+            setFill_color(areaSubObject.isNull("fillColor") ? null : areaSubObject.optString("fillColor")); // null is valid color value for "no fill"
             setStroke_color(stylejs.getJSONObject("line").optString("color"));
             setStroke_width(stylejs.getJSONObject("line").optInt("size"));
             setDot_shape(stylejs.getJSONObject("dot").optString("shape"));
             setStroke_linejoin(stylejs.getJSONObject("line").optString("corner"));
-            setFill_pattern(ConversionHelper.getInt(stylejs.getJSONObject("area").optString("fillStyle"), -1));
+            setFill_pattern(ConversionHelper.getInt(areaSubObject.optString("fillStyle"), -1));
             setStroke_linecap(stylejs.getJSONObject("line").optString("cap"));
             setStroke_dasharray(stylejs.getJSONObject("line").optString("style"));
-            setBorder_linejoin(stylejs.getJSONObject("area").optString("lineCorner"));
-            setBorder_dasharray(stylejs.getJSONObject("area").optString("lineStyle"));
+            setBorder_linejoin(areaSubObject.optString("lineCorner"));
+            setBorder_dasharray(areaSubObject.optString("lineStyle"));
         } catch (Exception ex) {
             throw new JSONException(ex);
         }

--- a/service-feature-engine/src/example/resources/fi/nls/oskari/fe/output/style/sld_oskari_custom.xml
+++ b/service-feature-engine/src/example/resources/fi/nls/oskari/fe/output/style/sld_oskari_custom.xml
@@ -468,78 +468,8 @@
                         </ogc:PropertyIsEqualTo>
                     </ogc:Filter>
                     <PolygonSymbolizer>
-                        <Fill>
-                            fill_pattern_partial
-                            <CssParameter name="fill-opacity">0.7</CssParameter>
-
-                            <!--
-                            if fill_pattern == -1
-                                <CssParameter name="fill">fill_color</CssParameter>
-                            0
-                                <GraphicFill>
-                                    <Graphic>
-                                        <Mark>
-                                            <WellKnownName>shape://slash</WellKnownName>
-                                            <Stroke>
-                                                <CssParameter name="stroke">fill_color</CssParameter>
-                                                <CssParameter name="stroke-width">1</CssParameter>
-                                            </Stroke>
-                                        </Mark>
-                                        <Size>4</Size>
-                                    </Graphic>
-                                </GraphicFill>
-                            1
-                                <GraphicFill>
-                                    <Graphic>
-                                        <Mark>
-                                            <WellKnownName>shape://slash</WellKnownName>
-                                            <Stroke>
-                                                <CssParameter name="stroke">fill_color</CssParameter>
-                                                <CssParameter name="stroke-width">2</CssParameter>
-                                            </Stroke>
-                                        </Mark>
-                                        <Size>6</Size>
-                                    </Graphic>
-                                </GraphicFill>
-                            2
-                                <GraphicFill>
-                                    <Graphic>
-                                        <Mark>
-                                            <WellKnownName>shape://horline</WellKnownName>
-                                            <Stroke>
-                                                <CssParameter name="stroke">fill_color</CssParameter>
-                                                <CssParameter name="stroke-width">0.4</CssParameter>
-                                            </Stroke>
-                                        </Mark>
-                                        <Size>4.5</Size>
-                                    </Graphic>
-                                </GraphicFill>
-                            3
-                                <GraphicFill>
-                                    <Graphic>
-                                        <Mark>
-                                            <WellKnownName>shape://horline</WellKnownName>
-                                            <Stroke>
-                                                <CssParameter name="stroke">fill_color</CssParameter>
-                                                <CssParameter name="stroke-width">2</CssParameter>
-                                            </Stroke>
-                                        </Mark>
-                                        <Size>5.5</Size>
-                                    </Graphic>
-                                </GraphicFill>
-                            -->
-                        </Fill>
-                        <Stroke>
-                            <CssParameter name="stroke">border_color</CssParameter>
-                            <CssParameter name="stroke-width">border_width</CssParameter>
-                            <CssParameter name="stroke-linejoin">border_linejoin</CssParameter>
-
-                            border_style_partial
-                            <!--
-                            if border_dasharray != 0
-                                <CssParameter name="stroke-dasharray">5 2</CssParameter>
-                            -->
-                        </Stroke>
+                        polygon_fill_partial
+                        polygon_stroke_partial
                     </PolygonSymbolizer>
                 </Rule>
             </FeatureTypeStyle>

--- a/servlet-transport/src/main/java/fi/nls/oskari/pojo/WFSCustomStyleStore.java
+++ b/servlet-transport/src/main/java/fi/nls/oskari/pojo/WFSCustomStyleStore.java
@@ -36,10 +36,25 @@ public class WFSCustomStyleStore {
     public static final String HIGHLIGHT_STROKE_COLOR = "#FAEBD7";
     public static final String HIGHLIGHT_DOT_COLOR = "#FAEBD7";
 
+    public static final String POLYGON_FILL_PARTIAL = "polygon_fill_partial";
+    public static final String POLYGON_STROKE_PARTIAL = "polygon_stroke_partial";
+
     public static final String GEOMETRY = "defaultGeometry";
     public static final String FILL_PATTERN_PARTIAL = "fill_pattern_partial";
     public static final String LINE_STYLE_PARTIAL = "line_style_partial";
     public static final String BORDER_STYLE_PARTIAL = "border_style_partial";
+
+    public static final String POLYGON_FILL_ELEMENT = "<Fill>\n" +
+            "    fill_pattern_partial\n" +
+            "    <CssParameter name=\"fill-opacity\">0.7</CssParameter>\n" +
+            "</Fill>";
+
+    public static final String POLYGON_STROKE_ELEMENT = "<Stroke>\n" +
+            "    <CssParameter name=\"stroke\">border_color</CssParameter>\n" +
+            "    <CssParameter name=\"stroke-width\">border_width</CssParameter>\n" +
+            "    <CssParameter name=\"stroke-linejoin\">border_linejoin</CssParameter>\n" +
+            "    border_style_partial\n" +
+            "</Stroke>";
 
     public static final String LINE_STYLE_PARTIAL_LINECAP = "<CssParameter name=\"stroke-linecap\">stroke_linecap</CssParameter>";
     public static final String LINE_STYLE_PARTIAL_DASHARRAY = "<CssParameter name=\"stroke-dasharray\">5 2</CssParameter>";
@@ -277,6 +292,14 @@ public class WFSCustomStyleStore {
             lineStylePartial = LINE_STYLE_PARTIAL_DASHARRAY;
         }
         template = template.replaceAll(LINE_STYLE_PARTIAL, lineStylePartial);
+
+        // Polygon Fill & Stroke elements
+        if(!("#-1").equals(fillColor) || isHighlight){
+            template = template.replaceAll(POLYGON_FILL_PARTIAL, POLYGON_FILL_ELEMENT);
+        }
+        if(!("#-1").equals(borderColor) || isHighlight){
+            template = template.replaceAll(POLYGON_STROKE_PARTIAL, POLYGON_STROKE_ELEMENT);
+        }
 
         // fill patterns
         String fillPatternPartial;

--- a/servlet-transport/src/main/java/fi/nls/oskari/pojo/WFSCustomStyleStore.java
+++ b/servlet-transport/src/main/java/fi/nls/oskari/pojo/WFSCustomStyleStore.java
@@ -119,7 +119,11 @@ public class WFSCustomStyleStore {
     }
 
     public void setFillColor(String fillColor) {
-        this.fillColor = addPrefixColor(fillColor);
+        if(fillColor != null) {
+            this.fillColor = addPrefixColor(fillColor);
+        } else {
+            this.fillColor = fillColor;
+        }
     }
 
     public int getFillPattern() {
@@ -135,7 +139,11 @@ public class WFSCustomStyleStore {
     }
 
     public void setBorderColor(String borderColor) {
-        this.borderColor = addPrefixColor(borderColor);
+        if(borderColor != null) {
+            this.borderColor = addPrefixColor(borderColor);
+        } else {
+            this.borderColor = borderColor;
+        }
     }
 
     public String getBorderLinejoin() {
@@ -294,10 +302,10 @@ public class WFSCustomStyleStore {
         template = template.replaceAll(LINE_STYLE_PARTIAL, lineStylePartial);
 
         // Polygon Fill & Stroke elements
-        if(!("#-1").equals(fillColor) || isHighlight){
+        if(fillColor != null || isHighlight){
             template = template.replaceAll(POLYGON_FILL_PARTIAL, POLYGON_FILL_ELEMENT);
         }
-        if(!("#-1").equals(borderColor) || isHighlight){
+        if(borderColor != null || isHighlight){
             template = template.replaceAll(POLYGON_STROKE_PARTIAL, POLYGON_STROKE_ELEMENT);
         }
 

--- a/servlet-transport/src/main/java/fi/nls/oskari/transport/TransportService.java
+++ b/servlet-transport/src/main/java/fi/nls/oskari/transport/TransportService.java
@@ -597,9 +597,9 @@ public class TransportService extends AbstractService {
         customStyle.setLayerId(layerId);
         customStyle.setClient(store.getClient());
 
-        customStyle.setFillColor(style.get(WFSCustomStyleStore.PARAM_FILL_COLOR).toString());
+        customStyle.setFillColor((String)style.get(WFSCustomStyleStore.PARAM_FILL_COLOR));
         customStyle.setFillPattern(((Number)style.get(WFSCustomStyleStore.PARAM_FILL_PATTERN)).intValue());
-        customStyle.setBorderColor(style.get(WFSCustomStyleStore.PARAM_BORDER_COLOR).toString());
+        customStyle.setBorderColor((String)style.get(WFSCustomStyleStore.PARAM_BORDER_COLOR));
         customStyle.setBorderLinejoin(style.get(WFSCustomStyleStore.PARAM_BORDER_LINEJOIN).toString());
         customStyle.setBorderDasharray(style.get(WFSCustomStyleStore.PARAM_BORDER_DASHARRAY).toString());
         customStyle.setBorderWidth(((Number)style.get(WFSCustomStyleStore.PARAM_BORDER_WIDTH)).intValue());

--- a/servlet-transport/src/main/resources/fi/nls/oskari/wfs/sld_oskari_custom.xml
+++ b/servlet-transport/src/main/resources/fi/nls/oskari/wfs/sld_oskari_custom.xml
@@ -468,78 +468,8 @@
                         </ogc:PropertyIsEqualTo>
                     </ogc:Filter>
                     <PolygonSymbolizer>
-                        <Fill>
-                            fill_pattern_partial
-                            <CssParameter name="fill-opacity">0.7</CssParameter>
-
-                            <!--
-                            if fill_pattern == -1
-                                <CssParameter name="fill">fill_color</CssParameter>
-                            0
-                                <GraphicFill>
-                                    <Graphic>
-                                        <Mark>
-                                            <WellKnownName>shape://slash</WellKnownName>
-                                            <Stroke>
-                                                <CssParameter name="stroke">fill_color</CssParameter>
-                                                <CssParameter name="stroke-width">1</CssParameter>
-                                            </Stroke>
-                                        </Mark>
-                                        <Size>4</Size>
-                                    </Graphic>
-                                </GraphicFill>
-                            1
-                                <GraphicFill>
-                                    <Graphic>
-                                        <Mark>
-                                            <WellKnownName>shape://slash</WellKnownName>
-                                            <Stroke>
-                                                <CssParameter name="stroke">fill_color</CssParameter>
-                                                <CssParameter name="stroke-width">2</CssParameter>
-                                            </Stroke>
-                                        </Mark>
-                                        <Size>6</Size>
-                                    </Graphic>
-                                </GraphicFill>
-                            2
-                                <GraphicFill>
-                                    <Graphic>
-                                        <Mark>
-                                            <WellKnownName>shape://horline</WellKnownName>
-                                            <Stroke>
-                                                <CssParameter name="stroke">fill_color</CssParameter>
-                                                <CssParameter name="stroke-width">0.4</CssParameter>
-                                            </Stroke>
-                                        </Mark>
-                                        <Size>4.5</Size>
-                                    </Graphic>
-                                </GraphicFill>
-                            3
-                                <GraphicFill>
-                                    <Graphic>
-                                        <Mark>
-                                            <WellKnownName>shape://horline</WellKnownName>
-                                            <Stroke>
-                                                <CssParameter name="stroke">fill_color</CssParameter>
-                                                <CssParameter name="stroke-width">2</CssParameter>
-                                            </Stroke>
-                                        </Mark>
-                                        <Size>5.5</Size>
-                                    </Graphic>
-                                </GraphicFill>
-                            -->
-                        </Fill>
-                        <Stroke>
-                            <CssParameter name="stroke">border_color</CssParameter>
-                            <CssParameter name="stroke-width">border_width</CssParameter>
-                            <CssParameter name="stroke-linejoin">border_linejoin</CssParameter>
-
-                            border_style_partial
-                            <!--
-                            if border_dasharray != 0
-                                <CssParameter name="stroke-dasharray">5 2</CssParameter>
-                            -->
-                        </Stroke>
+                        polygon_fill_partial
+                        polygon_stroke_partial
                     </PolygonSymbolizer>
                 </Rule>
             </FeatureTypeStyle>

--- a/servlet-transport/src/test/resources/fi/nls/oskari/pojo/custom_highlight_sld.xml
+++ b/servlet-transport/src/test/resources/fi/nls/oskari/pojo/custom_highlight_sld.xml
@@ -469,77 +469,15 @@
                     </ogc:Filter>
                     <PolygonSymbolizer>
                         <Fill>
-                            <CssParameter name="fill">#FAEBD7</CssParameter>
-                            <CssParameter name="fill-opacity">0.7</CssParameter>
-
-                            <!--
-                            if fill_pattern == -1
-                                <CssParameter name="fill">#FAEBD7</CssParameter>
-                            0
-                                <GraphicFill>
-                                    <Graphic>
-                                        <Mark>
-                                            <WellKnownName>shape://slash</WellKnownName>
-                                            <Stroke>
-                                                <CssParameter name="stroke">#FAEBD7</CssParameter>
-                                                <CssParameter name="stroke-width">1</CssParameter>
-                                            </Stroke>
-                                        </Mark>
-                                        <Size>4</Size>
-                                    </Graphic>
-                                </GraphicFill>
-                            1
-                                <GraphicFill>
-                                    <Graphic>
-                                        <Mark>
-                                            <WellKnownName>shape://slash</WellKnownName>
-                                            <Stroke>
-                                                <CssParameter name="stroke">#FAEBD7</CssParameter>
-                                                <CssParameter name="stroke-width">2</CssParameter>
-                                            </Stroke>
-                                        </Mark>
-                                        <Size>6</Size>
-                                    </Graphic>
-                                </GraphicFill>
-                            2
-                                <GraphicFill>
-                                    <Graphic>
-                                        <Mark>
-                                            <WellKnownName>shape://horline</WellKnownName>
-                                            <Stroke>
-                                                <CssParameter name="stroke">#FAEBD7</CssParameter>
-                                                <CssParameter name="stroke-width">0.4</CssParameter>
-                                            </Stroke>
-                                        </Mark>
-                                        <Size>4.5</Size>
-                                    </Graphic>
-                                </GraphicFill>
-                            3
-                                <GraphicFill>
-                                    <Graphic>
-                                        <Mark>
-                                            <WellKnownName>shape://horline</WellKnownName>
-                                            <Stroke>
-                                                <CssParameter name="stroke">#FAEBD7</CssParameter>
-                                                <CssParameter name="stroke-width">2</CssParameter>
-                                            </Stroke>
-                                        </Mark>
-                                        <Size>5.5</Size>
-                                    </Graphic>
-                                </GraphicFill>
-                            -->
-                        </Fill>
+    <CssParameter name="fill">#FAEBD7</CssParameter>
+    <CssParameter name="fill-opacity">0.7</CssParameter>
+</Fill>
                         <Stroke>
-                            <CssParameter name="stroke">#000000</CssParameter>
-                            <CssParameter name="stroke-width">1</CssParameter>
-                            <CssParameter name="stroke-linejoin">mitre</CssParameter>
-
-                            
-                            <!--
-                            if border_dasharray != 0
-                                <CssParameter name="stroke-dasharray">5 2</CssParameter>
-                            -->
-                        </Stroke>
+    <CssParameter name="stroke">#000000</CssParameter>
+    <CssParameter name="stroke-width">1</CssParameter>
+    <CssParameter name="stroke-linejoin">mitre</CssParameter>
+    
+</Stroke>
                     </PolygonSymbolizer>
                 </Rule>
             </FeatureTypeStyle>

--- a/servlet-transport/src/test/resources/fi/nls/oskari/pojo/custom_sld.xml
+++ b/servlet-transport/src/test/resources/fi/nls/oskari/pojo/custom_sld.xml
@@ -469,77 +469,15 @@
                     </ogc:Filter>
                     <PolygonSymbolizer>
                         <Fill>
-                            <CssParameter name="fill">#ffde00</CssParameter>
-                            <CssParameter name="fill-opacity">0.7</CssParameter>
-
-                            <!--
-                            if fill_pattern == -1
-                                <CssParameter name="fill">#ffde00</CssParameter>
-                            0
-                                <GraphicFill>
-                                    <Graphic>
-                                        <Mark>
-                                            <WellKnownName>shape://slash</WellKnownName>
-                                            <Stroke>
-                                                <CssParameter name="stroke">#ffde00</CssParameter>
-                                                <CssParameter name="stroke-width">1</CssParameter>
-                                            </Stroke>
-                                        </Mark>
-                                        <Size>4</Size>
-                                    </Graphic>
-                                </GraphicFill>
-                            1
-                                <GraphicFill>
-                                    <Graphic>
-                                        <Mark>
-                                            <WellKnownName>shape://slash</WellKnownName>
-                                            <Stroke>
-                                                <CssParameter name="stroke">#ffde00</CssParameter>
-                                                <CssParameter name="stroke-width">2</CssParameter>
-                                            </Stroke>
-                                        </Mark>
-                                        <Size>6</Size>
-                                    </Graphic>
-                                </GraphicFill>
-                            2
-                                <GraphicFill>
-                                    <Graphic>
-                                        <Mark>
-                                            <WellKnownName>shape://horline</WellKnownName>
-                                            <Stroke>
-                                                <CssParameter name="stroke">#ffde00</CssParameter>
-                                                <CssParameter name="stroke-width">0.4</CssParameter>
-                                            </Stroke>
-                                        </Mark>
-                                        <Size>4.5</Size>
-                                    </Graphic>
-                                </GraphicFill>
-                            3
-                                <GraphicFill>
-                                    <Graphic>
-                                        <Mark>
-                                            <WellKnownName>shape://horline</WellKnownName>
-                                            <Stroke>
-                                                <CssParameter name="stroke">#ffde00</CssParameter>
-                                                <CssParameter name="stroke-width">2</CssParameter>
-                                            </Stroke>
-                                        </Mark>
-                                        <Size>5.5</Size>
-                                    </Graphic>
-                                </GraphicFill>
-                            -->
-                        </Fill>
+    <CssParameter name="fill">#ffde00</CssParameter>
+    <CssParameter name="fill-opacity">0.7</CssParameter>
+</Fill>
                         <Stroke>
-                            <CssParameter name="stroke">#000000</CssParameter>
-                            <CssParameter name="stroke-width">1</CssParameter>
-                            <CssParameter name="stroke-linejoin">mitre</CssParameter>
-
-                            
-                            <!--
-                            if border_dasharray != 0
-                                <CssParameter name="stroke-dasharray">5 2</CssParameter>
-                            -->
-                        </Stroke>
+    <CssParameter name="stroke">#000000</CssParameter>
+    <CssParameter name="stroke-width">1</CssParameter>
+    <CssParameter name="stroke-linejoin">mitre</CssParameter>
+    
+</Stroke>
                     </PolygonSymbolizer>
                 </Rule>
             </FeatureTypeStyle>


### PR DESCRIPTION
Polygon style now supports no fill and no stroke. The condition is expressed as allowed `null` color String values for "fill_color" and "border_color" in UserLayerStyle/AnalysisStyle/MyPlaceCategory/WFSLayerStore.

Implemented both on WFS transport & Geoserver WMS layers. DefaultStyle SLDs needs to be manually updated on Geoserver.

Separate change in frontend UI will allow setting the colors to null.