### PR TITLE
Remove env variables from mapfull bundle config

### DIFF
--- a/content-resources/src/main/java/flyway/oskari/V1_45_0__limit_geoserver_max_request_memory.java
+++ b/content-resources/src/main/java/flyway/oskari/V1_45_0__limit_geoserver_max_request_memory.java
@@ -25,19 +25,23 @@ public class V1_45_0__limit_geoserver_max_request_memory implements JdbcMigratio
 
     private static final String GS_REST_WMS_SETTINGS_ENDPOINT = "/rest/services/wms/settings.json";
 
-    public void migrate(Connection connection) throws IOException, JSONException {
+    public void migrate(Connection connection) throws JSONException {
         String endPoint = PropertyUtil.getNecessary(PROP_GS_URL) + GS_REST_WMS_SETTINGS_ENDPOINT;
         String user = PropertyUtil.getNecessary(PROP_GS_USER);
         String pass = PropertyUtil.getNecessary(PROP_GS_PASS);
         int maxReqMem = PropertyUtil.getOptional(PROP_MAX_REQ_MEM, DEFAULT_MAX_REQ_MEM_KB);
-        setGeoserverMaxRequestMemory(endPoint, user, pass, maxReqMem);
+        try {
+            setGeoserverMaxRequestMemory(endPoint, user, pass, maxReqMem);
+        } catch (IOException ex) {
+            LOG.warn("Couldn't connect to Geoserver for updating the Max rendering memory WMS setting. You should update it " +
+                    "manually on the Geoserver if your environment has one. Tried updating it to", maxReqMem, "kB.");
+        }
     }
 
     protected static void setGeoserverMaxRequestMemory(String endPoint,
             String user, String pass, int maxReqMem) throws IOException, JSONException {
         LOG.debug("Trying to set maxRequestMemory to", maxReqMem,
                 "settings:", endPoint, user, pass);
-
         HttpURLConnection conn = IOHelper.getConnection(endPoint, user, pass);
         JSONObject settingsJson = toJSON(IOHelper.readBytes(conn));
 

--- a/content-resources/src/main/java/flyway/oskari/V1_45_1__migrate_mapfull_config.java
+++ b/content-resources/src/main/java/flyway/oskari/V1_45_1__migrate_mapfull_config.java
@@ -1,0 +1,124 @@
+package flyway.oskari;
+
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.util.JSONHelper;
+import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
+import org.json.JSONObject;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+
+/**
+ * Removes "globalMapAjaxUrl" and "user" keys from mapfull bundle configs in portti_bundle and portti_view_bundle_seq
+ * as they are now part of the "global environment variables" instead of mapfull config
+ */
+public class V1_45_1__migrate_mapfull_config implements JdbcMigration {
+
+    private static final Logger LOG = LogFactory.getLogger(V1_45_1__migrate_mapfull_config.class);
+
+    public void migrate(Connection connection)
+            throws Exception {
+        Bundle mapfull = getMapFullTemplate(connection);
+        if(modifyConfig(mapfull)) {
+            // update template back to db
+            updateBundleTemplate(connection, mapfull);
+        }
+
+        final ArrayList<Bundle> mapfullBundles = getMapFullBundles(connection);
+        for(Bundle bundle: mapfullBundles) {
+            if(!modifyConfig(bundle)) {
+                continue;
+            }
+            // update view back to db
+            updateBundleInView(connection, bundle);
+        }
+
+    }
+    private boolean modifyConfig(Bundle bundle) throws Exception {
+        JSONObject config = JSONHelper.createJSONObject(bundle.config);
+        if(config == null) {
+            LOG.warn("Couldn't get config JSON for view:", bundle.viewId);
+            return false;
+        }
+        config.remove("globalMapAjaxUrl");
+        config.remove("user");
+        bundle.config = config.toString(2);
+        return true;
+    }
+
+
+    private ArrayList<Bundle> getMapFullBundles(Connection connection) throws Exception {
+        ArrayList<Bundle> ids = new ArrayList<>();
+        final String sql = "SELECT view_id, bundle_id, config FROM portti_view_bundle_seq " +
+                "WHERE bundle_id = (select id from portti_bundle where name = 'mapfull')";
+        try (final PreparedStatement statement =
+                     connection.prepareStatement(sql);
+             ResultSet rs = statement.executeQuery()) {
+            while(rs.next()) {
+                Bundle b = new Bundle();
+                b.viewId = rs.getLong("view_id");
+                b.bundleId = rs.getLong("bundle_id");
+                b.config = rs.getString("config");
+                ids.add(b);
+            }
+        }
+        return ids;
+    }
+
+    public static Bundle updateBundleInView(Connection connection, Bundle bundle)
+            throws SQLException {
+        final String sql = "UPDATE portti_view_bundle_seq SET " +
+                "config=? " +
+                " WHERE bundle_id=? " +
+                " AND view_id=?";
+
+        try (final PreparedStatement statement =
+                     connection.prepareStatement(sql)) {
+            statement.setString(1, bundle.config);
+            statement.setLong(2, bundle.bundleId);
+            statement.setLong(3, bundle.viewId);
+            statement.execute();
+        }
+        return null;
+    }
+
+    private Bundle getMapFullTemplate(Connection connection) throws Exception {
+        final String sql = "SELECT id, config FROM portti_bundle WHERE name = 'mapfull'";
+        try (final PreparedStatement statement =
+                     connection.prepareStatement(sql);
+             ResultSet rs = statement.executeQuery()) {
+            while(rs.next()) {
+                Bundle b = new Bundle();
+                b.bundleId = rs.getLong("id");
+                b.config = rs.getString("config");
+                return b;
+            }
+        }
+        return null;
+    }
+
+    public static Bundle updateBundleTemplate(Connection connection, Bundle bundle)
+            throws SQLException {
+        final String sql = "UPDATE portti_bundle SET " +
+                "config=? " +
+                " WHERE id=?";
+
+        try (final PreparedStatement statement =
+                     connection.prepareStatement(sql)) {
+            statement.setString(1, bundle.config);
+            statement.setLong(2, bundle.bundleId);
+            statement.execute();
+        }
+        return null;
+    }
+
+    class Bundle {
+        long viewId;
+        long bundleId;
+        String config;
+    }
+}

--- a/control-base/src/main/java/fi/nls/oskari/control/view/modifier/bundle/MapfullHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/view/modifier/bundle/MapfullHandler.java
@@ -93,24 +93,6 @@ public class MapfullHandler extends BundleHandler {
         if (mapfullConfig == null) {
             return false;
         }
-        // TODO: moved to "env" part of the appsetup - remove once frontend has been changed!
-        // setup correct ajax url
-        final String ajaxUrl = mapfullConfig.optString("globalMapAjaxUrl");
-        try {
-            // fix ajaxurl to current community if possible
-            // (required to show correct help articles)
-            mapfullConfig.put("globalMapAjaxUrl", params.getBaseAjaxUrl());
-            LOGGER.debug("Replaced ajax url: ", ajaxUrl, "->", params.getBaseAjaxUrl());
-        } catch (Exception e) {
-            LOGGER.error(e, "Replacing ajax url failed: ", ajaxUrl, "- Parsed:",
-                    params.getBaseAjaxUrl());
-        }
-
-        // setup user data
-        final JSONObject user = params.getUser().toJSON();
-        JSONHelper.putValue(user, "apikey", params.getActionParams().getAPIkey());
-        JSONHelper.putValue(mapfullConfig, "user", user);
-        // /moved to "env" part of the appsetup - remove once frontend has been changed!
 
         // Any layer referenced in state.selectedLayers array NEEDS to
         // be in conf.layers otherwise it cant be added to map on startup
@@ -233,11 +215,6 @@ public class MapfullHandler extends BundleHandler {
         }
         return null;
     }
-
-
-
-
-
 
     /**
      * Creates JSON array of layer configurations.

--- a/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-coordinate-params.json
+++ b/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-coordinate-params.json
@@ -70,7 +70,6 @@
         "north": "456"
       },
       "conf": {
-        "globalMapAjaxUrl": "--oskari.ajax.url.prefix--",
         "plugins": [
           {
             "id": "Oskari.mapframework.bundle.mapmodule.plugin.LayersPlugin"
@@ -119,16 +118,6 @@
         "imageLocation": "/Oskari/resources",
         "projectionDefs": {
           "EPSG:3067": "+proj=utm +zone=35 +ellps=GRS80 +units=m +no_defs"
-        },
-        "user": {
-          "apikey": "testkey",
-          "userID": -1,
-          "lastName": "guest",
-          "nickName": "guest",
-          "roles": [],
-          "userUUID": "",
-          "firstName": "guest",
-          "email": ""
         }
       }
     }

--- a/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-3.json
+++ b/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-3.json
@@ -70,7 +70,6 @@
         "north": "6874042"
       },
       "conf": {
-        "globalMapAjaxUrl": "--oskari.ajax.url.prefix--",
         "plugins": [
           {
             "id": "Oskari.mapframework.bundle.mapmodule.plugin.LayersPlugin"
@@ -122,16 +121,6 @@
         "imageLocation": "/Oskari/resources",
         "projectionDefs": {
           "EPSG:3067": "+proj=utm +zone=35 +ellps=GRS80 +units=m +no_defs"
-        },
-        "user": {
-          "apikey": "testkey",
-          "userID": -1,
-          "lastName": "guest",
-          "nickName": "guest",
-          "roles": [],
-          "userUUID": "",
-          "firstName": "guest",
-          "email": ""
         }
       }
     }

--- a/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-guest.json
+++ b/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-guest.json
@@ -70,7 +70,6 @@
         "north": "6874042"
       },
       "conf": {
-        "globalMapAjaxUrl": "--oskari.ajax.url.prefix--",
         "plugins": [
           {
             "id": "Oskari.mapframework.bundle.mapmodule.plugin.LayersPlugin"
@@ -122,16 +121,6 @@
         "imageLocation": "/Oskari/resources",
         "projectionDefs": {
           "EPSG:3067": "+proj=utm +zone=35 +ellps=GRS80 +units=m +no_defs"
-        },
-        "user": {
-          "apikey": "testkey",
-          "userID": -1,
-          "lastName": "guest",
-          "nickName": "guest",
-          "roles": [],
-          "userUUID": "",
-          "firstName": "guest",
-          "email": ""
         }
       }
     }

--- a/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-loggedin.json
+++ b/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-loggedin.json
@@ -73,7 +73,6 @@
         "north": "6874042"
       },
       "conf": {
-        "globalMapAjaxUrl": "--oskari.ajax.url.prefix--",
         "plugins": [
           {
             "id": "Oskari.mapframework.bundle.mapmodule.plugin.LayersPlugin"
@@ -125,21 +124,6 @@
         "imageLocation": "/Oskari/resources",
         "projectionDefs": {
           "EPSG:3067": "+proj=utm +zone=35 +ellps=GRS80 +units=m +no_defs"
-        },
-        "user": {
-          "apikey": "testkey",
-          "userID": 123,
-          "lastName": "Oskari",
-          "nickName": "Ozkari",
-          "roles": [
-            {
-              "id": 1,
-              "name": "User"
-            }
-          ],
-          "userUUID": "my uuid is secrets",
-          "firstName": "Test",
-          "email": "test@oskari.org"
         }
       }
     }

--- a/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-roles-from-properties-admin.json
+++ b/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-roles-from-properties-admin.json
@@ -87,7 +87,6 @@
         "north": "6874042"
       },
       "conf": {
-        "globalMapAjaxUrl": "--oskari.ajax.url.prefix--",
         "plugins": [
           {
             "id": "Oskari.mapframework.bundle.mapmodule.plugin.LayersPlugin"
@@ -139,25 +138,6 @@
         "imageLocation": "/Oskari/resources",
         "projectionDefs": {
           "EPSG:3067": "+proj=utm +zone=35 +ellps=GRS80 +units=m +no_defs"
-        },
-        "user": {
-          "apikey": "testkey",
-          "userID": 123,
-          "lastName": "Oskari",
-          "nickName": "Ozkari",
-          "roles": [
-            {
-              "id": 1,
-              "name": "User"
-            },
-            {
-              "id": 66,
-              "name": "Administrator"
-            }
-          ],
-          "userUUID": "my uuid is secrets",
-          "firstName": "Test",
-          "email": "test@oskari.org"
         }
       }
     }

--- a/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-roles-from-properties.json
+++ b/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-roles-from-properties.json
@@ -83,7 +83,6 @@
         "north": "6874042"
       },
       "conf": {
-        "globalMapAjaxUrl": "--oskari.ajax.url.prefix--",
         "plugins": [
           {
             "id": "Oskari.mapframework.bundle.mapmodule.plugin.LayersPlugin"
@@ -135,25 +134,6 @@
         "imageLocation": "/Oskari/resources",
         "projectionDefs": {
           "EPSG:3067": "+proj=utm +zone=35 +ellps=GRS80 +units=m +no_defs"
-        },
-        "user": {
-          "apikey": "testkey",
-          "userID": 123,
-          "lastName": "Oskari",
-          "nickName": "Ozkari",
-          "roles": [
-            {
-              "id": 1,
-              "name": "User"
-            },
-            {
-              "id": 42,
-              "name": "Karttajulkaisija_Tre"
-            }
-          ],
-          "userUUID": "my uuid is secrets",
-          "firstName": "Test",
-          "email": "test@oskari.org"
         }
       }
     }

--- a/control-base/src/test/resources/fi/nls/oskari/control/view/GetViewsHandlerTest-has-views.json
+++ b/control-base/src/test/resources/fi/nls/oskari/control/view/GetViewsHandlerTest-has-views.json
@@ -15,7 +15,6 @@
                     "north":"6874042"
                 },
                 "config": {
-                    "globalMapAjaxUrl":"[REPLACED BY HANDLER]",
                     "plugins" : [
                         {"id":"Oskari.mapframework.bundle.mapmodule.plugin.LayersPlugin"},
                         {"id":"Oskari.mapframework.mapmodule.WmsLayerPlugin"},

--- a/shared-test-resources/src/main/resources/views/bundles/framework.mapfull.json
+++ b/shared-test-resources/src/main/resources/views/bundles/framework.mapfull.json
@@ -75,7 +75,6 @@
     },
     "config" : {
         "conf" : {
-            "globalMapAjaxUrl": "[REPLACED BY HANDLER]",
             "imageLocation": "/Oskari/resources",
             "plugins" : [
                 { "id" : "Oskari.mapframework.bundle.mapmodule.plugin.LayersPlugin" },


### PR DESCRIPTION
Removes "globalMapAjaxUrl" and "user" from mapfull bundle config as they are now part of the env-config in appsetup. Migrates any appsetups in db containing these in database.

Also makes Flyway migration for 1.45 to update GeoServer WMS memory setting optional as not every instance has a GeoServer running. A warning is logged if connection to GeoServer couldn't be established.