### PR TITLE
Removed styles from GFI response html

### DIFF
--- a/service-map/src/main/java/fi/nls/oskari/map/data/service/GetGeoPointDataService.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/data/service/GetGeoPointDataService.java
@@ -72,7 +72,7 @@ public class GetGeoPointDataService {
         // use text content if respObj isn't present (transformed JSON not created)
         if(respObj == null) {
             JSONHelper.putValue(response, PRESENTATION_TYPE, PRESENTATION_TYPE_TEXT);
-            JSONHelper.putValue(response, CONTENT, gfiResponse);
+            JSONHelper.putValue(response, CONTENT, Jsoup.clean(gfiResponse, Whitelist.relaxed()));
         }
         // Add gfi content, it needs to be a separate field so we can mangle it as we like in the frontend
         final String gfiContent = params.getLayer().getGfiContent();

--- a/service-map/src/test/java/fi/nls/oskari/map/data/service/GetGeoPointDataServiceTest.java
+++ b/service-map/src/test/java/fi/nls/oskari/map/data/service/GetGeoPointDataServiceTest.java
@@ -1,17 +1,26 @@
 package fi.nls.oskari.map.data.service;
 
+import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.map.data.domain.GFIRequestParams;
 import fi.nls.oskari.util.IOHelper;
 import fi.nls.oskari.util.JSONHelper;
 import org.json.JSONObject;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.IOException;
 
 import static org.junit.Assert.*;
+import static org.mockito.Matchers.anyString;
 
 /**
  * Created by SMAKINEN on 24.11.2016.
  */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(GetGeoPointDataService.class)
 public class GetGeoPointDataServiceTest {
 
     @Test
@@ -30,4 +39,22 @@ public class GetGeoPointDataServiceTest {
         assertNotNull(parsed.optString("Staður"));
 
     }
+
+    @Test
+    public void testResponseCleaning()
+            throws Exception {
+        final String dirty = "<style></style><script>alert('illegal!')</script><h4>Allowed</h4>";
+        GetGeoPointDataService partialMock = PowerMockito.spy(new GetGeoPointDataService());
+        PowerMockito.doReturn(dirty).when(partialMock, "makeGFIcall", anyString(), anyString(), anyString());
+        GFIRequestParams params = new GFIRequestParams();
+        final OskariLayer layer = new OskariLayer();
+        layer.setUsername("name");
+        layer.setPassword("anything");
+        layer.setUrl("http://example.com/");
+        layer.setName("layerName");
+        params.setLayer(layer);
+        JSONObject response = partialMock.getWMSFeatureInfo(params);
+        assertEquals("Should have cleaned html", response.optString("content"), "<h4>Allowed</h4>");
+    }
+
 }


### PR DESCRIPTION
Style-tags in GFI html response were interfering with global Oskari CSS. Response html is now sanitized with Jsoup if presentation type is TEXT. Only tags in in Jsoup ["relaxed" whitelist](https://jsoup.org/apidocs/org/jsoup/safety/Whitelist.html#relaxed--) are allowed.

Added also test.

In reference to:
https://jira.nls.fi/browse/AH-3983