### PR TITLE
Fix issues with storing analyses

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/data/CreateAnalysisLayerHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/data/CreateAnalysisLayerHandler.java
@@ -72,6 +72,7 @@ public class CreateAnalysisLayerHandler extends ActionHandler {
     private static final String ERROR_UNABLE_TO_GET_WPS_FEATURES = "Unable_to_get_WPS_features";
     private static final String ERROR_WPS_EXECUTE_RETURNS_EXCEPTION = "WPS_execute_returns_Exception";
     private static final String ERROR_WPS_EXECUTE_RETURNS_NO_FEATURES = "WPS_execute_returns_no_features";
+    private static final String ERROR_UNABLE_TO_MERGE_ANALYSIS_DATA = "Unable_to_merge_analysis_data";
     private static final String ERROR_UNABLE_TO_PROCESS_AGGREGATE_UNION = "Unable_to_process_aggregate_union";
     private static final String ERROR_UNABLE_TO_GET_FEATURES_FOR_UNION = "Unable_to_get_features_for_union";
     private static final String ERROR_UNABLE_TO_STORE_ANALYSIS_DATA = "Unable_to_store_analysis_data";
@@ -114,8 +115,12 @@ public class CreateAnalysisLayerHandler extends ActionHandler {
 
         if (analysisLayer.getMethod().equals(AnalysisParser.LAYER_UNION)) {
             // no WPS for merge analysis
-            analysis = analysisDataService.mergeAnalysisData(
+            try {
+                analysis = analysisDataService.mergeAnalysisData(
                     analysisLayer, analyse, params.getUser());
+            } catch (ServiceException e) {
+                throw new ActionException(ERROR_UNABLE_TO_MERGE_ANALYSIS_DATA, e);
+            }
         } else {
             // Generate WPS XML
             String featureSet = executeWPSprocess(analysisLayer);
@@ -179,8 +184,12 @@ public class CreateAnalysisLayerHandler extends ActionHandler {
             // Fix property names for WFST (property names might be renamed in Wps method )
             featureSet = fixPropertyNames(featureSet, analysisLayer);
 
-            analysis = analysisDataService.storeAnalysisData(
-                    featureSet, analysisLayer, analyse, params.getUser());
+            try {
+                analysis = analysisDataService.storeAnalysisData(
+                        featureSet, analysisLayer, analyse, params.getUser());
+            } catch (ServiceException e) {
+                throw new ActionException(ERROR_UNABLE_TO_STORE_ANALYSIS_DATA, e);
+            }
         }
 
         if (analysis == null) {

--- a/service-map/src/main/java/fi/nls/oskari/map/analysis/service/AnalysisDataService.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/analysis/service/AnalysisDataService.java
@@ -7,6 +7,7 @@ import fi.nls.oskari.domain.map.analysis.AnalysisStyle;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.map.analysis.domain.*;
+import fi.nls.oskari.service.ServiceException;
 import fi.nls.oskari.util.ConversionHelper;
 import fi.nls.oskari.util.IOHelper;
 import fi.nls.oskari.util.JSONHelper;
@@ -35,7 +36,7 @@ public class AnalysisDataService {
     private static final TransformationService transformationService = new TransformationService();
 
     public Analysis storeAnalysisData(final String featureset,
-                                      AnalysisLayer analysislayer, String json, User user) {
+            AnalysisLayer analysislayer, String json, User user) throws ServiceException {
 
         final String wfsURL = PropertyUtil.get("geoserver.wfs.url");
         final String wpsUser = PropertyUtil.get("geoserver.wms.user");
@@ -53,7 +54,6 @@ public class AnalysisDataService {
             log.debug("Unable to get AnalysisLayer style JSON", e);
         }
         // FIXME: do we really want to insert possibly empty style??
-        log.debug("Adding style", style);
         styleService.insertAnalysisStyleRow(style);
 
         try {

--- a/service-map/src/main/java/fi/nls/oskari/map/analysis/service/AnalysisDataService.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/analysis/service/AnalysisDataService.java
@@ -148,7 +148,7 @@ public class AnalysisDataService {
      * @param user
      * @return Analysis (stored analysis)
      */
-    public Analysis mergeAnalysisData(AnalysisLayer analysislayer, String json, User user) {
+    public Analysis mergeAnalysisData(AnalysisLayer analysislayer, String json, User user) throws ServiceException {
 
         final AnalysisStyle style = new AnalysisStyle();
         Analysis analysis = null;

--- a/service-map/src/main/java/fi/nls/oskari/map/analysis/service/AnalysisDbServiceMybatisImpl.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/analysis/service/AnalysisDbServiceMybatisImpl.java
@@ -1,7 +1,5 @@
 package fi.nls.oskari.map.analysis.service;
 
-import fi.mml.portti.service.db.permissions.PermissionsService;
-import fi.mml.portti.service.db.permissions.PermissionsServiceIbatisImpl;
 import fi.nls.oskari.db.DatasourceHelper;
 import fi.nls.oskari.domain.map.analysis.Analysis;
 import fi.nls.oskari.log.LogFactory;
@@ -23,16 +21,16 @@ import java.util.Map;
 
 public class AnalysisDbServiceMybatisImpl implements AnalysisDbService {
 
-    private static final Logger log = LogFactory.getLogger(AnalysisDbServiceMybatisImpl.class);
+    protected static final String DATASOURCE_ANALYSIS = "analysis";
 
-    private PermissionsService permissionsService = new PermissionsServiceIbatisImpl();
+    private static final Logger log = LogFactory.getLogger(AnalysisDbServiceMybatisImpl.class);
 
     private SqlSessionFactory factory = null;
 
     public AnalysisDbServiceMybatisImpl() {
 
         final DatasourceHelper helper = DatasourceHelper.getInstance();
-        DataSource dataSource = helper.getDataSource(helper.getOskariDataSourceName("analysis"));
+        DataSource dataSource = helper.getDataSource(helper.getOskariDataSourceName(DATASOURCE_ANALYSIS));
         if (dataSource == null) {
             dataSource = helper.createDataSource();
         }

--- a/service-map/src/main/java/fi/nls/oskari/map/analysis/service/AnalysisStyleDbService.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/analysis/service/AnalysisStyleDbService.java
@@ -1,8 +1,10 @@
 package fi.nls.oskari.map.analysis.service;
 
-
 import fi.nls.oskari.domain.map.analysis.AnalysisStyle;
+import fi.nls.oskari.service.ServiceException;
 
 public interface AnalysisStyleDbService {
-        long insertAnalysisStyleRow(final AnalysisStyle analysisStyle);
+
+    public long insertAnalysisStyleRow(AnalysisStyle analysisStyle) throws ServiceException;
+
 }

--- a/service-map/src/main/java/fi/nls/oskari/map/analysis/service/AnalysisStyleDbServiceMybatisImpl.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/analysis/service/AnalysisStyleDbServiceMybatisImpl.java
@@ -52,6 +52,7 @@ public class AnalysisStyleDbServiceMybatisImpl implements AnalysisStyleDbService
             LOG.debug("Inserted analysis style - id", analysisStyle.getId());
             return analysisStyle.getId();
         } catch (Exception e) {
+            LOG.warn(e, "Failed to insert analysis style", analysisStyle);
             throw new ServiceException("Failed to insert analysis style", e);
         }
     }

--- a/service-map/src/test/java/fi/nls/oskari/map/analysis/service/AnalysisDbServiceMybatisImplTest.java
+++ b/service-map/src/test/java/fi/nls/oskari/map/analysis/service/AnalysisDbServiceMybatisImplTest.java
@@ -2,6 +2,7 @@ package fi.nls.oskari.map.analysis.service;
 
 import fi.nls.oskari.domain.map.analysis.Analysis;
 import fi.nls.oskari.domain.map.analysis.AnalysisStyle;
+import fi.nls.oskari.service.ServiceException;
 import fi.nls.oskari.util.PropertyUtil;
 import fi.nls.test.util.TestHelper;
 import org.junit.*;
@@ -26,7 +27,7 @@ public class AnalysisDbServiceMybatisImplTest {
     }
 
     @Before
-    public void setUp() {
+    public void setUp() throws ServiceException {
         analysisDbServiceMybatis = new AnalysisDbServiceMybatisImpl();
         analysisStyleDbServiceMybatis = new AnalysisStyleDbServiceMybatisImpl();
 


### PR DESCRIPTION
`AnalysisStyleDbServiceMybatisImpl` was configured to use _analysisStyle_ DataSource which didn't exist, which lead to using the default database. This lead to `insertAnalysisStyleRow` always failing because `analysis_style` table doesn't exist in the default database (in Paikkatietoikkuna, the only place the Analysis module is used, let's hope that we can find the time to migrate all Analysis related stuff away from oskari core). This also caused the insertion of the analysis row to fail, because of a foreign key violation (the style referenced by the style_id didn't exist, since that failed previously). 
This PR fixes the issue by using the same DataSource for analysis styles and analyses. This also changes the logic so that if inserting the style row fails the whole process fails early.