### PR TITLE
Add support for logging http responses in Transport

### DIFF
--- a/service-wfs/src/main/java/fi/nls/oskari/wfs/WFSParser.java
+++ b/service-wfs/src/main/java/fi/nls/oskari/wfs/WFSParser.java
@@ -28,8 +28,8 @@ import org.xml.sax.SAXException;
 
 import javax.xml.namespace.QName;
 import javax.xml.parsers.ParserConfigurationException;
-import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.Reader;
 import java.io.StringReader;
 import java.util.*;
     
@@ -50,7 +50,7 @@ public class WFSParser {
 
     private static final String DEFAULT = "default";
     
-    private BufferedReader response = null;
+    private Reader response = null;
     private WFSLayerStore layer = null;
     private String geomProperty = null;
     private Map<String, SimpleFeatureType> featureTypes = null;
@@ -62,7 +62,7 @@ public class WFSParser {
      * @param response
      * @param layer
      */
-    public WFSParser(BufferedReader response, WFSLayerStore layer) {
+    public WFSParser(Reader response, WFSLayerStore layer) {
     	this.response = response;
     	this.layer = layer;
     	this.geomProperty = layer.getGMLGeometryProperty().replaceAll("^[^_]*:", "");

--- a/service-wfs/src/main/java/fi/nls/oskari/wfs/util/DebugLoggingReader.java
+++ b/service-wfs/src/main/java/fi/nls/oskari/wfs/util/DebugLoggingReader.java
@@ -1,4 +1,4 @@
-package fi.nls.oskari.wfs;
+package fi.nls.oskari.wfs.util;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -6,16 +6,16 @@ import java.io.Reader;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 
-public class LoggingReader extends Reader {
+public class DebugLoggingReader extends Reader {
 
-    private static final Logger LOG = LogFactory.getLogger(LoggingReader.class);
+    private static final Logger LOG = LogFactory.getLogger(DebugLoggingReader.class);
 
     private final Reader in;
     private final char[] arr;
     private final int len;
     private int pos;
 
-    public LoggingReader(Reader in) throws IOException {
+    public DebugLoggingReader(Reader in) throws IOException {
         char[] buf = new char[8192];
         int read = 0;
         while (true) {

--- a/service-wfs/src/main/java/fi/nls/oskari/wfs/util/HttpHelper.java
+++ b/service-wfs/src/main/java/fi/nls/oskari/wfs/util/HttpHelper.java
@@ -82,11 +82,13 @@ public class HttpHelper {
             if(cookies != null) {
                 request.getConnection().setRequestProperty("Cookie", cookies);
             }
-            if(request.ok() || request.code() == 304)
-                if(key != null) headerValue = request.header(key);
-                else {
-                    handleHTTPError("GET", url, request.code(), false);
+            if(request.ok() || request.code() == 304) {
+                if(key != null) {
+                    headerValue = request.header(key);
                 }
+            } else {
+                handleHTTPError("GET", url, request.code(), false);
+            }
         } catch (HttpRequestException e) {
             handleHTTPRequestFail(url, e, false);
         } catch (Exception e) {

--- a/service-wfs/src/main/java/fi/nls/oskari/wfs/util/HttpHelper.java
+++ b/service-wfs/src/main/java/fi/nls/oskari/wfs/util/HttpHelper.java
@@ -18,14 +18,20 @@ public class HttpHelper {
 
     private static final Logger log = LogFactory.getLogger(HttpHelper.class);
 
-    private static int CONNECTION_TIMEOUT_MS = 3000;
-    private static int READ_TIMEOUT_MS = 60000;
+    private static final int CONNECTION_TIMEOUT_MS_DEFAULT = 3000;
+    private static final int READ_TIMEOUT_MS_DEFAULT = 60000;
+    private static final boolean LOG_RESPONSES_DEFAULT = false;
+
+    private static final int CONNECTION_TIMEOUT_MS;
+    private static final int READ_TIMEOUT_MS;
+    private static final boolean LOG_RESPONSES;
 
     static {
-        CONNECTION_TIMEOUT_MS = PropertyUtil.getOptional("oskari.connection.timeout", CONNECTION_TIMEOUT_MS);
-        READ_TIMEOUT_MS = PropertyUtil.getOptional("oskari.read.timeout", READ_TIMEOUT_MS);
+        CONNECTION_TIMEOUT_MS = PropertyUtil.getOptional("oskari.connection.timeout", CONNECTION_TIMEOUT_MS_DEFAULT);
+        READ_TIMEOUT_MS = PropertyUtil.getOptional("oskari.read.timeout", READ_TIMEOUT_MS_DEFAULT);
+        LOG_RESPONSES = PropertyUtil.getOptional("transport.response.debug", LOG_RESPONSES_DEFAULT);
     }
-    
+
     /**
      * Basic HTTP GET method
      * 
@@ -33,29 +39,30 @@ public class HttpHelper {
      * @return response body
      */
     public static String getRequest(String url, String cookies) {
-		HttpRequest request;
-		String response = null;
-		try {
-			request = HttpRequest.get(url)
-					.acceptGzipEncoding().uncompress(true)
-					.trustAllCerts()
-					.trustAllHosts();
+        HttpRequest request;
+        String response = null;
+        try {
+            request = HttpRequest.get(url)
+                    .acceptGzipEncoding().uncompress(true)
+                    .trustAllCerts()
+                    .trustAllHosts();
             if(cookies != null) {
                 request.getConnection().setRequestProperty("Cookie", cookies);
             }
             if(request.ok() || request.code() == 304) {
-				response = request.body();
-                log.debug(response);
+                response = request.body();
+                if (LOG_RESPONSES) {
+                    log.debug(response);
+                }
+            } else {
+                handleHTTPError("GET", url, request.code(), false);
             }
-			else {
-				handleHTTPError("GET", url, request.code(), false);
-			}
-		} catch (HttpRequestException e) {
-			handleHTTPRequestFail(url, e, false);
-		} catch (Exception e) {
-			handleHTTPRequestFail(url, e, false);
-		}
-		return response;
+        } catch (HttpRequestException e) {
+            handleHTTPRequestFail(url, e, false);
+        } catch (Exception e) {
+            handleHTTPRequestFail(url, e, false);
+        }
+        return response;
     }
     /**
      * Basic HTTP GET method
@@ -77,9 +84,9 @@ public class HttpHelper {
             }
             if(request.ok() || request.code() == 304)
                 if(key != null) headerValue = request.header(key);
-            else {
-                handleHTTPError("GET", url, request.code(), false);
-            }
+                else {
+                    handleHTTPError("GET", url, request.code(), false);
+                }
         } catch (HttpRequestException e) {
             handleHTTPRequestFail(url, e, false);
         } catch (Exception e) {
@@ -87,6 +94,7 @@ public class HttpHelper {
         }
         return headerValue;
     }
+
     /**
      * HTTP GET method with optional basic authentication and contentType definition
      * 
@@ -97,11 +105,11 @@ public class HttpHelper {
      * @return response body
      */
     public static BufferedInputStream getRequestStream(String url, String contentType, String username, String password) {
-		HttpRequest request = getRequest(url, contentType, username, password);
-		if(request != null) {
-			return request.buffer();
-		}
-		return null;
+        HttpRequest request = getRequest(url, contentType, username, password);
+        if(request != null) {
+            return request.buffer();
+        }
+        return null;
     }
 
     /**
@@ -114,13 +122,13 @@ public class HttpHelper {
      * @return response body
      */
     public static Reader getRequestReader(String url, String contentType, String username, String password) {
-		HttpRequest request = getRequest(url, contentType, username, password);
-		if(request != null) {
-			return request.bufferedReader();
-		}
-		return null;
+        HttpRequest request = getRequest(url, contentType, username, password);
+        if(request != null) {
+            return request.bufferedReader();
+        }
+        return null;
     }
-    
+
     /**
      * HTTP GET method with optional basic authentication and contentType definition
      * 
@@ -131,40 +139,40 @@ public class HttpHelper {
      * @return response body
      */
     public static HttpRequest getRequest(String url, String contentType, String username, String password) {
-		HttpRequest request;
-		try {
+        HttpRequest request;
+        try {
 
-			HttpRequest.keepAlive(false);
-			if(username != null && !username.equals("") && !username.equals("null")) {
-				request = HttpRequest.get(url)
-						.basic(username, password)
-						.accept(contentType)
-						.connectTimeout(CONNECTION_TIMEOUT_MS)
+            HttpRequest.keepAlive(false);
+            if(username != null && !username.equals("") && !username.equals("null")) {
+                request = HttpRequest.get(url)
+                        .basic(username, password)
+                        .accept(contentType)
+                        .connectTimeout(CONNECTION_TIMEOUT_MS)
                         .readTimeout(READ_TIMEOUT_MS)
-						.acceptGzipEncoding().uncompress(true)
-						.trustAllCerts()
-						.trustAllHosts();
-			} else {
-				request = HttpRequest.get(url)
-						.contentType(contentType)
-						.connectTimeout(CONNECTION_TIMEOUT_MS)
+                        .acceptGzipEncoding().uncompress(true)
+                        .trustAllCerts()
+                        .trustAllHosts();
+            } else {
+                request = HttpRequest.get(url)
+                        .contentType(contentType)
+                        .connectTimeout(CONNECTION_TIMEOUT_MS)
                         .readTimeout(READ_TIMEOUT_MS)
-						.acceptGzipEncoding().uncompress(true)
-						.trustAllCerts()
-						.trustAllHosts();
-			}
-			if(request.ok() || request.code() == 304)
-				return request;
-			else {
-				handleHTTPError("GET", url, request.code(), false);
-			}
-			
-		} catch (HttpRequestException e) {
-			handleHTTPRequestFail(url, e, false);
-		} catch (Exception e) {
-			handleHTTPRequestFail(url, e, false);
-		}
-		return null;
+                        .acceptGzipEncoding().uncompress(true)
+                        .trustAllCerts()
+                        .trustAllHosts();
+            }
+            if(request.ok() || request.code() == 304)
+                return request;
+            else {
+                handleHTTPError("GET", url, request.code(), false);
+            }
+
+        } catch (HttpRequestException e) {
+            handleHTTPRequestFail(url, e, false);
+        } catch (Exception e) {
+            handleHTTPRequestFail(url, e, false);
+        }
+        return null;
     }
     /**
      * HTTP POST method with optional basic authentication and contentType definition
@@ -176,10 +184,10 @@ public class HttpHelper {
      * @return response body
      */
     public static Reader postRequestReader(String url, String contentType, String data, String username,
-                                                   String password) {
+            String password) {
         return postRequestReader(url, contentType, data, username, password, false);
     }
-    
+
     /**
      * HTTP POST method with optional basic authentication and contentType definition
      * 
@@ -191,51 +199,51 @@ public class HttpHelper {
      * @return response body
      */
     public static Reader postRequestReader(String url, String contentType, String data, String username,
-                                                   String password, boolean throwException) {
-		HttpRequest request;
-		Reader response = null;
-		try {
-			
-			HttpRequest.keepAlive(false);
-			if(username != null && !username.equals("") && !username.equals("null")) {
-				request = HttpRequest.post(url)
-						.basic(username, password)
-						.contentType(contentType)
+            String password, boolean throwException) {
+        HttpRequest request;
+        Reader response = null;
+        try {
+
+            HttpRequest.keepAlive(false);
+            if(username != null && !username.equals("") && !username.equals("null")) {
+                request = HttpRequest.post(url)
+                        .basic(username, password)
+                        .contentType(contentType)
                         .connectTimeout(CONNECTION_TIMEOUT_MS)
                         .readTimeout(READ_TIMEOUT_MS)
-						.acceptGzipEncoding().uncompress(true)
-						.trustAllCerts()
-						.trustAllHosts()
-						.send(data);
-			} else {
-				request = HttpRequest.post(url)
-						.contentType(contentType)
+                        .acceptGzipEncoding().uncompress(true)
+                        .trustAllCerts()
+                        .trustAllHosts()
+                        .send(data);
+            } else {
+                request = HttpRequest.post(url)
+                        .contentType(contentType)
                         .connectTimeout(CONNECTION_TIMEOUT_MS)
                         .readTimeout(READ_TIMEOUT_MS)
-						.acceptGzipEncoding().uncompress(true)
-						.trustAllCerts()
-						.trustAllHosts()
-						.send(data);
-			}
-			if(request.ok() || request.code() == 304) {
-			    // default charset is UTF-8
-			    log.debug("request charset:", request.charset());
-			    response = request.bufferedReader();
-			    if (log.isDebugEnabled()) {
-			        response = new DebugLoggingReader(response);
-			    }
-			} else {
-			    handleHTTPError("POST", url, request.code(), throwException);
-			}
-			
-		} catch (HttpRequestException e) {
-			handleHTTPRequestFail(url, e, throwException);
-		} catch (Exception e) {
-			handleHTTPRequestFail(url, e, throwException);
-		}
-		return response;
+                        .acceptGzipEncoding().uncompress(true)
+                        .trustAllCerts()
+                        .trustAllHosts()
+                        .send(data);
+            }
+            if(request.ok() || request.code() == 304) {
+                // default charset is UTF-8
+                log.debug("request charset:", request.charset());
+                response = request.bufferedReader();
+                if (LOG_RESPONSES) {
+                    response = new DebugLoggingReader(response);
+                }
+            } else {
+                handleHTTPError("POST", url, request.code(), throwException);
+            }
+
+        } catch (HttpRequestException e) {
+            handleHTTPRequestFail(url, e, throwException);
+        } catch (Exception e) {
+            handleHTTPRequestFail(url, e, throwException);
+        }
+        return response;
     }
-    
+
     /**
      * Handles HTTP error logging for HTTP request methods
      * 
@@ -266,4 +274,5 @@ public class HttpHelper {
                     e, WFSExceptionHelper.ERROR_COMMON_PROCESS_REQUEST_FAILURE);
         }
     }
+
 }

--- a/servlet-transport/src/main/java/fi/nls/oskari/arcgis/ArcGisCommunicator.java
+++ b/servlet-transport/src/main/java/fi/nls/oskari/arcgis/ArcGisCommunicator.java
@@ -19,8 +19,8 @@ import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 
 import java.awt.*;
-import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.Reader;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -217,11 +217,11 @@ public class ArcGisCommunicator {
 		return mapToString(data);		        		
 	}
 	
-	public static ArrayList<ArcGisFeature> parseFeatures(List<BufferedReader> responses, final WFSLayerStore layer) {
+	public static ArrayList<ArcGisFeature> parseFeatures(List<Reader> responses, final WFSLayerStore layer) {
 		ArrayList<ArcGisFeature> result = new ArrayList<ArcGisFeature>();
 		int count = responses.size();
 		
-		for (BufferedReader response : responses) {
+		for (Reader response : responses) {
 			ArrayList<ArcGisFeature> features = parseFeatures(response, layer);
 			if (features == null) {
 				if (count == 1) {
@@ -245,7 +245,7 @@ public class ArcGisCommunicator {
 	 * @return simple features
 	 */
 	@SuppressWarnings("unchecked")
-	public static ArrayList<ArcGisFeature> parseFeatures(BufferedReader response, final WFSLayerStore layer) {
+	public static ArrayList<ArcGisFeature> parseFeatures(Reader response, final WFSLayerStore layer) {
 		ArrayList<ArcGisFeature> result = new ArrayList<ArcGisFeature>();
 		
 		JSONParser parser = new JSONParser();

--- a/servlet-transport/src/main/java/fi/nls/oskari/wfs/LoggingReader.java
+++ b/servlet-transport/src/main/java/fi/nls/oskari/wfs/LoggingReader.java
@@ -37,7 +37,20 @@ public class LoggingReader extends Reader {
     }
 
     @Override
-    public int read(char[] cbuf, int off, int len) throws IOException {
+    public int read() {
+        if (pos == len) {
+            return -1;
+        }
+        return arr[pos++] & 0xFF;
+    }
+
+    @Override
+    public int read(char[] cbuf) {
+        return read(cbuf, 0, cbuf.length);
+    }
+
+    @Override
+    public int read(char[] cbuf, int off, int len) {
         int left = this.len - this.pos;
         if (left == 0) {
             return -1;

--- a/servlet-transport/src/main/java/fi/nls/oskari/wfs/LoggingReader.java
+++ b/servlet-transport/src/main/java/fi/nls/oskari/wfs/LoggingReader.java
@@ -1,0 +1,58 @@
+package fi.nls.oskari.wfs;
+
+import java.io.IOException;
+import java.io.Reader;
+
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+
+public class LoggingReader extends Reader {
+
+    private static final Logger LOG = LogFactory.getLogger(LoggingReader.class);
+
+    private final Reader in;
+    private final char[] arr;
+    private final int len;
+    private int pos;
+
+    public LoggingReader(Reader in) throws IOException {
+        char[] buf = new char[8192];
+        int read = 0;
+        while (true) {
+            if (read == buf.length) {
+                char[] tmp = new char[buf.length * 2];
+                System.arraycopy(buf, 0, tmp, 0, buf.length);
+                buf = tmp;
+            }
+            int n = in.read(buf, read, buf.length - read);
+            if (n == -1) {
+                break;
+            }
+            read += n;
+        }
+        this.in = in;
+        this.arr = buf;
+        this.len = read;
+        LOG.debug(new String(arr, 0, len));
+    }
+
+    @Override
+    public int read(char[] cbuf, int off, int len) throws IOException {
+        int left = this.len - this.pos;
+        if (left == 0) {
+            return -1;
+        }
+        if (left < len) {
+            len = left;
+        }
+        System.arraycopy(arr, pos, cbuf, off, len);
+        pos += len;
+        return len;
+    }
+
+    @Override
+    public void close() throws IOException {
+        in.close();
+    }
+
+}

--- a/servlet-transport/src/main/java/fi/nls/oskari/wfs/WFSCommunicator.java
+++ b/servlet-transport/src/main/java/fi/nls/oskari/wfs/WFSCommunicator.java
@@ -9,6 +9,7 @@ import fi.nls.oskari.service.ServiceRuntimeException;
 import fi.nls.oskari.transport.TransportJobException;
 import fi.nls.oskari.util.PropertyUtil;
 import fi.nls.oskari.wfs.pojo.WFSLayerStore;
+import fi.nls.oskari.wfs.util.DebugLoggingReader;
 import fi.nls.oskari.wfs.util.XMLHelper;
 import fi.nls.oskari.work.JobType;
 import org.apache.axiom.om.*;
@@ -189,7 +190,7 @@ public class WFSCommunicator {
 	 */
 	@SuppressWarnings("unchecked")
 	public static FeatureCollection<SimpleFeatureType, SimpleFeature> parseSimpleFeatures(
-            BufferedReader response,
+	        Reader response,
             final WFSLayerStore layer) {
 		Parser parser = null;
 		if(Character.getNumericValue(layer.getGMLVersion().charAt(2)) == 2) { // 3.2
@@ -200,18 +201,9 @@ public class WFSCommunicator {
 			parser = GMLParser3.getParser(layer);
 		}
 
-		Reader reader;
-		try {
-		    log.info("Wrapping response in LoggingReader");
-		    reader = new LoggingReader(response);
-		} catch (IOException e) {
-		    log.warn(e, "Failed to init logging reader");
-		    reader = response;
-		}
-
 		Object obj = null;
 		try {
-			obj = parser.parse(reader);
+			obj = parser.parse(response);
             if(obj instanceof FeatureCollection) {
                 FeatureCollection<SimpleFeatureType, SimpleFeature> featureCollection = (FeatureCollection<SimpleFeatureType, SimpleFeature>) obj;
                 return featureCollection;

--- a/servlet-transport/src/main/java/fi/nls/oskari/wfs/WFSCommunicator.java
+++ b/servlet-transport/src/main/java/fi/nls/oskari/wfs/WFSCommunicator.java
@@ -21,6 +21,8 @@ import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.referencing.operation.MathTransform;
 
 import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Reader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -198,9 +200,17 @@ public class WFSCommunicator {
 			parser = GMLParser3.getParser(layer);
 		}
 
+		Reader reader;
+		try {
+		    reader = new LoggingReader(response);
+		} catch (IOException e) {
+		    log.warn(e, "Failed to init logging reader");
+		    reader = response;
+		}
+
 		Object obj = null;
 		try {
-			obj = parser.parse(response);
+			obj = parser.parse(reader);
             if(obj instanceof FeatureCollection) {
                 FeatureCollection<SimpleFeatureType, SimpleFeature> featureCollection = (FeatureCollection<SimpleFeatureType, SimpleFeature>) obj;
                 return featureCollection;

--- a/servlet-transport/src/main/java/fi/nls/oskari/wfs/WFSCommunicator.java
+++ b/servlet-transport/src/main/java/fi/nls/oskari/wfs/WFSCommunicator.java
@@ -1,6 +1,5 @@
 package fi.nls.oskari.wfs;
 
-import com.vividsolutions.jts.geom.Geometry;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.map.geometry.ProjectionHelper;
@@ -9,20 +8,16 @@ import fi.nls.oskari.service.ServiceRuntimeException;
 import fi.nls.oskari.transport.TransportJobException;
 import fi.nls.oskari.util.PropertyUtil;
 import fi.nls.oskari.wfs.pojo.WFSLayerStore;
-import fi.nls.oskari.wfs.util.DebugLoggingReader;
 import fi.nls.oskari.wfs.util.XMLHelper;
 import fi.nls.oskari.work.JobType;
 import org.apache.axiom.om.*;
 import org.apache.axiom.om.impl.builder.StAXOMBuilder;
 import org.geotools.feature.FeatureCollection;
-import org.geotools.feature.FeatureIterator;
 import org.geotools.xml.Parser;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.referencing.operation.MathTransform;
 
-import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.Reader;
 import java.util.ArrayList;
 import java.util.List;

--- a/servlet-transport/src/main/java/fi/nls/oskari/wfs/WFSCommunicator.java
+++ b/servlet-transport/src/main/java/fi/nls/oskari/wfs/WFSCommunicator.java
@@ -202,6 +202,7 @@ public class WFSCommunicator {
 
 		Reader reader;
 		try {
+		    log.info("Wrapping response in LoggingReader");
 		    reader = new LoggingReader(response);
 		} catch (IOException e) {
 		    log.warn(e, "Failed to init logging reader");

--- a/servlet-transport/src/main/java/fi/nls/oskari/work/WFSCustomParserMapLayerJob.java
+++ b/servlet-transport/src/main/java/fi/nls/oskari/work/WFSCustomParserMapLayerJob.java
@@ -10,7 +10,7 @@ import org.geotools.feature.FeatureCollection;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 
-import java.io.BufferedReader;
+import java.io.Reader;
 
 /**
  * Job for WFS Map Layer
@@ -36,7 +36,7 @@ public class WFSCustomParserMapLayerJob extends  WFSMapLayerJob {
      */
     public FeatureCollection<SimpleFeatureType, SimpleFeature> response(
             WFSLayerStore layer, RequestResponse requestResponse) {
-        BufferedReader response = ((WFSRequestResponse) requestResponse).getResponse();
+        Reader response = ((WFSRequestResponse) requestResponse).getResponse();
 
         log.debug("Custom parser layer id: ", layer.getLayerId());
         WFSParser parser = new WFSParser(response, layer);

--- a/servlet-transport/src/main/java/fi/nls/oskari/work/WFSMapLayerJob.java
+++ b/servlet-transport/src/main/java/fi/nls/oskari/work/WFSMapLayerJob.java
@@ -24,7 +24,7 @@ import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.filter.Filter;
 import org.opengis.referencing.operation.MathTransform;
 
-import java.io.BufferedReader;
+import java.io.Reader;
 import java.util.*;
 /**
  * Job for WFS Map Layer
@@ -79,7 +79,7 @@ public class WFSMapLayerJob extends OWSMapLayerJob {
     public RequestResponse request(JobType type, WFSLayerStore layer,
             SessionStore session, List<Double> bounds,
             MathTransform transformService) {
-        BufferedReader response = null;
+        Reader response = null;
         if (layer.getTemplateType() == null) { // default
             String payload = WFSCommunicator.createRequestPayload(type, layer,
                     session, bounds, transformService);
@@ -113,7 +113,7 @@ public class WFSMapLayerJob extends OWSMapLayerJob {
      */
     public FeatureCollection<SimpleFeatureType, SimpleFeature> response(
             WFSLayerStore layer, RequestResponse requestResponse) {
-        BufferedReader response = ((WFSRequestResponse) requestResponse).getResponse();
+        Reader response = ((WFSRequestResponse) requestResponse).getResponse();
         FeatureCollection<SimpleFeatureType, SimpleFeature> features = WFSCommunicator.parseSimpleFeatures(response, layer);
 
         if (layerProcessor.isProcessable(layer)) {

--- a/servlet-transport/src/main/java/fi/nls/oskari/work/WFSRequestResponse.java
+++ b/servlet-transport/src/main/java/fi/nls/oskari/work/WFSRequestResponse.java
@@ -1,19 +1,20 @@
 package fi.nls.oskari.work;
 
-import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.Reader;
 
 /**
  * Created by SMAKINEN on 13.2.2015.
  */
 public class WFSRequestResponse  implements RequestResponse {
-        BufferedReader response ;
 
-    public BufferedReader getResponse() {
+    private Reader response;
+
+    public Reader getResponse() {
         return response;
     }
 
-    public void setResponse(BufferedReader response) {
+    public void setResponse(Reader response) {
         this.response = response;
     }
 

--- a/servlet-transport/src/main/java/fi/nls/oskari/work/arcgis/ArcGisMapLayerJob.java
+++ b/servlet-transport/src/main/java/fi/nls/oskari/work/arcgis/ArcGisMapLayerJob.java
@@ -24,8 +24,8 @@ import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.referencing.operation.MathTransform;
 
 import java.awt.image.BufferedImage;
-import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.Reader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -86,11 +86,11 @@ public class ArcGisMapLayerJob extends OWSMapLayerJob {
      * @param bounds
      * @return response
      */
-    public static BufferedReader sendQueryRequest(JobType type,
+    public static Reader sendQueryRequest(JobType type,
                                                   WFSLayerStore layer, ArcGisLayerStore arcGisLayer,
                                                   SessionStore session, List<Double> bounds,
                                                   String token) {
-        BufferedReader response = null;
+        Reader response = null;
         if(layer.getTemplateType() == null) { // default
             String payload = ArcGisCommunicator.createQueryRequestPayload(type, layer, session, bounds, token);
             String url = layer.getURL() + "/" + arcGisLayer.getId() + "/query?";
@@ -106,10 +106,10 @@ public class ArcGisMapLayerJob extends OWSMapLayerJob {
         return response;
     }
 
-    private BufferedReader sendIdentifyRequest(WFSLayerStore layer, List<ArcGisLayerStore> layers,
+    private Reader sendIdentifyRequest(WFSLayerStore layer, List<ArcGisLayerStore> layers,
                                                SessionStore session, List<Double> bounds,
                                                String token) {
-        BufferedReader response = null;
+        Reader response = null;
 
         String payload = ArcGisCommunicator.createIdentifyRequestPayload(layers, session, bounds, token);
         String url = layer.getURL() + "/identify?";
@@ -410,7 +410,7 @@ public class ArcGisMapLayerJob extends OWSMapLayerJob {
      */
     public FeatureCollection<SimpleFeatureType, SimpleFeature> response(
             WFSLayerStore layer, RequestResponse requestResponse) {
-        BufferedReader response = ((WFSRequestResponse) requestResponse).getResponse();
+        Reader response = ((WFSRequestResponse) requestResponse).getResponse();
         features = ArcGisCommunicator.parseFeatures(response, layer);
         //FeatureCollection<SimpleFeatureType, SimpleFeature> features = WFSCommunicator.parseSimpleFeatures(response, layer);
         IOHelper.close(response);
@@ -429,9 +429,9 @@ public class ArcGisMapLayerJob extends OWSMapLayerJob {
 
         log.debug("Starting request handler");
         Map<String, Object> output = new HashMap<String, Object>();
-        List<BufferedReader> responses = new ArrayList<BufferedReader>();
+        List<Reader> responses = new ArrayList<>();
         for (ArcGisLayerStore subLayer : this.arcGisLayers) {
-            BufferedReader response = sendQueryRequest(this.type, this.layer, subLayer, this.session, bounds, this.token);
+            Reader response = sendQueryRequest(this.type, this.layer, subLayer, this.session, bounds, this.token);
             // request failed
             if(response == null) {
                 log.warn("Request failed for layer", layer.getLayerId());

--- a/servlet-transport/src/test/java/fi/nls/oskari/utils/HttpHelperTest.java
+++ b/servlet-transport/src/test/java/fi/nls/oskari/utils/HttpHelperTest.java
@@ -6,7 +6,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.BufferedInputStream;
-import java.io.BufferedReader;
+import java.io.Reader;
 
 import static org.junit.Assert.assertTrue;
 
@@ -44,25 +44,25 @@ public class HttpHelperTest {
 	
 	@Test
 	public void testReaderGetRequest() {
-		BufferedReader responseReader = HttpHelper.getRequestReader("http://httpbin.org/ip", "text/html", null, null);
+	    Reader responseReader = HttpHelper.getRequestReader("http://httpbin.org/ip", "text/html", null, null);
 		assertTrue("Should get buffer", responseReader != null);
 	}
 	
 	@Test
 	public void testReaderGetRequestFail() {
-		BufferedReader responseReader = HttpHelper.getRequestReader("http://httpbin.org/asda", "text/html", null, null);
+	    Reader responseReader = HttpHelper.getRequestReader("http://httpbin.org/asda", "text/html", null, null);
 		assertTrue("Shouldn't get buffer", responseReader == null);
 	}
 	
 	@Test
 	public void testPostRequestSuccess() {
-		BufferedReader responseReader = HttpHelper.postRequestReader("http://httpbin.org/post", "text/html", "test", null, null);
+	    Reader responseReader = HttpHelper.postRequestReader("http://httpbin.org/post", "text/html", "test", null, null);
 		assertTrue("Should get buffer", responseReader != null);
 	}
 	
 	@Test
 	public void testPostRequestFail() {
-		BufferedReader responseReader = HttpHelper.postRequestReader("http://httpbin.org/asda", "text/html", "test", null, null);
+	    Reader responseReader = HttpHelper.postRequestReader("http://httpbin.org/asda", "text/html", "test", null, null);
 		assertTrue("Shouldn't get buffer", responseReader == null);
 	}
 }

--- a/servlet-transport/src/test/java/fi/nls/oskari/wfs/WFSCommunicatorTest.java
+++ b/servlet-transport/src/test/java/fi/nls/oskari/wfs/WFSCommunicatorTest.java
@@ -22,6 +22,7 @@ import org.opengis.feature.simple.SimpleFeatureType;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.Reader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -97,7 +98,7 @@ public class WFSCommunicatorTest {
         assertTrue("Should get expected bounds result " + xmlDiff, xmlDiff.similar());
 		
 		// request (maplayer_id 216)
-		BufferedReader response = HttpHelper.postRequestReader(layer.getURL(), "text/xml", payload, layer.getUsername(), layer.getPassword());
+        Reader response = HttpHelper.postRequestReader(layer.getURL(), "text/xml", payload, layer.getUsername(), layer.getPassword());
 		assertTrue("Should get valid response", response != null);
 		
 		// parse
@@ -113,7 +114,7 @@ public class WFSCommunicatorTest {
         WFSLayerStore userlayer = WFSLayerStore.setJSON(layerJSON);
 
         // get response xml
-        BufferedReader response = new BufferedReader(new InputStreamReader(getClass().getResourceAsStream("Userlayer-GetFeature-response.xml")));
+        Reader response = new BufferedReader(new InputStreamReader(getClass().getResourceAsStream("Userlayer-GetFeature-response.xml")));
         assertTrue("Should get valid response", response != null);
 
         // parse the xml

--- a/servlet-transport/src/test/java/fi/nls/oskari/wfs/WFSParserTest.java
+++ b/servlet-transport/src/test/java/fi/nls/oskari/wfs/WFSParserTest.java
@@ -13,8 +13,8 @@ import org.junit.Test;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 
-import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.Reader;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -67,7 +67,7 @@ public class WFSParserTest {
 
 		// request (maplayer_id 216)
 		// FIXME: instead of making actual http request, record an expected response and parse it.
-        BufferedReader response = HttpHelper.postRequestReader(this.layer.getURL(), "", payload, this.layer.getUsername(), this.layer.getPassword());
+		Reader response = HttpHelper.postRequestReader(this.layer.getURL(), "", payload, this.layer.getUsername(), this.layer.getPassword());
 		assertTrue("Should get valid response", response != null);
 
 		// parse


### PR DESCRIPTION
Sometimes transport does weird things. If the http responses were logged it would be easier to pin-point what's happening and why things don't work the way we expect. This PR adds such functionality. To use the functionality set property `transport.response.debug=true` in transport-ext.properties. The flag was added in v1.41, see [here](https://github.com/oskariorg/oskari-server/blob/master/ReleaseNotes.md#servlet-transport).

Large portion of transport codebase was using BufferedReader instead of plain Reader. This is changed here. This PR also contains some whitespace changes (tabs to spaces) in HttpHelper class (deal with it).