### PR TITLE
Role service fixes

### DIFF
--- a/MigrationGuide.md
+++ b/MigrationGuide.md
@@ -18,6 +18,10 @@ Common issues:
 DefaultStyle SLDs needs to be manually updated on Geoserver from
 https://github.com/oskariorg/oskari-server/tree/master/content-resources/src/main/resources/sld
 
+### Users service
+
+The database access library has been updated from iBATIS to MyBatis. DatabaseUserService now uses MybatisRoleService and MybatisUserService. If you are using old IbatisRoleService or IbatisUserService in your own Oskari server extensions, you have to update them to use MybatisRoleService and MybatisUserService implementations.
+
 ## 1.42.1
 
 ### User registration feature

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -120,6 +120,9 @@ Removed countries listing resource JSON. Instead uses a CountryFilter operation 
 
 Removed serval API integration and now only including the monitor API.
 
+### service-users
+The database access library has been updated from iBATIS to MyBatis. DatabaseUserService now uses MybatisRoleService and MybatisUserService.
+
 ## 1.43.0
 
 ### servlet-printout

--- a/service-users/src/main/java/fi/nls/oskari/user/MybatisRoleService.java
+++ b/service-users/src/main/java/fi/nls/oskari/user/MybatisRoleService.java
@@ -200,7 +200,7 @@ public class MybatisRoleService {
     public Map<String, Role> getExternalRolesMapping(String type) {
         final Map<String, Role> mapping = new HashMap<>();
         if(type == null) {
-            return mapping;
+            type="";
         }
         final SqlSession session = factory.openSession();
         List<Object> roleMappingList = null;

--- a/service-users/src/main/java/fi/nls/oskari/user/RolesMapper.java
+++ b/service-users/src/main/java/fi/nls/oskari/user/RolesMapper.java
@@ -5,6 +5,7 @@ import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 
@@ -22,7 +23,7 @@ public interface RolesMapper {
 
     @Insert("INSERT INTO oskari_role_oskari_user (role_id, user_id) " +
             "VALUES (#{roleId}, #{userId})")
-    void linkRoleToNewUser(long roleId, long userId);
+    void linkRoleToNewUser(@Param("roleId") long roleId, @Param("userId") long userId);
 
     @Delete("DELETE FROM oskari_role_oskari_user WHERE user_id = #{userId}")
     void deleteUsersRoles(long userId);


### PR DESCRIPTION
If getExternalRolesMapping type value is null, replace it with empty string.

Added missing param annotations to linkRoleToNewUser.
