### PR TITLE
Remove OskariLayer.tileMatrixSetId

### DIFF
--- a/content-resources/src/main/resources/flyway/oskari/V1_46_6__drop_column_tile_matrix_set_id.sql
+++ b/content-resources/src/main/resources/flyway/oskari/V1_46_6__drop_column_tile_matrix_set_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oskari_maplayer DROP COLUMN tile_matrix_set_id;

--- a/control-base/src/main/java/fi/nls/oskari/control/layer/GetWmsServicesHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/GetWmsServicesHandler.java
@@ -133,7 +133,6 @@ public class GetWmsServicesHandler extends ActionHandler {
 //                mapProperties.put("orderNumber", ml.getOrdernumber());
 
                 mapProperties.put("layerType", ml.getType());
-                mapProperties.put("tileMatrixSetId", ml.getTileMatrixSetId());
 /*
                 mapProperties.put("wms_dcp_http", ml.getWms_dcp_http());
                 mapProperties.put("wms_parameter_layers", ml

--- a/control-base/src/main/java/fi/nls/oskari/control/layer/SaveLayerHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/SaveLayerHandler.java
@@ -85,7 +85,6 @@ public class SaveLayerHandler extends ActionHandler {
     private static final String PARAM_MAX_SCALE ="maxScale";
     private static final String PARAM_LEGEND_IMAGE ="legendImage";
     private static final String PARAM_METADATA_ID ="metadataId";
-    private static final String PARAM_TILE_MATRIX_SET_ID ="tileMatrixSetId";
     private static final String PARAM_GFI_CONTENT ="gfiContent";
     private static final String PARAM_USERNAME ="username";
     private static final String PARAM_PASSWORD ="password";
@@ -354,7 +353,6 @@ public class SaveLayerHandler extends ActionHandler {
 
         ml.setLegendImage(params.getHttpParam(PARAM_LEGEND_IMAGE, ml.getLegendImage()));
         ml.setMetadataId(params.getHttpParam(PARAM_METADATA_ID, ml.getMetadataId()));
-        ml.setTileMatrixSetId(params.getHttpParam(PARAM_TILE_MATRIX_SET_ID));
 
         final String gfiContent = request.getParameter(PARAM_GFI_CONTENT);
         if (gfiContent != null) {

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/OskariLayer.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/OskariLayer.java
@@ -46,8 +46,6 @@ public class OskariLayer extends JSONLocalizedNameAndTitle implements Comparable
     private String legendImage;
     private String metadataId;
 
-    private String tileMatrixSetId;
-
     private JSONObject params = new JSONObject();
     private JSONObject options = new JSONObject();
     private JSONObject attributes = new JSONObject();
@@ -254,13 +252,6 @@ public class OskariLayer extends JSONLocalizedNameAndTitle implements Comparable
 	}
 	public void setLegendImage(String legendImage) {
 		this.legendImage = legendImage;
-	}
-	public String getTileMatrixSetId() {
-		return tileMatrixSetId;
-	}
-
-	public void setTileMatrixSetId(String value) {
-		tileMatrixSetId = value;
 	}
 
     public int getParentId() {

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/OskariLayerServiceIbatisImpl.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/OskariLayerServiceIbatisImpl.java
@@ -101,7 +101,6 @@ public class OskariLayerServiceIbatisImpl extends OskariLayerService {
         // additional info
         result.setLegendImage((String) data.get("legend_image"));
         result.setMetadataId((String) data.get("metadataid"));
-        result.setTileMatrixSetId((String) data.get("tile_matrix_set_id"));
 
         // map implementation parameters
         result.setParams(JSONHelper.createJSONObject((String) data.get("params")));

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
@@ -286,7 +286,6 @@ public class LayerJSONFormatter {
         layer.setMaxScale(json.optDouble("maxscale", layer.getMaxScale()));
         layer.setLegendImage(json.optString("legend_image", layer.getLegendImage()));
         layer.setMetadataId(json.optString("metadataid", layer.getMetadataId()));
-        layer.setTileMatrixSetId(json.optString("tile_matrix_set_id", layer.getTileMatrixSetId()));
         layer.setGfiType(json.optString("gfi_type", layer.getGfiType()));
         layer.setGfiXslt(json.optString("gfi_xslt", layer.getGfiXslt()));
         layer.setGfiContent(json.optString("gfi_content", layer.getGfiContent()));

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWMTS.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWMTS.java
@@ -24,11 +24,8 @@ public class LayerJSONFormatterWMTS extends LayerJSONFormatter {
         final JSONObject layerJson = getBaseJSON(layer, lang, isSecure);
 
         // Use capabities in 1st hand for to get matrix id
-        String mid = LayerJSONFormatterWMTS.getTileMatrixSetId(layer.getCapabilities(), layer.getSrs_name());
-        if(mid != null){
-            layer.setTileMatrixSetId(mid);
-        }
-        JSONHelper.putValue(layerJson, "tileMatrixSetId", layer.getTileMatrixSetId());
+        String tileMatrixSetId = LayerJSONFormatterWMTS.getTileMatrixSetId(layer.getCapabilities(), layer.getSrs_name());
+        JSONHelper.putValue(layerJson, "tileMatrixSetId", tileMatrixSetId);
 
         // TODO: parse tileMatrixSetData for styles and set default style name from the one where isDefault = true
         String styleName = layer.getStyle();

--- a/service-map/src/main/java/fi/nls/oskari/service/capabilities/OskariLayerCapabilitiesHelper.java
+++ b/service-map/src/main/java/fi/nls/oskari/service/capabilities/OskariLayerCapabilitiesHelper.java
@@ -119,9 +119,6 @@ public class OskariLayerCapabilitiesHelper {
         JSONObject jscaps = LayerJSONFormatterWMTS.createCapabilitiesJSON(layer, systemCRSs);
         ml.setCapabilities(jscaps);
         ml.setCapabilitiesLastUpdated(new Date());
-
-        crs = crs != null ? crs : ml.getSrs_name();
-        ml.setTileMatrixSetId(LayerJSONFormatterWMTS.getTileMatrixSetId(jscaps, crs));
     }
 
     public static void setPropertiesFromCapabilitiesWFS(OskariLayer ml,

--- a/service-map/src/main/resources/META-INF/OskariLayer.xml
+++ b/service-map/src/main/resources/META-INF/OskariLayer.xml
@@ -30,7 +30,6 @@
         <parameter property="legendImage" />
         <parameter property="metadataId" />
 
-        <parameter property="tileMatrixSetId" />
         <parameter property="params" jdbcType="VARCHAR" javaType="org.json.JSONObject" />
         <parameter property="options" jdbcType="VARCHAR" javaType="org.json.JSONObject" />
         <parameter property="attributes" jdbcType="VARCHAR" javaType="org.json.JSONObject" />
@@ -75,7 +74,6 @@
         <parameter property="legendImage" />
         <parameter property="metadataId" />
 
-        <parameter property="tileMatrixSetId" />
         <parameter property="params" jdbcType="VARCHAR" javaType="org.json.JSONObject" />
         <parameter property="options" jdbcType="VARCHAR" javaType="org.json.JSONObject" />
         <parameter property="attributes" jdbcType="VARCHAR" javaType="org.json.JSONObject" />
@@ -126,7 +124,6 @@
         l.legend_image,
         l.metadataId,
 
-        l.tile_matrix_set_id,
         l.params,
         l.options,
         l.attributes,
@@ -184,7 +181,6 @@
         l.legend_image,
         l.metadataId,
 
-        l.tile_matrix_set_id,
         l.params,
         l.options,
         l.attributes,
@@ -242,7 +238,6 @@
         l.legend_image,
         l.metadataId,
 
-        l.tile_matrix_set_id,
         l.params,
         l.options,
         l.attributes,
@@ -301,7 +296,6 @@
         l.legend_image,
         l.metadataId,
 
-        l.tile_matrix_set_id,
         l.params,
         l.options,
         l.attributes,
@@ -360,7 +354,6 @@
         l.legend_image,
         l.metadataId,
 
-        l.tile_matrix_set_id,
         l.params,
         l.options,
         l.attributes,
@@ -418,7 +411,6 @@
     l.legend_image,
     l.metadataId,
 
-    l.tile_matrix_set_id,
     l.params,
     l.options,
     l.attributes,
@@ -481,7 +473,6 @@
         l.legend_image,
         l.metadataId,
 
-        l.tile_matrix_set_id,
         l.params,
         l.options,
         l.attributes,
@@ -558,7 +549,6 @@
     l.legend_image,
     l.metadataId,
 
-    l.tile_matrix_set_id,
     l.params,
     l.options,
     l.attributes,
@@ -617,7 +607,6 @@
             legend_image,
             metadataId,
 
-            tile_matrix_set_id,
             params,
             options,
             attributes,
@@ -642,7 +631,7 @@
             capabilities_last_updated,
             capabilities_update_rate_sec)
 
-        values (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+        values (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
     </statement>
     
     <update id="updateOrder" parameterClass="java.util.HashMap">
@@ -680,7 +669,6 @@
         legend_image = ?,
         metadataId = ?,
 
-        tile_matrix_set_id = ?,
         params = ?,
         options = ?,
         attributes = ?,

--- a/service-map/src/test/java/fi/nls/oskari/wmts/WMTSCapabilitiesParserTest.java
+++ b/service-map/src/test/java/fi/nls/oskari/wmts/WMTSCapabilitiesParserTest.java
@@ -58,7 +58,6 @@ public class WMTSCapabilitiesParserTest {
 
         OskariLayerCapabilitiesHelper.setPropertiesFromCapabilitiesWMTS(caps, layer, "EPSG:3575", crss);
 
-        assertEquals("EPSG:3575_arcticsdi", layer.getTileMatrixSetId());
         assertFalse("'format' value should have been removed since the layer doesn't support RESTful WMTS", options.has("format"));
     }
 


### PR DESCRIPTION
Remove tileMatrixSetId field from OskariLayer. It's only usable for WMTS layers and even then the field has rarely any effect. Its' meaning is also confusing now that we support multiple coordinate systems in one application.