### PR TITLE
Add a limit to Geoserver max request memory

### DIFF
--- a/content-resources/src/main/java/flyway/oskari/V1_45_0__limit_geoserver_max_request_memory.java
+++ b/content-resources/src/main/java/flyway/oskari/V1_45_0__limit_geoserver_max_request_memory.java
@@ -1,0 +1,71 @@
+package flyway.oskari;
+
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.util.IOHelper;
+import fi.nls.oskari.util.PropertyUtil;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class V1_45_0__limit_geoserver_max_request_memory implements JdbcMigration {
+
+    private static final Logger LOG = LogFactory.getLogger(V1_45_0__limit_geoserver_max_request_memory.class);
+
+    private static final String PROP_GS_URL = "geoserver.url";
+    private static final String PROP_GS_USER = "geoserver.user";
+    private static final String PROP_GS_PASS = "geoserver.password";
+
+    private static final String PROP_MAX_REQ_MEM = "geoserver.V145.wms.max.request.memory";
+    private static final int DEFAULT_MAX_REQ_MEM_KB = 128 * 1024;
+
+    private static final String GS_REST_WMS_SETTINGS_ENDPOINT = "/rest/services/wms/settings.json";
+
+    public void migrate(Connection connection) throws IOException, JSONException {
+        String endPoint = PropertyUtil.getNecessary(PROP_GS_URL) + GS_REST_WMS_SETTINGS_ENDPOINT;
+        String user = PropertyUtil.getNecessary(PROP_GS_USER);
+        String pass = PropertyUtil.getNecessary(PROP_GS_PASS);
+        int maxReqMem = PropertyUtil.getOptional(PROP_MAX_REQ_MEM, DEFAULT_MAX_REQ_MEM_KB);
+        setGeoserverMaxRequestMemory(endPoint, user, pass, maxReqMem);
+    }
+
+    protected static void setGeoserverMaxRequestMemory(String endPoint,
+            String user, String pass, int maxReqMem) throws IOException, JSONException {
+        LOG.debug("Trying to set maxRequestMemory to", maxReqMem,
+                "settings:", endPoint, user, pass);
+
+        HttpURLConnection conn = IOHelper.getConnection(endPoint, user, pass);
+        JSONObject settingsJson = toJSON(IOHelper.readBytes(conn));
+
+        int maxReqMemCurrent = settingsJson.getJSONObject("wms").getInt("maxRequestMemory");
+        if (maxReqMem == maxReqMemCurrent) {
+            LOG.info("maxRequestMemory is already set to", maxReqMem, "- consider job done");
+            return;
+        }
+        settingsJson.getJSONObject("wms").put("maxRequestMemory", maxReqMem);
+
+        conn = IOHelper.getConnection(endPoint, user, pass);
+        IOHelper.put(conn, IOHelper.CONTENT_TYPE_JSON, toUTF8(settingsJson));
+
+        int sc = conn.getResponseCode();
+        if (sc == HttpURLConnection.HTTP_OK) {
+            LOG.info("Updated maxRequestMemory succesfully from",
+                    maxReqMemCurrent, "to", maxReqMem);
+        } else {
+            LOG.info("Failed to PUT settings.json");
+        }
+    }
+
+    protected static JSONObject toJSON(byte[] utf8) throws JSONException {
+        return new JSONObject(new String(utf8, StandardCharsets.UTF_8));
+    }
+
+    protected static byte[] toUTF8(JSONObject json) {
+        return json.toString().getBytes(StandardCharsets.UTF_8);
+    }
+
+}

--- a/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
@@ -616,8 +616,22 @@ public class IOHelper {
 
     public static HttpURLConnection post(String url, String contentType, byte[] body)
             throws IOException {
-        HttpURLConnection conn = getConnection(url);
-        conn.setRequestMethod("POST");
+        return send(getConnection(url), "POST", contentType, body);
+    }
+
+    public static HttpURLConnection put(String url, String contentType, byte[] body)
+            throws IOException {
+        return put(getConnection(url), contentType, body);
+    }
+
+    public static HttpURLConnection put(HttpURLConnection conn, String contentType, byte[] body)
+            throws IOException {
+        return send(conn, "PUT", contentType, body);
+    }
+
+    private static HttpURLConnection send(HttpURLConnection conn, String method,
+            String contentType, byte[] body) throws IOException {
+        conn.setRequestMethod(method);
         conn.setDoOutput(true);
         conn.setDoInput(true);
         setContentType(conn, contentType);


### PR DESCRIPTION
By default `maxRequestMemory` is set to 0 in Geoserver WMS service. This can lead to OutOfMemoryExceptions when requesting too large images. This migration will set the limit to a more reasonable number via Geoserver REST API. This migration will set the value to 128mb, which should be enough for example for an 8192x4096 argb image. The setting is configurable with `geoserver.V145.wms.max.request.memory` property, note that the value is set in **kilobytes**

For more information about `maxRequestMemory` see http://docs.geoserver.org/stable/en/user/services/wms/configuration.html
