### PR TITLE
Enable scale line drawing in PDF prints

### DIFF
--- a/service-print/src/main/java/org/oskari/print/PrintService.java
+++ b/service-print/src/main/java/org/oskari/print/PrintService.java
@@ -14,7 +14,7 @@ import org.oskari.print.wmts.WMTSCapabilitiesCache;
 
 public class PrintService {
 
-    private WMTSCapabilitiesCache tmsCache;
+    private WMTSCapabilitiesCache wmtsCapsCache;
 
     public PrintService() {
         this(new WMTSCapabilitiesCache());
@@ -24,19 +24,19 @@ public class PrintService {
         this(new WMTSCapabilitiesCache(capCacheService));
     }
 
-    public PrintService(WMTSCapabilitiesCache tmsCache) {
-        this.tmsCache = tmsCache;
+    public PrintService(WMTSCapabilitiesCache wmtsCapsCache) {
+        this.wmtsCapsCache = wmtsCapsCache;
     }
 
     public BufferedImage getPNG(PrintRequest request) throws ServiceException {
         request.setLayers(filterLayersWithZeroOpacity(request.getLayers()));
-        return PNG.getBufferedImage(request, tmsCache);
+        return PNG.getBufferedImage(request, wmtsCapsCache);
     }
 
     public void getPDF(PrintRequest request, PDDocument doc)
             throws IOException, ServiceException {
         request.setLayers(filterLayersWithZeroOpacity(request.getLayers()));
-        PDF.getPDF(request, doc, tmsCache);
+        PDF.getPDF(request, doc, wmtsCapsCache);
     }
 
     private static List<PrintLayer> filterLayersWithZeroOpacity(List<PrintLayer> layers) {

--- a/service-print/src/main/java/org/oskari/print/loader/AsyncImageLoader.java
+++ b/service-print/src/main/java/org/oskari/print/loader/AsyncImageLoader.java
@@ -14,7 +14,7 @@ public class AsyncImageLoader {
 
     public static final String GROUP_KEY = "LoadImageFromURL";
 
-    public static List<Future<BufferedImage>> initLayers(PrintRequest request, WMTSCapabilitiesCache cache)
+    public static List<Future<BufferedImage>> initLayers(PrintRequest request, WMTSCapabilitiesCache wmtsCapsCache)
             throws ServiceException {
         final List<Future<BufferedImage>> images = new ArrayList<>();
 
@@ -38,7 +38,7 @@ public class AsyncImageLoader {
                 break;
             case OskariLayer.TYPE_WMTS:
                 images.add(new CommandLoadImageWMTS(layer, width, height, bbox, srsName,
-                        cache.get(layer), request.getResolution()).queue());
+                        wmtsCapsCache.get(layer), request.getResolution()).queue());
                 break;
             case OskariLayer.TYPE_WFS:
                 images.add(new CommandLoadImageWFS(layer, width, height, bbox).queue());

--- a/service-print/src/main/java/org/oskari/print/util/Units.java
+++ b/service-print/src/main/java/org/oskari/print/util/Units.java
@@ -4,9 +4,6 @@ public interface Units {
 
     public static final double MM_PER_INCH = 25.4;
 
-    public static final double METRES_PER_MILE = 1609.344;
-    public static final double METRES_PER_FOOT = 0.3048;
-
     public static final double PDF_DPI = 72.0;
 
     // OGC Standardised pixel size

--- a/service-print/src/test/java/org/oskari/print/PrintServiceTest.java
+++ b/service-print/src/test/java/org/oskari/print/PrintServiceTest.java
@@ -89,6 +89,8 @@ public class PrintServiceTest {
         request.setHeight(700);
         request.setResolution(2);
 
+        request.setShowScale(true);
+
         PrintLayer bg = new PrintLayer();
         bg.setId(1);
         bg.setName("taustakartta");


### PR DESCRIPTION
Draw scale line if the unit of measure of the first axis of the projection is metres.
Rename `tmsCache` to `wmtsCapsCache` to avoid confusion (for example I was confused by the name).
