### PR TITLE
Metadata catalogue field value blacklisting

### DIFF
--- a/service-csw/src/main/java/fi/nls/oskari/control/metadata/MetadataField.java
+++ b/service-csw/src/main/java/fi/nls/oskari/control/metadata/MetadataField.java
@@ -6,6 +6,7 @@ import fi.nls.oskari.util.JSONHelper;
 import org.json.JSONArray;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -19,6 +20,7 @@ import java.util.Map;
  * - dependencies maps a possible field value to another field for combining filter (example type=service can be further filtered with serviceType field ->
  * these need to be wrapped in Logical AND operation)
  * - shownIf is a dumb JSON presentation for frontend form (example serviceType should only be shown if value 'service' is selected in field 'type')
+ * - blacklist is a list of response values that will be filtered out
  */
 public class MetadataField {
 
@@ -33,6 +35,7 @@ public class MetadataField {
     private MetadataFieldHandler handler = null;
     private JSONArray shownIf = null;
     private String defaultValue = null;
+    private List<String> blacklist = null;
 
     public static final String RESULT_KEY_ORGANIZATION = "organization";
 
@@ -157,5 +160,13 @@ public class MetadataField {
 
     public void setDefaultValue(String defaultValue) {
         this.defaultValue = defaultValue;
+    }
+
+    public List<String> getBlacklist() {
+        return blacklist;
+    }
+
+    public void setBlacklist(List<String> blacklist) {
+        this.blacklist = blacklist;
     }
 }

--- a/service-csw/src/main/java/fi/nls/oskari/control/metadata/MetadataFieldHandler.java
+++ b/service-csw/src/main/java/fi/nls/oskari/control/metadata/MetadataFieldHandler.java
@@ -19,6 +19,7 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.DataInputStream;
 import java.net.HttpURLConnection;
+import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -117,8 +118,12 @@ public class MetadataFieldHandler {
 
         final String url = getSearchURL() + propertyName;
         final NodeList valueList = getTags(url, "csw:Value");
+        List<String> blacklist = field.getBlacklist();
         for (int i = 0; i < valueList.getLength(); i++) {
             String value = valueList.item(i).getChildNodes().item(0).getTextContent();
+            if (blacklist.contains(value)) {
+                continue;
+            }
             response.add(new SelectItem(null, value));
         }
         cache.put(propertyName, response);

--- a/service-csw/src/main/java/fi/nls/oskari/search/channel/MetadataCatalogueChannelSearchService.java
+++ b/service-csw/src/main/java/fi/nls/oskari/search/channel/MetadataCatalogueChannelSearchService.java
@@ -41,6 +41,7 @@ import java.util.*;
  *          showIf is closely related to dependencies field
  *      - filterOp: used for creating query and mapped in code to Deegree filter operations (defaults to LIKE operations)
  *      - mustMatch: true means the field will be treated as AND filter instead of OR when creating query filter (defaults to false)
+ *      - blacklist: is a list of response values that will be filtered out
  *
  */
 @Oskari(MetadataCatalogueChannelSearchService.ID)
@@ -129,6 +130,7 @@ public class MetadataCatalogueChannelSearchService extends SearchChannel {
             field.setMustMatch(PropertyUtil.getOptional(propPrefix + name + ".mustMatch", false));
             field.setDependencies(PropertyUtil.getMap(propPrefix + name + ".dependencies"));
             field.setDefaultValue(PropertyUtil.getOptional(propPrefix + name + ".value"));
+            field.setBlacklist(Arrays.asList(PropertyUtil.getCommaSeparatedList(propPrefix + name + ".blacklist")));
             fields.add(field);
         }
         return fields;


### PR DESCRIPTION
New configuration

`search.channel.METADATA_CATALOGUE_CHANNEL.field.<field name>.blacklist=<comma separated list of values>`

for filtering out field values from MetadataSearchOptions query.