### PR TITLE
Support new version of ELF Geolocator ElasticSearch autocomplete API

### DIFF
--- a/service-search-nls/src/main/java/fi/nls/oskari/search/channel/ELFGeoLocatorSearchChannel.java
+++ b/service-search-nls/src/main/java/fi/nls/oskari/search/channel/ELFGeoLocatorSearchChannel.java
@@ -429,16 +429,22 @@ public class ELFGeoLocatorSearchChannel extends SearchChannel implements SearchA
         if(PROPERTY_AUTOCOMPLETE_URL == null || PROPERTY_AUTOCOMPLETE_URL.isEmpty()) {
             return Collections.emptyList();
         }
+        JSONObject jsonObject;
         try {
             log.info("Creating autocomplete search url with url:", PROPERTY_AUTOCOMPLETE_URL);
             HttpURLConnection conn = IOHelper.getConnection(PROPERTY_AUTOCOMPLETE_URL,
                     PROPERTY_AUTOCOMPLETE_USERNAME, PROPERTY_AUTOCOMPLETE_PASSWORD);
             IOHelper.writeToConnection(conn, getElasticQuery(searchString));
             String result = IOHelper.readString(conn);
-            JSONObject jsonObject = new JSONObject(result);
+            jsonObject = new JSONObject(result);
+        }
+        catch (Exception ex) {
+            log.error("Couldn't open or read from connection for search channel!");
+            throw new RuntimeException("Couldn't open or read from connection!", ex);
+        }
 
-            HitCombiner combiner = new HitCombiner();
-
+        HitCombiner combiner = new HitCombiner();
+        try {
             JSONArray fuzzyHits = jsonObject.getJSONArray("fuzzy_search").getJSONObject(0).getJSONArray("options");
             for (int i = 0; i < fuzzyHits.length(); ++i) {
                 combiner.addHit(fuzzyHits.getJSONObject(i), 0);
@@ -448,13 +454,13 @@ public class ELFGeoLocatorSearchChannel extends SearchChannel implements SearchA
             for (int i = 0; i < exactHits.length(); ++i) {
                 combiner.addHit(exactHits.getJSONObject(i), 1000);
             }
+        }
+        catch (JSONException ex) {
+            log.error("Unexpected autocomplete service JSON response structure!");
+            throw new RuntimeException("Unexpected autocomplete service JSON response structure!", ex);
+        }
 
-            return combiner.getSortedHits();
-        }
-        catch (Exception ex) {
-            log.error("Couldn't open or read from connection for search channel!");
-            throw new RuntimeException("Couldn't open or read from connection!", ex);
-        }
+        return combiner.getSortedHits();
     }
 
 

--- a/service-search-nls/src/main/java/fi/nls/oskari/search/channel/ELFGeoLocatorSearchChannel.java
+++ b/service-search-nls/src/main/java/fi/nls/oskari/search/channel/ELFGeoLocatorSearchChannel.java
@@ -8,6 +8,7 @@ import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.search.util.ELFGeoLocatorParser;
 import fi.nls.oskari.search.util.ELFGeoLocatorQueryHelper;
+import fi.nls.oskari.search.util.HitCombiner;
 import fi.nls.oskari.service.ServiceRuntimeException;
 import fi.nls.oskari.util.IOHelper;
 import fi.nls.oskari.util.JSONHelper;
@@ -475,41 +476,4 @@ public class ELFGeoLocatorSearchChannel extends SearchChannel implements SearchA
         return elasticQueryTemplate.toString();
     }
 
-    private class HitCombiner {
-        Map<String, ScoredSearchHit> combinedHits = new TreeMap<>();
-
-        public void addHit(JSONObject hit, int scoreBoost) throws JSONException {
-            String text = hit.getString("text");
-            int score = hit.getInt("_score") + scoreBoost;
-            ScoredSearchHit existingHit = combinedHits.get(text);
-            if (existingHit == null || existingHit.score < score) {
-                combinedHits.put(text, new ScoredSearchHit(text, score));
-            }
-        }
-
-        public List<String> getSortedHits() {
-            List<ScoredSearchHit> suggestions = new ArrayList<>(combinedHits.values());
-            Collections.sort(suggestions, Collections.reverseOrder());
-            List<String> resultList = new ArrayList<>();
-            for (ScoredSearchHit hit : suggestions) {
-                resultList.add(hit.text);
-            }
-            return resultList;
-        }
-
-        private class ScoredSearchHit implements Comparable<ScoredSearchHit> {
-            public final int score;
-            public final String text;
-
-            public ScoredSearchHit(String t, int s) {
-                text = t;
-                score = s;
-            }
-
-            @Override
-            public int compareTo(ScoredSearchHit other) {
-                return score - other.score;
-            }
-        }
-    }
 }

--- a/service-search-nls/src/main/java/fi/nls/oskari/search/channel/ELFGeoLocatorSearchChannel.java
+++ b/service-search-nls/src/main/java/fi/nls/oskari/search/channel/ELFGeoLocatorSearchChannel.java
@@ -447,12 +447,12 @@ public class ELFGeoLocatorSearchChannel extends SearchChannel implements SearchA
         HitCombiner combiner = new HitCombiner();
         try {
             JSONArray fuzzyHits = jsonObject.getJSONArray("fuzzy_search").getJSONObject(0).getJSONArray("options");
-            for (int i = 0; i < fuzzyHits.length(); ++i) {
+            for (int i = 0; i < fuzzyHits.length(); i++) {
                 combiner.addHit(fuzzyHits.getJSONObject(i), 0);
             }
 
             JSONArray exactHits = jsonObject.getJSONArray("normal_search").getJSONObject(0).getJSONArray("options");
-            for (int i = 0; i < exactHits.length(); ++i) {
+            for (int i = 0; i < exactHits.length(); i++) {
                 combiner.addHit(exactHits.getJSONObject(i), 1000);
             }
         }

--- a/service-search-nls/src/main/java/fi/nls/oskari/search/util/HitCombiner.java
+++ b/service-search-nls/src/main/java/fi/nls/oskari/search/util/HitCombiner.java
@@ -6,7 +6,7 @@ import org.json.JSONObject;
 import java.util.*;
 
 public class HitCombiner {
-    Map<String, ScoredSearchHit> combinedHits = new TreeMap<>();
+    Map<String, ScoredSearchHit> combinedHits = new HashMap<>();
 
     public void addHit(JSONObject hit, int scoreBoost) throws JSONException {
         String text = hit.getString("text");
@@ -20,7 +20,7 @@ public class HitCombiner {
     public List<String> getSortedHits() {
         List<ScoredSearchHit> suggestions = new ArrayList<>(combinedHits.values());
         Collections.sort(suggestions, Collections.reverseOrder());
-        List<String> resultList = new ArrayList<>();
+        List<String> resultList = new ArrayList<>(suggestions.size());
         for (ScoredSearchHit hit : suggestions) {
             resultList.add(hit.text);
         }

--- a/service-search-nls/src/main/java/fi/nls/oskari/search/util/HitCombiner.java
+++ b/service-search-nls/src/main/java/fi/nls/oskari/search/util/HitCombiner.java
@@ -1,0 +1,4 @@
+package fi.nls.oskari.search.util;
+
+public class HitCombiner {
+}

--- a/service-search-nls/src/main/java/fi/nls/oskari/search/util/HitCombiner.java
+++ b/service-search-nls/src/main/java/fi/nls/oskari/search/util/HitCombiner.java
@@ -1,4 +1,30 @@
 package fi.nls.oskari.search.util;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.*;
+
 public class HitCombiner {
+    Map<String, ScoredSearchHit> combinedHits = new TreeMap<>();
+
+    public void addHit(JSONObject hit, int scoreBoost) throws JSONException {
+        String text = hit.getString("text");
+        int score = hit.getInt("_score") + scoreBoost;
+        ScoredSearchHit existingHit = combinedHits.get(text);
+        if (existingHit == null || existingHit.score < score) {
+            combinedHits.put(text, new ScoredSearchHit(text, score));
+        }
+    }
+
+    public List<String> getSortedHits() {
+        List<ScoredSearchHit> suggestions = new ArrayList<>(combinedHits.values());
+        Collections.sort(suggestions, Collections.reverseOrder());
+        List<String> resultList = new ArrayList<>();
+        for (ScoredSearchHit hit : suggestions) {
+            resultList.add(hit.text);
+        }
+        return resultList;
+    }
+
 }

--- a/service-search-nls/src/main/java/fi/nls/oskari/search/util/ScoredSearchHit.java
+++ b/service-search-nls/src/main/java/fi/nls/oskari/search/util/ScoredSearchHit.java
@@ -1,0 +1,4 @@
+package fi.nls.oskari.search.util;
+
+public class ScoredSearchHit {
+}

--- a/service-search-nls/src/main/java/fi/nls/oskari/search/util/ScoredSearchHit.java
+++ b/service-search-nls/src/main/java/fi/nls/oskari/search/util/ScoredSearchHit.java
@@ -1,4 +1,16 @@
 package fi.nls.oskari.search.util;
 
-public class ScoredSearchHit {
+class ScoredSearchHit implements Comparable<ScoredSearchHit> {
+    public final int score;
+    public final String text;
+
+    public ScoredSearchHit(String t, int s) {
+        text = t;
+        score = s;
+    }
+
+    @Override
+    public int compareTo(ScoredSearchHit other) {
+        return score - other.score;
+    }
 }

--- a/service-search-nls/src/main/java/fi/nls/oskari/search/util/ScoredSearchHit.java
+++ b/service-search-nls/src/main/java/fi/nls/oskari/search/util/ScoredSearchHit.java
@@ -1,8 +1,8 @@
 package fi.nls.oskari.search.util;
 
 class ScoredSearchHit implements Comparable<ScoredSearchHit> {
-    public final int score;
     public final String text;
+    public final int score;
 
     public ScoredSearchHit(String t, int s) {
         text = t;

--- a/service-search-nls/src/test/java/fi/nls/oskari/search/channel/ELFGeoLocatorSearchChannelTest.java
+++ b/service-search-nls/src/test/java/fi/nls/oskari/search/channel/ELFGeoLocatorSearchChannelTest.java
@@ -70,7 +70,7 @@ public class ELFGeoLocatorSearchChannelTest {
     @Test
     public void getElasticQuery() {
         ELFGeoLocatorSearchChannel channel = new ELFGeoLocatorSearchChannel();
-        final JSONObject expected = JSONHelper.createJSONObject("{\"query\":{\"match\":{\"name\":{\"analyzer\":\"standard\",\"query\":\"\\\"}, {\\\"break\\\": []\"}}}}");
+        final JSONObject expected = JSONHelper.createJSONObject("{\"normal_search\":{\"text\":\"\\\"}, {\\\"break\\\": []\",\"completion\":{\"field\":\"name_suggest\",\"size\":20}},\"fuzzy_search\":{\"text\":\"\\\"}, {\\\"break\\\": []\",\"completion\":{\"field\":\"name_suggest\",\"size\":20,\"fuzzy\":{\"fuzziness\":5}}}}");
         final JSONObject actual = JSONHelper.createJSONObject(channel.getElasticQuery("\"}, {\"break\": []"));
         assertTrue("JSON should not break", JSONHelper.isEqual(expected, actual));
     }


### PR DESCRIPTION
Structure of ElasticSearch service response has changed and old version is no longer supported.  Version in use now should be version /asdielastic/placenames3/_suggest

New implementation also combines and deduplicates exact & fuzzy matches, sorting the exact matches on top in the response list.

In reference to:
https://jira.nls.fi/browse/AH-3911