### PR TITLE
Fix Oskarilayer groupId to dataprovider_id

### DIFF
--- a/service-map/src/main/resources/META-INF/OskariLayer.xml
+++ b/service-map/src/main/resources/META-INF/OskariLayer.xml
@@ -559,7 +559,7 @@
     l.externalId,
     l.type,
     l.base_map,
-    l.groupId,
+    l.dataprovider_id,
 
     l.name,
     l.url,


### PR DESCRIPTION
https://github.com/oskariorg/oskari-server/pull/129 renamed oskari_maplayer.groupid column to oskari_maplayer.dataprovider_id. https://github.com/oskariorg/oskari-server/pull/130 added `<select id="findAllWithPositiveUpdateRateSec" ...>` which was based on previous version of the XML mapping when the column was still named groupId. This PR fixes the issue.