### PR TITLE
Allow partial update of layer fields

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/layer/SaveLayerHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/SaveLayerHandler.java
@@ -337,9 +337,6 @@ public class SaveLayerHandler extends ActionHandler {
 
         String parameters = params.getHttpParam("params");
         if (parameters != null && !parameters.equals("")) {
-            if (!parameters.startsWith("{")) {
-                parameters = "{time=" + parameters + "}";
-            }
             ml.setParams(JSONHelper.createJSONObject(parameters));
         }
 

--- a/control-base/src/main/java/fi/nls/oskari/control/layer/SaveLayerHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/SaveLayerHandler.java
@@ -331,20 +331,17 @@ public class SaveLayerHandler extends ActionHandler {
         ml.setPassword(params.getHttpParam("password", ml.getPassword()));
 
         String attributes = params.getHttpParam("attributes");
-        if (attributes == null || attributes.equals("")) {
-            attributes = "{}";
+        if (attributes != null && !attributes.equals("")) {
+            ml.setAttributes(JSONHelper.createJSONObject(attributes));
         }
-
-        ml.setAttributes(JSONHelper.createJSONObject(attributes));
 
         String parameters = params.getHttpParam("params");
-        if (parameters == null || parameters.equals("")) {
-            parameters = "{}";
+        if (parameters != null && !parameters.equals("")) {
+            if (!parameters.startsWith("{")) {
+                parameters = "{time=" + parameters + "}";
+            }
+            ml.setParams(JSONHelper.createJSONObject(parameters));
         }
-        if (!parameters.startsWith("{")) {
-            parameters = "{time="+parameters+"}";
-        }
-        ml.setParams(JSONHelper.createJSONObject(parameters));
 
         ml.setSrs_name(params.getHttpParam("srs_name", ml.getSrs_name()));
         ml.setVersion(params.getHttpParam("version",ml.getVersion()));


### PR DESCRIPTION
Update layer "params" and "attributes" fields only if request had corresponding parameters. Other request parameters could already be omitted without problem.

This is an overall improvement, but also fixes:
https://jira.nls.fi/browse/AH-3616