### PR TITLE
Refactor GetIndicatorDataHandler

### DIFF
--- a/control-statistics/src/main/java/fi/nls/oskari/control/statistics/GetIndicatorDataHandler.java
+++ b/control-statistics/src/main/java/fi/nls/oskari/control/statistics/GetIndicatorDataHandler.java
@@ -48,7 +48,7 @@ public class GetIndicatorDataHandler extends ActionHandler {
         try {
             selectorsJSON = new JSONObject(selectors);
         } catch (JSONException e) {
-            throw new ActionParamsException("Invalid parameter value: "
+            throw new ActionParamsException("Invalid parameter value for key: "
                     + PARAM_SELECTORS + " - expected JSON object");
         }
         JSONObject response = getIndicatorDataJSON(params.getUser(),

--- a/control-statistics/src/main/java/fi/nls/oskari/control/statistics/GetIndicatorDataHandler.java
+++ b/control-statistics/src/main/java/fi/nls/oskari/control/statistics/GetIndicatorDataHandler.java
@@ -55,7 +55,7 @@ public class GetIndicatorDataHandler extends ActionHandler {
         ResponseHelper.writeResponse(ap, response);
     }
 
-    public JSONObject getIndicatorDataJSON(User user, long pluginId, String indicatorId,
+    private JSONObject getIndicatorDataJSON(User user, long pluginId, String indicatorId,
             long layerId, JSONObject selectorJSON) throws ActionException {
         StatisticalDatasourcePlugin plugin = PLUGIN_MANAGER.getPlugin(pluginId);
         if (plugin == null) {

--- a/control-statistics/src/main/java/fi/nls/oskari/control/statistics/GetIndicatorDataHandler.java
+++ b/control-statistics/src/main/java/fi/nls/oskari/control/statistics/GetIndicatorDataHandler.java
@@ -61,10 +61,12 @@ public class GetIndicatorDataHandler extends ActionHandler {
 
     public JSONObject getIndicatorDataJSON(User user, long pluginId, String indicatorId,
             long layerId, JSONObject selectorJSON) throws ActionException {
-        final String cacheKey = GetIndicatorDataHelper.getCacheKey(pluginId, indicatorId, layerId, selectorJSON);
-        final String cachedData = JedisManager.get(cacheKey);
-        StatisticalDatasourcePlugin plugin = PLUGIN_MANAGER.getPlugin(pluginId);
+        final StatisticalDatasourcePlugin plugin = PLUGIN_MANAGER.getPlugin(pluginId);
+
+        final String cacheKey;
         if (plugin.canCache()) {
+            cacheKey = GetIndicatorDataHelper.getCacheKey(pluginId, indicatorId, layerId, selectorJSON);
+            String cachedData = JedisManager.get(cacheKey);
             if (cachedData != null && !cachedData.isEmpty()) {
                 try {
                     return new JSONObject(cachedData);
@@ -72,7 +74,10 @@ public class GetIndicatorDataHandler extends ActionHandler {
                     // Failed serializing. Skipping the cache.
                 }
             }
+        } else {
+            cacheKey = null;
         }
+
         JSONObject response;
         try {
 

--- a/control-statistics/src/main/java/fi/nls/oskari/control/statistics/GetIndicatorDataHandler.java
+++ b/control-statistics/src/main/java/fi/nls/oskari/control/statistics/GetIndicatorDataHandler.java
@@ -18,15 +18,9 @@ import org.json.JSONObject;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
 
 /**
- * This interface gives the data for one indicator to the frontend for showing it on the map and on the table.
- * 
- * - action_route=GetIndicatorData&plugin_id=plugin_id&indicator_id=indicator_id&layer_id=layer_id&selectors=URL_ENCODED_JSON
- * 
- * For example SotkaNET requires selectors for year and gender. This means that selectors parameter content
- * could be for example: selectors=%7B%22gender%22%3A%20%22male%22%2C%20%22year%22%3A%20%222005%22%7D
+ * This ActionHandler retrieves data for an indicator for the frontend
  * 
  * Response is in JSON, and contains the indicator data.
  */

--- a/control-statistics/src/main/java/fi/nls/oskari/control/statistics/GetIndicatorDataHandler.java
+++ b/control-statistics/src/main/java/fi/nls/oskari/control/statistics/GetIndicatorDataHandler.java
@@ -40,29 +40,28 @@ public class GetIndicatorDataHandler extends ActionHandler {
      * For now, this uses pretty much static global store for the plugins.
      * In the future it might make sense to inject the pluginManager references to different controllers using DI.
      */
-    private static final StatisticalDatasourcePluginManager pluginManager = StatisticalDatasourcePluginManager.getInstance();
+    private static final StatisticalDatasourcePluginManager PLUGIN_MANAGER = StatisticalDatasourcePluginManager.getInstance();
 
     @Override
     public void handleAction(ActionParameters ap) throws ActionException {
-        final long pluginId = ap.getRequiredParamInt(PARAM_PLUGIN_ID);
+        final long pluginId = ap.getRequiredParamLong(PARAM_PLUGIN_ID);
         final String indicatorId = ap.getRequiredParam(PARAM_INDICATOR_ID);
-        final long layerId = new Long(ap.getRequiredParam(PARAM_LAYER_ID));
+        final long layerId = ap.getRequiredParamLong(PARAM_LAYER_ID);
         final String selectors = ap.getRequiredParam(PARAM_SELECTORS);
         JSONObject response = getIndicatorDataJSON(ap.getUser(), pluginId, indicatorId, layerId, selectors);
         ResponseHelper.writeResponse(ap, response);
     }
 
     public JSONObject getIndicatorDataJSON(User user, long pluginId, String indicatorId,
-            Long layerId, String selectorsStr)
-            throws ActionException {
+            long layerId, String selectorsStr) throws ActionException {
         final String cacheKey;
         try {
-             cacheKey = GetIndicatorDataHelper.getCacheKey(pluginId, indicatorId, layerId, selectorsStr);
+            cacheKey = GetIndicatorDataHelper.getCacheKey(pluginId, indicatorId, layerId, selectorsStr);
         } catch (JSONException e) {
             throw new ActionParamsException("Could not create cache key", e);
         }
         final String cachedData = JedisManager.get(cacheKey);
-        StatisticalDatasourcePlugin plugin = pluginManager.getPlugin(pluginId);
+        StatisticalDatasourcePlugin plugin = PLUGIN_MANAGER.getPlugin(pluginId);
         if (plugin.canCache()) {
             if (cachedData != null && !cachedData.isEmpty()) {
                 try {

--- a/control-statistics/src/main/java/fi/nls/oskari/control/statistics/GetIndicatorDataHandler.java
+++ b/control-statistics/src/main/java/fi/nls/oskari/control/statistics/GetIndicatorDataHandler.java
@@ -95,6 +95,11 @@ public class GetIndicatorDataHandler extends ActionHandler {
         return response;
     }
 
+    private JSONObject getFromCache(String cacheKey) {
+        String cachedData = JedisManager.get(cacheKey);
+        return JSONHelper.createJSONObject(cachedData);
+    }
+
     private StatisticalIndicatorDataModel getIndicatorDataModel(JSONObject selectorJSON) {
         StatisticalIndicatorDataModel selectors = new StatisticalIndicatorDataModel();
         @SuppressWarnings("unchecked")
@@ -109,11 +114,6 @@ public class GetIndicatorDataHandler extends ActionHandler {
             }
         }
         return selectors;
-    }
-
-    private JSONObject getFromCache(String cacheKey) {
-        String cachedData = JedisManager.get(cacheKey);
-        return JSONHelper.createJSONObject(cachedData);
     }
 
     private JSONObject toJSON(Map<String, IndicatorValue> values) throws ActionException {

--- a/control-statistics/src/main/java/fi/nls/oskari/control/statistics/GetIndicatorDataHandler.java
+++ b/control-statistics/src/main/java/fi/nls/oskari/control/statistics/GetIndicatorDataHandler.java
@@ -64,6 +64,9 @@ public class GetIndicatorDataHandler extends ActionHandler {
     public JSONObject getIndicatorDataJSON(User user, long pluginId, String indicatorId,
             long layerId, JSONObject selectorJSON) throws ActionException {
         StatisticalDatasourcePlugin plugin = PLUGIN_MANAGER.getPlugin(pluginId);
+        if (plugin == null) {
+            throw new ActionParamsException("No such datasource");
+        }
 
         String cacheKey = GetIndicatorDataHelper.getCacheKey(pluginId, indicatorId, layerId, selectorJSON);
         if (plugin.canCache()) {

--- a/control-statistics/src/main/java/fi/nls/oskari/control/statistics/GetIndicatorDataHandler.java
+++ b/control-statistics/src/main/java/fi/nls/oskari/control/statistics/GetIndicatorDataHandler.java
@@ -63,9 +63,9 @@ public class GetIndicatorDataHandler extends ActionHandler {
 
     public JSONObject getIndicatorDataJSON(User user, long pluginId, String indicatorId,
             long layerId, JSONObject selectorJSON) throws ActionException {
-        final StatisticalDatasourcePlugin plugin = PLUGIN_MANAGER.getPlugin(pluginId);
+        StatisticalDatasourcePlugin plugin = PLUGIN_MANAGER.getPlugin(pluginId);
 
-        final String cacheKey = GetIndicatorDataHelper.getCacheKey(pluginId, indicatorId, layerId, selectorJSON);
+        String cacheKey = GetIndicatorDataHelper.getCacheKey(pluginId, indicatorId, layerId, selectorJSON);
         if (plugin.canCache()) {
             JSONObject cached = getFromCache(cacheKey);
             if (cached != null) {
@@ -73,26 +73,18 @@ public class GetIndicatorDataHandler extends ActionHandler {
             }
         }
 
+        StatisticalIndicator indicator = plugin.getIndicator(user, indicatorId);
+        if (indicator == null) {
+            throw new ActionParamsException("No such indicator");
+        }
+
+        StatisticalIndicatorLayer layer = indicator.getLayer(layerId);
+        if (layer == null) {
+            throw new ActionParamsException("No such regionset");
+        }
+
         JSONObject response;
         try {
-
-            // TODO: Might be faster to store the indicator id to indicator map in a proper map.
-            //       Who should do this, though? We don't want to put this functionality into the plugins.
-            //       It should be in a common wrapper for the plugins.
-
-            StatisticalIndicator indicator = plugin.getIndicator(user, indicatorId);
-            if(indicator == null) {
-                throw new ActionParamsException("No such indicator");
-            }
-
-            StatisticalIndicatorLayer layer = indicator.getLayer(layerId);
-            if(layer == null) {
-                throw new ActionParamsException("No such regionset");
-            }
-
-            // Note: Layer version is handled already in the indicator metadata.
-            // We found the correct indicator and the layer.
-
             StatisticalIndicatorDataModel selectors = new StatisticalIndicatorDataModel();
             @SuppressWarnings("unchecked")
             Iterator<String> keys = selectorJSON.keys();

--- a/control-statistics/src/main/java/fi/nls/oskari/control/statistics/GetIndicatorDataHandler.java
+++ b/control-statistics/src/main/java/fi/nls/oskari/control/statistics/GetIndicatorDataHandler.java
@@ -39,20 +39,21 @@ public class GetIndicatorDataHandler extends ActionHandler {
     private static final StatisticalDatasourcePluginManager PLUGIN_MANAGER = StatisticalDatasourcePluginManager.getInstance();
 
     @Override
-    public void handleAction(ActionParameters ap) throws ActionException {
-        final long pluginId = ap.getRequiredParamLong(PARAM_PLUGIN_ID);
-        final String indicatorId = ap.getRequiredParam(PARAM_INDICATOR_ID);
-        final long layerId = ap.getRequiredParamLong(PARAM_LAYER_ID);
-        final String selectors = ap.getRequiredParam(PARAM_SELECTORS);
+    public void handleAction(ActionParameters params) throws ActionException {
+        final long pluginId = params.getRequiredParamLong(PARAM_PLUGIN_ID);
+        final String indicatorId = params.getRequiredParam(PARAM_INDICATOR_ID);
+        final long layerId = params.getRequiredParamLong(PARAM_LAYER_ID);
+        final String selectors = params.getRequiredParam(PARAM_SELECTORS);
         JSONObject selectorsJSON;
         try {
             selectorsJSON = new JSONObject(selectors);
         } catch (JSONException e) {
-            throw new ActionParamsException("Invalid parameter value "
-                    + PARAM_SELECTORS + " expected JSON object");
+            throw new ActionParamsException("Invalid parameter value: "
+                    + PARAM_SELECTORS + " - expected JSON object");
         }
-        JSONObject response = getIndicatorDataJSON(ap.getUser(), pluginId, indicatorId, layerId, selectorsJSON);
-        ResponseHelper.writeResponse(ap, response);
+        JSONObject response = getIndicatorDataJSON(params.getUser(),
+                pluginId, indicatorId, layerId, selectorsJSON);
+        ResponseHelper.writeResponse(params, response);
     }
 
     private JSONObject getIndicatorDataJSON(User user, long pluginId, String indicatorId,

--- a/control-statistics/src/main/java/fi/nls/oskari/control/statistics/GetIndicatorDataHelper.java
+++ b/control-statistics/src/main/java/fi/nls/oskari/control/statistics/GetIndicatorDataHelper.java
@@ -17,21 +17,24 @@ import org.json.JSONObject;
 public class GetIndicatorDataHelper {
 
     protected static String getCacheKey(long datasourceId, String indicatorId,
-            Long layerId, String selectorsStr) throws JSONException {
+            Long layerId, JSONObject selectorJSON) {
         StringBuilder cacheKey = new StringBuilder("oskari:stats:");
         cacheKey.append(datasourceId);
         cacheKey.append(":data:");
         cacheKey.append(indicatorId);
         cacheKey.append(':');
         cacheKey.append(layerId);
-        JSONObject selector = new JSONObject(selectorsStr);
-        Iterator<String> it = selector.sortedKeys();
+        Iterator<String> it = selectorJSON.sortedKeys();
         while (it.hasNext()) {
             String key = it.next();
             cacheKey.append(':');
             cacheKey.append(key);
             cacheKey.append('=');
-            cacheKey.append(selector.get(key));
+            try {
+                cacheKey.append(selectorJSON.get(key));
+            } catch (JSONException e) {
+                // Ignore, we are iterating the keys, the key _does_ exist
+            }
         }
         return cacheKey.toString();
     }

--- a/control-statistics/src/main/java/fi/nls/oskari/control/statistics/GetIndicatorDataHelper.java
+++ b/control-statistics/src/main/java/fi/nls/oskari/control/statistics/GetIndicatorDataHelper.java
@@ -17,7 +17,7 @@ import org.json.JSONObject;
 public class GetIndicatorDataHelper {
 
     protected static String getCacheKey(long datasourceId, String indicatorId,
-            Long layerId, JSONObject selectorJSON) {
+            long layerId, JSONObject selectorJSON) {
         StringBuilder cacheKey = new StringBuilder("oskari:stats:");
         cacheKey.append(datasourceId);
         cacheKey.append(":data:");

--- a/control-statistics/src/test/java/fi/nls/oskari/control/statistics/GetIndicatorDataHelperTest.java
+++ b/control-statistics/src/test/java/fi/nls/oskari/control/statistics/GetIndicatorDataHelperTest.java
@@ -1,6 +1,7 @@
 package fi.nls.oskari.control.statistics;
 
 import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -12,7 +13,8 @@ public class GetIndicatorDataHelperTest {
         String indicatorId = "232";
         Long layerId = 1850L;
         String selectionStr = "{\"year\":\"2015\",\"sex\":\"female\"}";
-        String actual = GetIndicatorDataHelper.getCacheKey(pluginId, indicatorId, layerId, selectionStr);
+        JSONObject selectionJSON = new JSONObject(selectionStr);
+        String actual = GetIndicatorDataHelper.getCacheKey(pluginId, indicatorId, layerId, selectionJSON);
         String expected = "oskari:stats:1:data:232:1850:sex=female:year=2015";
         Assert.assertEquals(expected, actual);
     }

--- a/control-statistics/src/test/java/fi/nls/oskari/control/statistics/GetIndicatorDataHelperTest.java
+++ b/control-statistics/src/test/java/fi/nls/oskari/control/statistics/GetIndicatorDataHelperTest.java
@@ -11,7 +11,7 @@ public class GetIndicatorDataHelperTest {
     public void testGetCacheKey() throws JSONException {
         long pluginId = 1L;
         String indicatorId = "232";
-        Long layerId = 1850L;
+        long layerId = 1850L;
         String selectionStr = "{\"year\":\"2015\",\"sex\":\"female\"}";
         JSONObject selectionJSON = new JSONObject(selectionStr);
         String actual = GetIndicatorDataHelper.getCacheKey(pluginId, indicatorId, layerId, selectionJSON);

--- a/service-control/src/main/java/fi/nls/oskari/control/ActionParameters.java
+++ b/service-control/src/main/java/fi/nls/oskari/control/ActionParameters.java
@@ -111,6 +111,24 @@ public class ActionParameters {
             throw new ActionParamsException(errMsg);
         }
     }
+
+    /**
+     * Returns a cleaned up (think XSS) value for the requested parameter
+     * @param key parameter name
+     * @return cleaned up value for the parameter as long
+     * @throws ActionParamsException if parameter is not found, is empty or can't be parsed as long
+     */
+    public long getRequiredParamLong(final String key) throws ActionParamsException {
+        final String errMsg = "Required parameter '" + key + "' missing!";
+        final String val = getRequiredParam(key, errMsg);
+
+        try {
+            return Long.parseLong(val);
+        } catch (Exception e) {
+            throw new ActionParamsException(errMsg);
+        }
+    }
+
     /**
      * Returns a cleaned up (think XSS) value for the requested parameter
      * @param key parameter name


### PR DESCRIPTION
GetIndicatorDataHandler was issueing redis cache checks for plugins that did not allow caching.
This PR also:
- Fails fast if selectors is not a valid JSON Object
- Refactors the handler into smaller methods. 
- Removes outdated Javadoc
- Improves error reporting