### PR TITLE
servlet-printout Java 8 support

### DIFF
--- a/servlet-printout/WebContent/WEB-INF/web.xml
+++ b/servlet-printout/WebContent/WEB-INF/web.xml
@@ -1,19 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns="http://java.sun.com/xml/ns/javaee" xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
-	id="WebApp_ID" version="2.5">
+		 xmlns="http://java.sun.com/xml/ns/javaee" xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+		 xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+		 id="WebApp_ID" version="2.5">
+
 	<servlet>
-		<servlet-name>Jersey Web Application</servlet-name>
-		<servlet-class>com.sun.jersey.spi.container.servlet.ServletContainer</servlet-class>
+		<servlet-name>printout</servlet-name>
+		<servlet-class>org.glassfish.jersey.servlet.ServletContainer</servlet-class>
 		<init-param>
-			<param-name>fi.nls.oskari.printout.ws</param-name>
-			<param-value>managed</param-value>
+			<param-name>javax.ws.rs.Application</param-name>
+			<param-value>fi.nls.oskari.printout.ws.jaxrs.Application</param-value>
 		</init-param>
+		<init-param>
+			<param-name>jersey.config.server.tracing</param-name>
+			<param-value>ALL</param-value>
+		</init-param>
+		<load-on-startup>1</load-on-startup>
 	</servlet>
+
 	<servlet-mapping>
-		<servlet-name>Jersey Web Application</servlet-name>
+		<servlet-name>printout</servlet-name>
 		<url-pattern>/*</url-pattern>
 	</servlet-mapping>
 </web-app>
- 

--- a/servlet-printout/pom.xml
+++ b/servlet-printout/pom.xml
@@ -14,9 +14,11 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <geotools.version>14.2</geotools.version>
-        <gwc.version>1.11.1</gwc.version>
-        <pdfbox.version>1.8.2</pdfbox.version>
+        <geotools.version>18.1</geotools.version>
+        <gwc.version>1.12.2</gwc.version>
+        <httpcomponents.version>4.1.3</httpcomponents.version>
+        <jersey.version>2.19</jersey.version>
+        <pdfbox.version>1.8.13</pdfbox.version>
         <skipTests>false</skipTests>
     </properties>
 
@@ -146,55 +148,40 @@
             <artifactId>xmpbox</artifactId>
             <version>1.8.13</version>
         </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <version>2.0</version>
+        </dependency>
 
-        <!-- use (temporarily) trunk 2.0.0-SNAPSHOT for pdfbox PDF/A support -->
-        <!-- dependency>
-            <groupId>org.apache.pdfbox</groupId>
-            <artifactId>pdfbox</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
-            <scope>system</scope>
-            <systemPath>${project.basedir}/WebContent/WEB-INF/lib/pdfbox-2.0.0-SNAPSHOT.jar</systemPath>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-multipart</artifactId>
+            <version>${jersey.version}</version>
+        </dependency>
+
+        <!-- Jersey 2.19 -->
+        <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-servlet</artifactId>
+            <version>${jersey.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.pdfbox</groupId>
-            <artifactId>jempbox</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
-            <scope>system</scope>
-            <systemPath>${project.basedir}/WebContent/WEB-INF/lib/jempbox-2.0.0-SNAPSHOT.jar</systemPath>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-server</artifactId>
+            <version>${jersey.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.pdfbox</groupId>
-            <artifactId>fontbox</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
-            <scope>system</scope>
-            <systemPath>${project.basedir}/WebContent/WEB-INF/lib/fontbox-2.0.0-SNAPSHOT.jar</systemPath>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.pdfbox</groupId>
-            <artifactId>preflight</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
-            <scope>system</scope>
-            <systemPath>${project.basedir}/WebContent/WEB-INF/lib/preflight-2.0.0-SNAPSHOT.jar</systemPath>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.pdfbox</groupId>
-            <artifactId>xmpbox</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
-            <scope>system</scope>
-            <systemPath>${project.basedir}/WebContent/WEB-INF/lib/xmpbox-2.0.0-SNAPSHOT.jar</systemPath>
-        </dependency -->
-        <dependency>
+        <!--dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-servlet</artifactId>
-            <version>1.17</version>
+            <version>${jersey.version}</version>
 
         </dependency>
         <dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-bundle</artifactId>
-            <version>1.17</version>
-
-        </dependency>
+            <version>${jersey.version}</version>
+        </dependency-->
         <dependency>
             <groupId>net.sf.flexjson</groupId>
             <artifactId>flexjson</artifactId>
@@ -204,12 +191,12 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpasyncclient</artifactId>
-            <version>4.0-beta3</version>
+            <version>${httpcomponents.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpasyncclient-cache</artifactId>
-            <version>4.0-beta3</version>
+            <version>${httpcomponents.version}</version>
         </dependency>
 
         <dependency>

--- a/servlet-printout/src/main/java/fi/nls/oskari/printout/output/layer/AsyncLayerProcessor.java
+++ b/servlet-printout/src/main/java/fi/nls/oskari/printout/output/layer/AsyncLayerProcessor.java
@@ -1,80 +1,43 @@
 package fi.nls.oskari.printout.output.layer;
 
+import java.io.IOException;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.HttpGet;
 import org.apache.http.concurrent.FutureCallback;
-import org.apache.http.conn.scheme.PlainSocketFactory;
-import org.apache.http.conn.scheme.Scheme;
-import org.apache.http.conn.scheme.SchemeRegistry;
-import org.apache.http.conn.ssl.SSLSocketFactory;
-import org.apache.http.impl.conn.ProxySelectorRoutePlanner;
-import org.apache.http.impl.nio.client.DefaultHttpAsyncClient;
-import org.apache.http.impl.nio.conn.PoolingClientAsyncConnectionManager;
-import org.apache.http.impl.nio.reactor.DefaultConnectingIOReactor;
-import org.apache.http.impl.nio.reactor.IOReactorConfig;
-import org.apache.http.nio.client.HttpAsyncClient;
-import org.apache.http.nio.reactor.ConnectingIOReactor;
-import org.apache.http.nio.reactor.IOReactorException;
-import org.apache.http.params.CoreConnectionPNames;
-
-import java.net.ProxySelector;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.impl.nio.client.HttpAsyncClients;
 
 /**
  * This class is used to process map tile requests.
- * 
+ *
  * Async http client is used to hopefully serve client with improved response
  * times.
- * 
+ *
  * Note : performance has not been optimized or measured atm.
- * 
+ *
  */
 public class AsyncLayerProcessor {
     protected static Log log = LogFactory.getLog(AsyncLayerProcessor.class);
-    HttpAsyncClient httpclient;
+    CloseableHttpAsyncClient httpclient;
 
-    public AsyncLayerProcessor() throws IOReactorException {
+    public AsyncLayerProcessor() {
 
-        SchemeRegistry schemeRegistry = new SchemeRegistry();
-        schemeRegistry.register(new Scheme("http", 80, PlainSocketFactory
-                .getSocketFactory()));
-        schemeRegistry.register(new Scheme("https", 443, SSLSocketFactory
-                .getSocketFactory()));
-
-        IOReactorConfig config = new IOReactorConfig();
-        config.setIoThreadCount(4);
-        config.setSoReuseAddress(true);
-
-        ConnectingIOReactor ioreactor = new DefaultConnectingIOReactor();
-        PoolingClientAsyncConnectionManager cm = new PoolingClientAsyncConnectionManager(
-                ioreactor);
-        cm.setMaxTotal(10000);
-        cm.setDefaultMaxPerRoute(4);
-
-        DefaultHttpAsyncClient asyncHttpclient = new DefaultHttpAsyncClient(cm);
-
-        httpclient = asyncHttpclient;
-
-        ProxySelectorRoutePlanner routePlanner = new ProxySelectorRoutePlanner(
-                schemeRegistry, ProxySelector.getDefault());
-        asyncHttpclient.setRoutePlanner(routePlanner);
-
-        httpclient
-                .getParams()
-                .setIntParameter(CoreConnectionPNames.SO_TIMEOUT, 16000)
-                .setIntParameter(CoreConnectionPNames.CONNECTION_TIMEOUT, 8000)
-                .setIntParameter(CoreConnectionPNames.SOCKET_BUFFER_SIZE,
-                        8 * 1024)
-                .setBooleanParameter(CoreConnectionPNames.TCP_NODELAY, true);
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setSocketTimeout(3000).setConnectTimeout(3000).build();
+        httpclient = HttpAsyncClients.custom()
+                .setDefaultRequestConfig(requestConfig).build();
     }
 
-    public void execute(HttpUriRequest arg0, FutureCallback<HttpResponse> arg1) {
+    public void execute(HttpGet arg0, FutureCallback<HttpResponse> arg1) {
         httpclient.execute(arg0, arg1);
     }
 
-    public void shutdown() throws InterruptedException {
-        httpclient.shutdown();
+    public void shutdown() throws InterruptedException, IOException {
+        httpclient.close();
         httpclient = null;
     }
 

--- a/servlet-printout/src/main/java/fi/nls/oskari/printout/output/map/MapProducer.java
+++ b/servlet-printout/src/main/java/fi/nls/oskari/printout/output/map/MapProducer.java
@@ -20,7 +20,7 @@ import fi.nls.oskari.printout.output.layer.DirectFeatureLayer;
 import fi.nls.oskari.printout.output.layer.DirectTileLayer;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.geotools.data.collection.CollectionDataStore;
+import org.geotools.data.memory.MemoryDataStore;
 import org.geotools.data.simple.SimpleFeatureSource;
 import org.geotools.feature.DefaultFeatureCollection;
 import org.geotools.feature.FeatureCollection;
@@ -229,7 +229,7 @@ public class MapProducer {
 
                 if (layerDefinition.getData() != null
                         && layerDefinition.getData().size() > 0) {
-                    CollectionDataStore ds = new CollectionDataStore(
+                    MemoryDataStore ds = new MemoryDataStore(
                             layerDefinition.getData());
                     SimpleFeatureSource fs = ds.getFeatureSource(ds
                             .getTypeNames()[0]);

--- a/servlet-printout/src/main/java/fi/nls/oskari/printout/ws/jaxrs/Application.java
+++ b/servlet-printout/src/main/java/fi/nls/oskari/printout/ws/jaxrs/Application.java
@@ -1,0 +1,23 @@
+package fi.nls.oskari.printout.ws.jaxrs;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.ws.rs.ApplicationPath;
+
+import org.glassfish.jersey.media.multipart.MultiPartFeature;
+
+import fi.nls.oskari.printout.ws.jaxrs.resource.MapResource;
+
+@ApplicationPath("/")
+public class Application extends javax.ws.rs.core.Application {
+    @Override
+    public Set<Class<?>> getClasses() {
+        final Set<Class<?>> classes = new HashSet<Class<?>>();
+        // register resources and features
+        classes.add(MapResource.class);
+        classes.add(MultiPartFeature.class);
+
+        return classes;
+    }
+}


### PR DESCRIPTION
Modifications required for printout to work with Java 8 as compile target. Java 8 has been the compile target of Oskari-server since 1.44.0 so the printout isn't working properly on versions 1.44.0-145.0.

This can be added as a hotfix to enable servlet-printout to be compilable from source with the latest Oskari version or as a workaround the old version can be used (downloadable from http://oskari.org/nexus/service/local/repositories/releases/content/fi/nls/oskari/oskari-printout-backend/1.43.0/oskari-printout-backend-1.43.0.war). 

Note! The old 1.43.0 can be run on Java 8, but compiling with 8 as target version breaks the more recent maven artifact versions as the libraries used do not support Java 8.