### PR TITLE
Request regionset with srs instead of reprojecting locally

### DIFF
--- a/control-statistics/src/main/java/fi/nls/oskari/control/statistics/GetRegionsHandler.java
+++ b/control-statistics/src/main/java/fi/nls/oskari/control/statistics/GetRegionsHandler.java
@@ -90,10 +90,8 @@ public class GetRegionsHandler extends ActionHandler {
         JSONHelper.putValue(response, KEY_REGIONS, regions);
 
         try {
-            final List<Region> result = service.getRegions(regionset);
+            final List<Region> result = service.getRegions(regionset, srs);
             for (Region region : result) {
-                region.setGeojson(getTransformedGeoJSON(region.getGeojson(), regionset.getSrs(), srs));
-                region.setPointOnSurface(getTransformedPoint(region.getPointOnSurface(), regionset.getSrs(), srs));
                 regions.put(region.toJSON());
             }
         } catch (IOException e) {
@@ -106,15 +104,5 @@ public class GetRegionsHandler extends ActionHandler {
 
         JedisManager.setex(cacheKey, JedisManager.EXPIRY_TIME_DAY, response.toString());
         return response;
-    }
-
-    private JSONObject getTransformedGeoJSON(JSONObject geojson, String sourceSrs, final String targetSrs) {
-        JSONObject transformed = ProjectionHelper.transformGeometry(geojson.optJSONObject("geometry"), sourceSrs, targetSrs, true, true);
-        JSONHelper.putValue(geojson, "geometry", transformed);
-        return geojson;
-    }
-
-    private Point getTransformedPoint(final Point point, final String sourceSrs, final String targetSrs) {
-        return ProjectionHelper.transformPoint(point.getLon(), point.getLat(), sourceSrs, targetSrs);
     }
 }

--- a/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/RegionSetService.java
+++ b/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/RegionSetService.java
@@ -9,7 +9,9 @@ import fi.nls.oskari.util.IOHelper;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Created by SMAKINEN on 27.4.2016.
@@ -19,15 +21,21 @@ public abstract class RegionSetService extends OskariComponent {
     public abstract List<RegionSet> getRegionSets();
     public abstract RegionSet getRegionSet(long id);
 
-    public List<Region> getRegions(RegionSet regionset) throws IOException, ServiceException {
+    public List<Region> getRegions(RegionSet regionset, String requestedSRS) throws IOException, ServiceException {
         final String propId = regionset.getIdProperty();
         final String propName = regionset.getNameProperty();
 
         // For example: http://localhost:8080/geoserver/wfs?service=wfs&version=1.1.0&request=GetFeature&typeNames=oskari:kunnat2013
         //&propertyName=kuntakoodi,kuntanimi,geom
-        final String url = regionset.getFeaturesUrl() + "?service=wfs&version=1.1.0&request=GetFeature&typeNames=" + regionset.getOskariLayerName();
-                //"&propertyName=" + propId + "," + propName;
+        Map<String, String> params = new HashMap<>();
+        params.put("service", "wfs");
+        params.put("version", "1.1.0");
+        params.put("request", "GetFeature");
+        params.put("typeNames", regionset.getOskariLayerName());
+        params.put("srsName", requestedSRS);
+        //params.put("propertyName", propId + "," + propName);
 
+        final String url = IOHelper.constructUrl(regionset.getFeaturesUrl(), params);
         final HttpURLConnection connection = IOHelper.getConnection(url);
         return WfsXmlParser.parse(connection.getInputStream(), propId, propName);
     }

--- a/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/RegionSetService.java
+++ b/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/RegionSetService.java
@@ -31,7 +31,7 @@ public abstract class RegionSetService extends OskariComponent {
         params.put("service", "wfs");
         params.put("version", "1.1.0");
         params.put("request", "GetFeature");
-        params.put("typeNames", regionset.getOskariLayerName());
+        params.put("typeName", regionset.getOskariLayerName());
         params.put("srsName", requestedSRS);
         //params.put("propertyName", propId + "," + propName);
 


### PR DESCRIPTION
Previously the reprojection/transformation for statistics regions was done locally. With this change the dataset is requested with the target SRS and no transform is required.