### PR TITLE
Disable bounding geometry calculations for UserLayers

### DIFF
--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERLAYER.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERLAYER.java
@@ -54,7 +54,7 @@ public class LayerJSONFormatterUSERLAYER extends LayerJSONFormatter {
         // user layer rendering url - override DB url if property is defined
         JSONHelper.putValue(layerJson, "url", getUserLayerTileUrl());
         JSONHelper.putValue(layerJson, "renderingElement", userlayerRenderingElement);
-        JSONHelper.putValue(layerJson, "geom", userLayerService.getUserLayerExtent(ulayer.getId()));
+        // JSONHelper.putValue(layerJson, "geom", userLayerService.getUserLayerExtent(ulayer.getId()));
 
         return layerJson;
     }


### PR DESCRIPTION
`OskariLayerWorker.transformWKTGeom(JSONObject layerJSON, String crs)` assumes that the value of `layerJSON.geom` is the WKT presentation of a Polygon with exterior ring of 5 points representing the extent of the layer in question in WGS84 coordinates. The interpolation method added in https://github.com/oskariorg/oskari-server/pull/104 goes crazy if that is not the case.

This PR fixes the problem by disabling the setting of the `geom` for UserLayers altogether (it is not doing what it's supposed to do, so this is not a big loss).