### PR TITLE
Add default version for WMS layers

### DIFF
--- a/service-print/src/main/java/org/oskari/print/util/GetMapBuilder.java
+++ b/service-print/src/main/java/org/oskari/print/util/GetMapBuilder.java
@@ -9,6 +9,8 @@ import java.util.List;
  */
 public class GetMapBuilder {
 
+    private static final String DEFAULT_VERSION = "1.1.1";
+
     private String endPoint;
     private String version;
     private String bbox;
@@ -27,6 +29,9 @@ public class GetMapBuilder {
     }
 
     public GetMapBuilder version(String version) {
+        if (version == null || version.isEmpty()) {
+            version = DEFAULT_VERSION;
+        }
         this.version = version;
         return this;
     }
@@ -99,7 +104,13 @@ public class GetMapBuilder {
     public String toKVP() {
         StringBuilder sb = new StringBuilder();
         sb.append(endPoint);
-        sb.append("?SERVICE=WMS");
+        int j = endPoint.indexOf('?');
+        if (j < 0) {
+            sb.append('?');
+        } else if (j != (endPoint.length() - 1)) {
+            sb.append('&');
+        }
+        sb.append("SERVICE=WMS");
         sb.append("&REQUEST=GetMap");
         sb.append("&VERSION=").append(version);
         sb.append("&BBOX=").append(bbox);


### PR DESCRIPTION
Some Layers have null or empty version value. This leads to print module generating errorneous WMS requests. This PR fixes the issue. Also add a workaround to layer urls with query parameters, those didn't work.