### PR TITLE
Bundle registration for admin-publish-transfer

### DIFF
--- a/content-resources/src/main/java/flyway/oskari/V1_45_2__register_admin_publish_transfer_bundle.java
+++ b/content-resources/src/main/java/flyway/oskari/V1_45_2__register_admin_publish_transfer_bundle.java
@@ -9,7 +9,7 @@ import java.sql.SQLException;
 
 public class V1_45_2__register_admin_publish_transfer_bundle implements JdbcMigration {
 
-    private static final String NAMESPACE = "admin";
+    private static final String NAMESPACE = "framework";
     private static final String BUNDLE_ID = "admin-publish-transfer";
 
     public void migrate(Connection connection) throws SQLException {

--- a/content-resources/src/main/java/flyway/oskari/V1_45_2__register_admin_publish_transfer_bundle.java
+++ b/content-resources/src/main/java/flyway/oskari/V1_45_2__register_admin_publish_transfer_bundle.java
@@ -1,0 +1,22 @@
+package flyway.oskari;
+
+import fi.nls.oskari.db.BundleHelper;
+import fi.nls.oskari.domain.map.view.Bundle;
+import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class V1_45_2__register_admin_publish_transfer_bundle implements JdbcMigration {
+
+    private static final String NAMESPACE = "admin";
+    private static final String BUNDLE_ID = "admin-publish-transfer";
+
+    public void migrate(Connection connection) throws SQLException {
+        // BundleHelper checks if these bundles are already registered
+        Bundle bundle = new Bundle();
+        bundle.setName(BUNDLE_ID);
+        bundle.setStartup(BundleHelper.getDefaultBundleStartup(NAMESPACE, BUNDLE_ID, "Published maps import/export"));
+        BundleHelper.registerBundle(bundle, connection);
+    }
+}


### PR DESCRIPTION
New bundle has been added to oskari-frontend. This migration registers it so it can be used as an admin bundle or added to views.