### PR TITLE
Remove status of a monitored layer when layer is removed

### DIFF
--- a/content-resources/src/main/resources/flyway/oskari/V1_45_18__fix_backendstatus_constraint.sql
+++ b/content-resources/src/main/resources/flyway/oskari/V1_45_18__fix_backendstatus_constraint.sql
@@ -1,0 +1,5 @@
+-- Delete status when layer is removed with cascade. Otherwise prevents monitored layers from being removed.
+alter table oskari_backendstatus drop constraint oskari_backendstatus_maplayer_id_fkey;
+alter table oskari_backendstatus add CONSTRAINT oskari_backendstatus_maplayer_id_fkey FOREIGN KEY (maplayer_id)
+      REFERENCES oskari_maplayer (id) MATCH SIMPLE
+      ON UPDATE NO ACTION ON DELETE CASCADE;


### PR DESCRIPTION
Otherwise any monitored layer cannot be removed because of the constraint.