### PR TITLE
Add utility for creating query strings with key-multivalue-pairs

### DIFF
--- a/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
@@ -616,8 +616,22 @@ public class IOHelper {
 
     public static HttpURLConnection post(String url, String contentType, byte[] body)
             throws IOException {
-        HttpURLConnection conn = getConnection(url);
-        conn.setRequestMethod("POST");
+        return send(getConnection(url), "POST", contentType, body);
+    }
+
+    public static HttpURLConnection put(String url, String contentType, byte[] body)
+            throws IOException {
+        return put(getConnection(url), contentType, body);
+    }
+
+    public static HttpURLConnection put(HttpURLConnection conn, String contentType, byte[] body)
+            throws IOException {
+        return send(conn, "PUT", contentType, body);
+    }
+
+    private static HttpURLConnection send(HttpURLConnection conn, String method,
+            String contentType, byte[] body) throws IOException {
+        conn.setRequestMethod(method);
         conn.setDoOutput(true);
         conn.setDoInput(true);
         setContentType(conn, contentType);

--- a/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
@@ -616,22 +616,8 @@ public class IOHelper {
 
     public static HttpURLConnection post(String url, String contentType, byte[] body)
             throws IOException {
-        return send(getConnection(url), "POST", contentType, body);
-    }
-
-    public static HttpURLConnection put(String url, String contentType, byte[] body)
-            throws IOException {
-        return put(getConnection(url), contentType, body);
-    }
-
-    public static HttpURLConnection put(HttpURLConnection conn, String contentType, byte[] body)
-            throws IOException {
-        return send(conn, "PUT", contentType, body);
-    }
-
-    private static HttpURLConnection send(HttpURLConnection conn, String method,
-            String contentType, byte[] body) throws IOException {
-        conn.setRequestMethod(method);
+        HttpURLConnection conn = getConnection(url);
+        conn.setRequestMethod("POST");
         conn.setDoOutput(true);
         conn.setDoInput(true);
         setContentType(conn, contentType);
@@ -863,19 +849,59 @@ public class IOHelper {
             if (key == null || key.isEmpty() || value == null || value.isEmpty()) {
                 continue;
             }
-            try {
-                final String keyEnc = URLEncoder.encode(key, DEFAULT_CHARSET);
-                final String valueEnc = URLEncoder.encode(value, DEFAULT_CHARSET);
+            final String keyEnc = urlEncode(key);
+            final String valueEnc = urlEncode(value);
+            if (!first) {
+                sb.append('&');
+            }
+            sb.append(keyEnc).append('=').append(valueEnc);
+            first = false;
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Same as {@link #getParams(Map) getParams} but this allows
+     * the map and the generated query string to have multiple instances
+     * with the same key e.g. ?foo=bar&foo=baz
+     */
+    public static String getParamsMultiValue(Map<String, String[]> kvps) {
+        if (kvps == null || kvps.isEmpty()) {
+            return "";
+        }
+
+        final StringBuilder sb = new StringBuilder();
+        boolean first = true;
+        for (Map.Entry<String, String[]> entry : kvps.entrySet()) {
+            final String key = entry.getKey();
+            final String[] values = entry.getValue();
+            if (key == null || key.isEmpty() || values == null || values.length == 0) {
+                continue;
+            }
+            String keyEnc = urlEncode(key);
+            for (String value : values) {
+                if (value == null || value.isEmpty()) {
+                    continue;
+                }
+                String valueEnc = urlEncode(value);
                 if (!first) {
                     sb.append('&');
                 }
                 sb.append(keyEnc).append('=').append(valueEnc);
                 first = false;
-            } catch (UnsupportedEncodingException ignore) {
-                // Ignore the exception, UTF-8 _IS_ supported
             }
         }
         return sb.toString();
+    }
+
+    private static String urlEncode(String s) {
+        try {
+            return URLEncoder.encode(s, CHARSET_UTF8);
+        } catch (UnsupportedEncodingException ignore) {
+            // Ignore the exception, 'UTF-8' is supported
+        }
+        // return something, this code is unreachable
+        return s;
     }
 
     public static InputStream getInputStream(HttpURLConnection conn) {

--- a/service-base/src/test/java/fi/nls/oskari/util/IOHelperTest.java
+++ b/service-base/src/test/java/fi/nls/oskari/util/IOHelperTest.java
@@ -74,4 +74,23 @@ public class IOHelperTest {
         params.put("key1", "baz qux");
         assertEquals("Space characters are replaced by '+' in form encoding", "key1=baz+qux", IOHelper.getParams(params));
     }
+
+    @Test
+    public void testGetParamsMultiValue() {
+        assertEquals("null map should return an empty string", "", IOHelper.getParamsMultiValue(null));
+
+        Map<String, String[]> params = new LinkedHashMap<String, String[]>();
+        assertEquals("Empty map should return an empty string", "", IOHelper.getParamsMultiValue(params));
+
+        params.put("key1", new String[]{ "foo" });
+        assertEquals("If there's only one key-value pair no '&' follows", "key1=foo", IOHelper.getParamsMultiValue(params));
+
+        params.put("key2", new String[]{ "bar" });
+        assertEquals("Values are be separated with a '&'", "key1=foo&key2=bar", IOHelper.getParamsMultiValue(params));
+
+        params.put("key3", new String[]{ "foobar", "baz+qux" });
+        assertEquals("Values are URL encoded, keys with multiple values appear as multiple ${key}=${value1} entries",
+                "key1=foo&key2=bar&key3=foobar&key3=baz%2Bqux", IOHelper.getParamsMultiValue(params));
+    }
+
 }


### PR DESCRIPTION
Add helper function `IOHelper.getParamsMultiValue(Map<String, String[]>)`.
It does the same thing as `IOHelper.getParams(Map<String, String>)` except that it allows multiple values for each key.