### PR TITLE
Use "feature" key for all status flags

### DIFF
--- a/servlet-transport/src/main/java/fi/nls/oskari/work/WFSMapLayerJob.java
+++ b/servlet-transport/src/main/java/fi/nls/oskari/work/WFSMapLayerJob.java
@@ -169,7 +169,7 @@ public class WFSMapLayerJob extends OWSMapLayerJob {
             final Map<String, Object> output = createCommonResponse();
             if(features == null || features.isEmpty()) {
                 log.debug("Empty result for", this.layerId, "type:", type);
-                output.put(OUTPUT_FEATURES, "empty");
+                output.put(OUTPUT_FEATURE, "empty");
                 log.debug(PROCESS_ENDED, getKey());
                 if(this.type == JobType.MAP_CLICK) {
                     output.put(OUTPUT_KEEP_PREVIOUS, this.session.isKeepPrevious());


### PR DESCRIPTION
Previously the messages used both "feature" and "features" as keys for status flags.