### PR TITLE
Get TileMatrixSetId based on current projection

### DIFF
--- a/service-map/src/main/java/fi/mml/map/mapwindow/util/OskariLayerWorker.java
+++ b/service-map/src/main/java/fi/mml/map/mapwindow/util/OskariLayerWorker.java
@@ -141,11 +141,12 @@ public class OskariLayerWorker {
                 continue;
             }
             try {
-                final JSONObject layerJson = FORMATTER.getJSON(layer, lang, isSecure);
+                final JSONObject layerJson = FORMATTER.getJSON(layer, lang, isSecure, crs);
 
-            	if (layerJson == null) {
+                if (layerJson == null) {
                     continue;
                 }
+                // TODO: handle inside formatter now that crs is available there
                 transformWKTGeom(layerJson, crs);
 
                 JSONObject permissions = getPermissions(user, permissionKey, permissionsList, downloadPermissionsList, editAccessList, dynamicPermissions);

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
@@ -76,18 +76,20 @@ public class LayerJSONFormatter {
 
     public JSONObject getJSON(final OskariLayer layer,
                                      final String lang,
-                                     final boolean isSecure) {
+                                     final boolean isSecure,
+                                     final String crs) {
         LayerJSONFormatter formatter = getFormatter(layer.getType());
         // to prevent nullpointer and infinite loop
         if(formatter != null && !formatter.getClass().equals(LayerJSONFormatter.class)) {
-            return formatter.getJSON(layer, lang, isSecure);
+            return formatter.getJSON(layer, lang, isSecure, crs);
         }
-        return getBaseJSON(layer, lang, isSecure);
+        return getBaseJSON(layer, lang, isSecure, crs);
     }
 
     public JSONObject getBaseJSON(final OskariLayer layer,
                                      final String lang,
-                                     final boolean isSecure) {
+                                     final boolean isSecure,
+                                     final String crs) {
         JSONObject layerJson = new JSONObject();
 
         final String externalId = layer.getExternalId();
@@ -179,7 +181,7 @@ public class LayerJSONFormatter {
         if(layer.getSublayers() != null && !layer.getSublayers().isEmpty()) {
             JSONArray sublayers = new JSONArray();
             for(OskariLayer sub : layer.getSublayers()) {
-                JSONObject subJSON = getJSON(sub, lang, isSecure);
+                JSONObject subJSON = getJSON(sub, lang, isSecure, crs);
                 sublayers.put(subJSON);
             }
             JSONHelper.putValue(layerJson, "subLayer", sublayers);

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterStats.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterStats.java
@@ -25,9 +25,10 @@ public class LayerJSONFormatterStats extends LayerJSONFormatter {
 
     public JSONObject getJSON(OskariLayer layer,
                                      final String lang,
-                                     final boolean isSecure) {
+                                     final boolean isSecure,
+                                     final String crs) {
 
-        final JSONObject layerJson = getBaseJSON(layer, lang, isSecure);
+        final JSONObject layerJson = getBaseJSON(layer, lang, isSecure, crs);
 
         // get visualizations for statslayers
         final List<StatsVisualization> list = service.findForLayerId(layer.getId());

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERLAYER.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERLAYER.java
@@ -37,9 +37,10 @@ public class LayerJSONFormatterUSERLAYER extends LayerJSONFormatter {
     public JSONObject getJSON(OskariLayer layer,
                                      final String lang,
                                      final boolean isSecure,
+                                     final String crs,
                                      UserLayer ulayer) {
 
-        final JSONObject layerJson = getBaseJSON(layer, lang, isSecure);
+        final JSONObject layerJson = getBaseJSON(layer, lang, isSecure, crs);
 
         JSONHelper.putValue(layerJson, "isQueryable", true);
         JSONHelper.putValue(layerJson, "name",ulayer.getLayer_name());

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWFS.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWFS.java
@@ -28,9 +28,10 @@ public class LayerJSONFormatterWFS extends LayerJSONFormatter {
 
     public JSONObject getJSON(OskariLayer layer,
                                      final String lang,
-                                     final boolean isSecure) {
+                                     final boolean isSecure,
+                                     final String crs) {
 
-        final JSONObject layerJson = getBaseJSON(layer, lang, isSecure);
+        final JSONObject layerJson = getBaseJSON(layer, lang, isSecure, crs);
         final WFSLayerConfiguration wfsConf = wfsService.findConfiguration(layer.getId());
         JSONHelper.putValue(layerJson, "styles", getStyles(wfsConf));
         // Use maplayer setup

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWMS.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWMS.java
@@ -46,9 +46,10 @@ public class LayerJSONFormatterWMS extends LayerJSONFormatter {
 
     public JSONObject getJSON(OskariLayer layer,
                               final String lang,
-                              final boolean isSecure) {
+                              final boolean isSecure,
+                              final String crs) {
 
-        final JSONObject layerJson = getBaseJSON(layer, lang, isSecure);
+        final JSONObject layerJson = getBaseJSON(layer, lang, isSecure, crs);
         JSONHelper.putValue(layerJson, KEY_STYLE, layer.getStyle());
         JSONHelper.putValue(layerJson, KEY_GFICONTENT, layer.getGfiContent());
 
@@ -71,9 +72,10 @@ public class LayerJSONFormatterWMS extends LayerJSONFormatter {
     public JSONObject getJSON(OskariLayer layer,
                               final String lang,
                               final boolean isSecure,
+                              final String crs,
                               final WebMapService capabilities) {
 
-        final JSONObject layerJson = getJSON(layer, lang, isSecure);
+        final JSONObject layerJson = getJSON(layer, lang, isSecure, crs);
         final JSONObject capsJSON = createCapabilitiesJSON(capabilities);
         includeCapabilitiesInfo(layerJson, layer, capsJSON);
 

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWMTS.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWMTS.java
@@ -19,12 +19,13 @@ public class LayerJSONFormatterWMTS extends LayerJSONFormatter {
 
     public JSONObject getJSON(OskariLayer layer,
                               final String lang,
-                              final boolean isSecure) {
+                              final boolean isSecure,
+                              final String crs) {
 
-        final JSONObject layerJson = getBaseJSON(layer, lang, isSecure);
+        final JSONObject layerJson = getBaseJSON(layer, lang, isSecure, crs);
 
-        // Use capabities in 1st hand for to get matrix id
-        String tileMatrixSetId = LayerJSONFormatterWMTS.getTileMatrixSetId(layer.getCapabilities(), layer.getSrs_name());
+        String crsForTileMatrixSet = crs != null ? crs : layer.getSrs_name();
+        String tileMatrixSetId = LayerJSONFormatterWMTS.getTileMatrixSetId(layer.getCapabilities(), crsForTileMatrixSet);
         JSONHelper.putValue(layerJson, "tileMatrixSetId", tileMatrixSetId);
 
         // TODO: parse tileMatrixSetData for styles and set default style name from the one where isDefault = true

--- a/service-map/src/main/java/fi/nls/oskari/map/userlayer/service/UserLayerDataService.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/userlayer/service/UserLayerDataService.java
@@ -189,7 +189,7 @@ public class UserLayerDataService {
             baseLayer.setName(ulayer.getLayer_name());
             baseLayer.setType(OskariLayer.TYPE_USERLAYER);
             // create the JSON
-            final JSONObject json = FORMATTER.getJSON(baseLayer, PropertyUtil.getDefaultLanguage(), false, ulayer);
+            final JSONObject json = FORMATTER.getJSON(baseLayer, PropertyUtil.getDefaultLanguage(), false, null, ulayer);
 
             // restore the previous values for baseLayer
             baseLayer.setExternalId(id);

--- a/service-map/src/main/java/fi/nls/oskari/wfs/GetGtWFSCapabilities.java
+++ b/service-map/src/main/java/fi/nls/oskari/wfs/GetGtWFSCapabilities.java
@@ -574,7 +574,7 @@ public class GetGtWFSCapabilities {
 
         try {
 
-            JSONObject json = FORMATTER.getJSON(oskariLayer, PropertyUtil.getDefaultLanguage(), false);
+            JSONObject json = FORMATTER.getJSON(oskariLayer, PropertyUtil.getDefaultLanguage(), false, null);
             // add/modify admin specific fields
             OskariLayerWorker.modifyCommonFieldsForEditing(json, oskariLayer);
             // for admin ui only

--- a/service-map/src/main/java/fi/nls/oskari/wms/GetGtWMSCapabilities.java
+++ b/service-map/src/main/java/fi/nls/oskari/wms/GetGtWMSCapabilities.java
@@ -264,7 +264,7 @@ OnlineResource xlink:type="simple" xlink:href="http://www.paikkatietohakemisto.f
             oskariLayerCapabilities.put("styles", styles);
             oskariLayer.setCapabilities(oskariLayerCapabilities);
 
-            JSONObject json = FORMATTER.getJSON(oskariLayer, PropertyUtil.getDefaultLanguage(), false);
+            JSONObject json = FORMATTER.getJSON(oskariLayer, PropertyUtil.getDefaultLanguage(), false, currentCrs);
 
             // add/modify admin specific fields
             OskariLayerWorker.modifyCommonFieldsForEditing(json, oskariLayer);

--- a/service-myplaces/src/main/java/fi/nls/oskari/myplaces/MyPlacesService.java
+++ b/service-myplaces/src/main/java/fi/nls/oskari/myplaces/MyPlacesService.java
@@ -98,7 +98,7 @@ java.lang.RuntimeException: Unable to encode filter [[ geometry bbox POLYGON ((4
         // enable gfi
         capabilities.setQueryable(true);
 
-        JSONObject myPlaceLayer = JSON_FORMATTER.getJSON(layer, lang, modifyURLs, capabilities);
+        JSONObject myPlaceLayer = JSON_FORMATTER.getJSON(layer, lang, modifyURLs, null, capabilities);
         // flag with metaType for frontend
         JSONHelper.putValue(myPlaceLayer, "metaType", "published");
         return myPlaceLayer;


### PR DESCRIPTION
Currently oskari_maplayer.srs_name dictates which `tileMatrixSetId` is returned to frontend. With the new multi projection support this simply does not work. Add `crs` as a parameter to `LayerJSONFormatter#getJSON()`.