### PR TITLE
Fix order of key-value pairs in cache key in GetIndicatorData

### DIFF
--- a/control-statistics/src/main/java/fi/nls/oskari/control/statistics/GetIndicatorDataHandler.java
+++ b/control-statistics/src/main/java/fi/nls/oskari/control/statistics/GetIndicatorDataHandler.java
@@ -10,6 +10,7 @@ import fi.nls.oskari.control.statistics.data.*;
 import fi.nls.oskari.control.statistics.plugins.*;
 import fi.nls.oskari.domain.User;
 import fi.nls.oskari.util.ResponseHelper;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -29,7 +30,7 @@ import java.util.Map.Entry;
  */
 @OskariActionRoute("GetIndicatorData")
 public class GetIndicatorDataHandler extends ActionHandler {
-    private final static String CACHE_KEY_PREFIX = "oskari_get_indicator_data_handler:";
+
     private final static String PARAM_PLUGIN_ID = "datasource"; // previously plugin_id
     private final static String PARAM_INDICATOR_ID = "indicator"; // previously indicator_id
     private final static String PARAM_LAYER_ID = "regionset"; // previously layer_id
@@ -54,7 +55,12 @@ public class GetIndicatorDataHandler extends ActionHandler {
     public JSONObject getIndicatorDataJSON(User user, long pluginId, String indicatorId,
             Long layerId, String selectorsStr)
             throws ActionException {
-        final String cacheKey = CACHE_KEY_PREFIX + pluginId + ":" + indicatorId + ":" + layerId + ":" + selectorsStr;
+        final String cacheKey;
+        try {
+             cacheKey = GetIndicatorDataHelper.getCacheKey(pluginId, indicatorId, layerId, selectorsStr);
+        } catch (JSONException e) {
+            throw new ActionParamsException("Could not create cache key", e);
+        }
         final String cachedData = JedisManager.get(cacheKey);
         StatisticalDatasourcePlugin plugin = pluginManager.getPlugin(pluginId);
         if (plugin.canCache()) {

--- a/control-statistics/src/main/java/fi/nls/oskari/control/statistics/GetIndicatorDataHelper.java
+++ b/control-statistics/src/main/java/fi/nls/oskari/control/statistics/GetIndicatorDataHelper.java
@@ -16,13 +16,11 @@ import org.json.JSONObject;
  */
 public class GetIndicatorDataHelper {
 
-    private final static String CACHE_KEY_PREFIX = "oskari_get_indicator_data_handler:";
-
-    protected static String getCacheKey(long pluginId, String indicatorId,
+    protected static String getCacheKey(long datasourceId, String indicatorId,
             Long layerId, String selectorsStr) throws JSONException {
-        StringBuilder cacheKey = new StringBuilder(CACHE_KEY_PREFIX);
-        cacheKey.append(pluginId);
-        cacheKey.append(':');
+        StringBuilder cacheKey = new StringBuilder("oskari:stats:");
+        cacheKey.append(datasourceId);
+        cacheKey.append(":data:");
         cacheKey.append(indicatorId);
         cacheKey.append(':');
         cacheKey.append(layerId);

--- a/control-statistics/src/main/java/fi/nls/oskari/control/statistics/GetIndicatorDataHelper.java
+++ b/control-statistics/src/main/java/fi/nls/oskari/control/statistics/GetIndicatorDataHelper.java
@@ -1,0 +1,41 @@
+package fi.nls.oskari.control.statistics;
+
+import java.util.Iterator;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Utility class for GetIndicatorDataHandler
+ *
+ * Reason for a separate class is that GetIndicatorDataHandler
+ * has a static class member that throws an exception while
+ * instantiating if certain properties have not been set
+ * causing unit tests that load the class to fail. If this
+ * issue gets fixed feel free to move these functions around.
+ */
+public class GetIndicatorDataHelper {
+
+    private final static String CACHE_KEY_PREFIX = "oskari_get_indicator_data_handler:";
+
+    protected static String getCacheKey(long pluginId, String indicatorId,
+            Long layerId, String selectorsStr) throws JSONException {
+        StringBuilder cacheKey = new StringBuilder(CACHE_KEY_PREFIX);
+        cacheKey.append(pluginId);
+        cacheKey.append(':');
+        cacheKey.append(indicatorId);
+        cacheKey.append(':');
+        cacheKey.append(layerId);
+        JSONObject selector = new JSONObject(selectorsStr);
+        Iterator<String> it = selector.sortedKeys();
+        while (it.hasNext()) {
+            String key = it.next();
+            cacheKey.append(':');
+            cacheKey.append(key);
+            cacheKey.append('=');
+            cacheKey.append(selector.get(key));
+        }
+        return cacheKey.toString();
+    }
+
+}

--- a/control-statistics/src/test/java/fi/nls/oskari/control/statistics/GetIndicatorDataHelperTest.java
+++ b/control-statistics/src/test/java/fi/nls/oskari/control/statistics/GetIndicatorDataHelperTest.java
@@ -1,0 +1,20 @@
+package fi.nls.oskari.control.statistics;
+
+import org.json.JSONException;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class GetIndicatorDataHelperTest {
+
+    @Test
+    public void testGetCacheKey() throws JSONException {
+        long pluginId = 1L;
+        String indicatorId = "232";
+        Long layerId = 1850L;
+        String selectionStr = "{\"year\":\"2015\",\"sex\":\"female\"}";
+        String actual = GetIndicatorDataHelper.getCacheKey(pluginId, indicatorId, layerId, selectionStr);
+        String expected = "oskari_get_indicator_data_handler:1:232:1850:sex=female:year=2015";
+        Assert.assertEquals(expected, actual);
+    }
+
+}

--- a/control-statistics/src/test/java/fi/nls/oskari/control/statistics/GetIndicatorDataHelperTest.java
+++ b/control-statistics/src/test/java/fi/nls/oskari/control/statistics/GetIndicatorDataHelperTest.java
@@ -13,7 +13,7 @@ public class GetIndicatorDataHelperTest {
         Long layerId = 1850L;
         String selectionStr = "{\"year\":\"2015\",\"sex\":\"female\"}";
         String actual = GetIndicatorDataHelper.getCacheKey(pluginId, indicatorId, layerId, selectionStr);
-        String expected = "oskari_get_indicator_data_handler:1:232:1850:sex=female:year=2015";
+        String expected = "oskari:stats:1:data:232:1850:sex=female:year=2015";
         Assert.assertEquals(expected, actual);
     }
 


### PR DESCRIPTION
`GetIndicatorData` generates different cache keys for semantically equal JSON selection strings due to the order not being fixed when stringifying the JSONObject. For example:
```
"oskari_get_indicator_data_handler:1:232:1850:{\"year\":\"2015\",\"sex\":\"female\"}"
"oskari_get_indicator_data_handler:1:232:1850:{\"sex\":\"female\",\"year\":\"2015\"}"
```
This PR changes the behaviour so that the key-value pairs are sorted alphabetically by the key in the cache key.