### PR TITLE
Fix issues with UpdateCapabilitiesHandler

### DIFF
--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/UpdateCapabilitiesHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/UpdateCapabilitiesHandler.java
@@ -53,8 +53,6 @@ public class UpdateCapabilitiesHandler extends ActionHandler {
     private CapabilitiesUpdateService capabilitiesUpdateService;
     private ViewService viewService;
 
-    private static final int NOT_SPECIFIED_VALUE = -1;
-
     public UpdateCapabilitiesHandler() {
         // No-param constructor for @OskariActionRoute
     }
@@ -90,8 +88,8 @@ public class UpdateCapabilitiesHandler extends ActionHandler {
     public void handleAction(ActionParameters params) throws ActionException {
         params.requireAdminUser();
 
-        int layerId = params.getHttpParam(ActionConstants.KEY_ID, NOT_SPECIFIED_VALUE);
-        List<OskariLayer> layers = getLayersToUpdate(layerId, NOT_SPECIFIED_VALUE);
+        String layerId = params.getHttpParam(ActionConstants.KEY_ID);
+        List<OskariLayer> layers = getLayersToUpdate(layerId);
         Set<String> systemCRSs = getSystemCRSs();
 
         List<CapabilitiesUpdateResult> result =
@@ -101,9 +99,9 @@ public class UpdateCapabilitiesHandler extends ActionHandler {
         ResponseHelper.writeResponse(params, response);
     }
 
-    private List<OskariLayer> getLayersToUpdate(int layerId, int notSpecified)
+    private List<OskariLayer> getLayersToUpdate(String layerId)
             throws ActionParamsException {
-        if (layerId == notSpecified) {
+        if (layerId == null) {
             return layerService.findAll();
         }
         OskariLayer layer = layerService.find(layerId);
@@ -121,7 +119,7 @@ public class UpdateCapabilitiesHandler extends ActionHandler {
         }
     }
 
-    private JSONObject createResponse(List<CapabilitiesUpdateResult> result, int layerId, ActionParameters params)
+    private JSONObject createResponse(List<CapabilitiesUpdateResult> result, String layerId, ActionParameters params)
             throws ActionException {
         JSONArray success = new JSONArray();
         JSONObject errors = new JSONObject();
@@ -138,7 +136,7 @@ public class UpdateCapabilitiesHandler extends ActionHandler {
         response.put("success", success);
         response.put("error", errors);
 
-        if (layerId != NOT_SPECIFIED_VALUE && success.size() == 1) {
+        if (layerId != null && success.size() == 1) {
             OskariLayer layer = layerService.find(layerId);
             org.json.JSONObject layerJSON = OskariLayerWorker.getMapLayerJSON(layer, params.getUser(), params.getLocale().getLanguage(), params.getHttpParam(PARAM_SRS));
             response.put("layerUpdate", layerJSON);

--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/UpdateCapabilitiesHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/UpdateCapabilitiesHandler.java
@@ -95,7 +95,6 @@ public class UpdateCapabilitiesHandler extends ActionHandler {
                 capabilitiesUpdateService.updateCapabilities(layers, systemCRSs);
 
         JSONObject response = createResponse(result, layerId, params);
-
         ResponseHelper.writeResponse(params, response);
     }
 

--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/UpdateCapabilitiesHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/UpdateCapabilitiesHandler.java
@@ -24,9 +24,8 @@ import fi.nls.oskari.map.view.ViewService;
 import fi.nls.oskari.map.view.util.ViewHelper;
 import fi.nls.oskari.service.ServiceException;
 import fi.nls.oskari.service.capabilities.CapabilitiesCacheService;
+import fi.nls.oskari.util.JSONHelper;
 import fi.nls.oskari.util.ResponseHelper;
-
-import static fi.nls.oskari.control.ActionConstants.PARAM_SRS;
 
 /**
  * ActionRoute to update the capabilities of layers
@@ -97,6 +96,7 @@ public class UpdateCapabilitiesHandler extends ActionHandler {
                 capabilitiesUpdateService.updateCapabilities(layers, systemCRSs);
 
         JSONObject response = createResponse(result, layerId, params);
+
         ResponseHelper.writeResponse(params, response);
     }
 
@@ -139,14 +139,20 @@ public class UpdateCapabilitiesHandler extends ActionHandler {
             response.put("error", errors);
 
             if (layerId != null && success.length() == 1) {
+                // If this is a update-single-layer request then add the updated information 
+                // Fetch the OskariLayer again to make sure we have all the fields updated in the object
                 OskariLayer layer = layerService.find(layerId);
-                JSONObject layerJSON = OskariLayerWorker.getMapLayerJSON(layer, params.getUser(), params.getLocale().getLanguage(), params.getHttpParam(PARAM_SRS));
+                JSONObject layerJSON = OskariLayerWorker.getMapLayerJSON(layer,
+                        params.getUser(),
+                        params.getLocale().getLanguage(),
+                        params.getHttpParam(ActionConstants.PARAM_SRS));
                 response.put("layerUpdate", layerJSON);
             }
 
             return response;
         } catch (JSONException e) {
-            throw new ActionException("Failed to create JSON", e);
+            throw new ActionException("Failed to create response JSON", e);
         }
     }
+
 }

--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/UpdateCapabilitiesHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/UpdateCapabilitiesHandler.java
@@ -24,7 +24,6 @@ import fi.nls.oskari.map.view.ViewService;
 import fi.nls.oskari.map.view.util.ViewHelper;
 import fi.nls.oskari.service.ServiceException;
 import fi.nls.oskari.service.capabilities.CapabilitiesCacheService;
-import fi.nls.oskari.util.JSONHelper;
 import fi.nls.oskari.util.ResponseHelper;
 
 /**

--- a/service-capabilities-update/src/main/java/org/oskari/capabilities/CapabilitiesUpdateResult.java
+++ b/service-capabilities-update/src/main/java/org/oskari/capabilities/CapabilitiesUpdateResult.java
@@ -4,23 +4,27 @@ import fi.nls.oskari.domain.map.OskariLayer;
 
 public class CapabilitiesUpdateResult {
 
-    private final int layerId;
+    private final String layerId;
     private final String errorMessage;
 
-    private CapabilitiesUpdateResult(int layerId, String errorMessage) {
-        this.layerId = layerId;
+    private CapabilitiesUpdateResult(OskariLayer layer, String errorMessage) {
+        if (layer.getExternalId() != null && !layer.getExternalId().isEmpty()) {
+            this.layerId = layer.getExternalId();
+        } else {
+            this.layerId = Integer.toString(layer.getId());
+        }
         this.errorMessage = errorMessage;
     }
 
     public static CapabilitiesUpdateResult ok(OskariLayer layer) {
-        return new CapabilitiesUpdateResult(layer.getId(), null);
+        return new CapabilitiesUpdateResult(layer, null);
     }
 
     public static CapabilitiesUpdateResult err(OskariLayer layer, String errorMessage) {
-        return new CapabilitiesUpdateResult(layer.getId(), errorMessage);
+        return new CapabilitiesUpdateResult(layer, errorMessage);
     }
 
-    public int getLayerId() {
+    public String getLayerId() {
         return layerId;
     }
 


### PR DESCRIPTION
Fixes the issue when the public id of a layer is not an integer.
Use org.json stuff instead of org.json.simple like is done throughout the codebase.