### PR TITLE
Fix metadata data quality parsing

### DIFF
--- a/service-csw/src/main/java/fi/nls/oskari/csw/domain/CSWIsoRecord.java
+++ b/service-csw/src/main/java/fi/nls/oskari/csw/domain/CSWIsoRecord.java
@@ -169,7 +169,7 @@ public class CSWIsoRecord {
             arr.put(onlineResource.toJSON());
         }
         JSONHelper.putValue(ret, "onlineResources", arr);
-
+        //TODO: should we create toJSON() instead of using ObjectMapper
         ObjectMapper mapper = new ObjectMapper();
         String jsonInString = "";
         try {
@@ -202,7 +202,7 @@ public class CSWIsoRecord {
 
     public static class DataQualityNode {
         private String nodeName;
-        private String linageStatement;
+        private String lineageStatement;
         private String nameOfMeasure;
         private String measureIdentificationCode;
         private String measureIdentificationAuthorization;
@@ -221,12 +221,12 @@ public class CSWIsoRecord {
             this.nodeName = nodeName;
         }
 
-        public String getLinageStatement() {
-            return linageStatement;
+        public String getLineageStatement() {
+            return lineageStatement;
         }
 
-        public void setLinageStatement(String linageStatement) {
-            this.linageStatement = linageStatement;
+        public void setLineageStatement(String lineageStatement) {
+            this.lineageStatement = lineageStatement;
         }
 
         public String getNameOfMeasure() {

--- a/service-csw/src/main/java/fi/nls/oskari/csw/domain/CSWIsoRecord.java
+++ b/service-csw/src/main/java/fi/nls/oskari/csw/domain/CSWIsoRecord.java
@@ -171,15 +171,22 @@ public class CSWIsoRecord {
         JSONHelper.putValue(ret, "onlineResources", arr);
         //TODO: should we create toJSON() instead of using ObjectMapper
         ObjectMapper mapper = new ObjectMapper();
-        String jsonInString = "";
+        String json = "";
         try {
-            jsonInString = mapper.writeValueAsString(dataQualityObject);
+            arr = new JSONArray();
+            for (DataQuality dqNode: dataQualityObject.getDataQualities()){
+                json = mapper.writeValueAsString(dqNode);
+                arr.put(JSONHelper.createJSONObject(json));
+            }
+        } catch (Exception e) {
+            // TODO?
         }
-        catch (Exception e) {
-            //TODO?
+        JSONHelper.putValue(ret, "dataQualities", arr);
+        arr = new JSONArray();
+        for (String lineage : dataQualityObject.getLineageStatements()){
+            arr.put(lineage);
         }
-        JSONHelper.putValue(ret, "dataQualityObject", JSONHelper.createJSONObject(jsonInString));
-
+        JSONHelper.putValue(ret, "lineageStatements", arr);
         return ret;
     }
 
@@ -187,22 +194,28 @@ public class CSWIsoRecord {
         return referenceSystems;
     }
 
-
     public static class DataQualityObject {
-        private List<DataQualityNode> dataQualityNodes = new ArrayList<>();
+        private List<DataQuality> dataQualities = new ArrayList<>();
+        private List<String> lineageStatements = new ArrayList<>();
 
-        public List<DataQualityNode> getDataQualityNodes() {
-            return dataQualityNodes;
+        public List<DataQuality> getDataQualities() {
+            return dataQualities;
         }
 
-        public void setDataQualityNodes(List<DataQualityNode> dataQualityNodes) {
-            this.dataQualityNodes = dataQualityNodes;
+        public void setDataQualities(List<DataQuality> dataQualities) {
+            this.dataQualities = dataQualities;
+        }
+        public List<String> getLineageStatements() {
+            return lineageStatements;
+        }
+
+        public void setLineageStatements(List<String> lineageStatements) {
+            this.lineageStatements = lineageStatements;
         }
     }
 
-    public static class DataQualityNode {
+    public static class DataQuality {
         private String nodeName;
-        private String lineageStatement;
         private String nameOfMeasure;
         private String measureIdentificationCode;
         private String measureIdentificationAuthorization;
@@ -219,14 +232,6 @@ public class CSWIsoRecord {
 
         public void setNodeName(String nodeName) {
             this.nodeName = nodeName;
-        }
-
-        public String getLineageStatement() {
-            return lineageStatement;
-        }
-
-        public void setLineageStatement(String lineageStatement) {
-            this.lineageStatement = lineageStatement;
         }
 
         public String getNameOfMeasure() {
@@ -668,7 +673,6 @@ public class CSWIsoRecord {
                     this.code = code;
                 }
 
-
                 public JSONObject toJSON() {
                     JSONObject ret = new JSONObject();
                     JSONHelper.putValue(ret, "code", code);
@@ -696,7 +700,9 @@ public class CSWIsoRecord {
             private String dateType;
             private String xmlDate;
 
-            public String getXmlDate() { return xmlDate; }
+            public String getXmlDate() {
+                return xmlDate;
+            }
 
             public void setXmlDate(String xmlDate) {
                 this.xmlDate = xmlDate;
@@ -725,8 +731,7 @@ public class CSWIsoRecord {
                     try {
                         final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
                         formattedDate = sdf.format(date);
-                    }
-                    catch (Exception e){
+                    } catch (Exception e){
                         //do nothing
                     }
                 }

--- a/service-csw/src/main/java/fi/nls/oskari/csw/helper/CSWISORecordDataQualityParser.java
+++ b/service-csw/src/main/java/fi/nls/oskari/csw/helper/CSWISORecordDataQualityParser.java
@@ -97,12 +97,8 @@ public class CSWISORecordDataQualityParser {
         }
     }
 
-    public CSWIsoRecord.DataQualityObject parseDataQualities(final NodeList dataQualityNodes, final Locale locale)  throws XPathExpressionException {
-        if (locale != null) {
-                pathToLocalizedValue = xpath.compile(
-                        "../gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale='#"
-                                + locale.getLanguage().toUpperCase() + "']");
-        }
+    public CSWIsoRecord.DataQualityObject parseDataQualities(final NodeList dataQualityNodes, final XPathExpression pathToLoc)  throws XPathExpressionException {
+        pathToLocalizedValue = pathToLoc;
         CSWIsoRecord.DataQualityObject dataQualityObject = new CSWIsoRecord.DataQualityObject();
         List<CSWIsoRecord.DataQualityNode> dataQualityObjectNodeList = dataQualityObject.getDataQualityNodes();
         for (int i = 0; i < dataQualityNodes.getLength(); i++) {

--- a/service-csw/src/main/java/fi/nls/oskari/csw/helper/CSWISORecordDataQualityParser.java
+++ b/service-csw/src/main/java/fi/nls/oskari/csw/helper/CSWISORecordDataQualityParser.java
@@ -199,15 +199,15 @@ public class CSWISORecordDataQualityParser {
         Node quantitativeResultValueUnitNode = (Node) XPATH_QUANTITATIVE_RESULT_VALUE_UNIT.evaluate(parentNode, XPathConstants.NODE);
         dataQualityObjectQuantitativeResult.setValueUnit(localize(quantitativeResultValueUnitNode));
 
-        NodeList quantitativeResultErrorStatisticNode = (NodeList) XPATH_QUANTITATIVE_RESULT_ERROR_STATISTIC.evaluate(parentNode, XPathConstants.NODESET);
-        List<String> valueValueList = new ArrayList<>();
-        for (int i = 0;i < quantitativeResultErrorStatisticNode.getLength(); ++i) {
-            valueValueList.add(localize(quantitativeResultErrorStatisticNode.item(i)));
+        NodeList quantitativeValueNodeList = (NodeList) XPATH_QUANTITATIVE_RESULT_VALUE.evaluate(parentNode, XPathConstants.NODESET);
+        List<String> valueList = new ArrayList<>();
+        for (int i = 0;i < quantitativeValueNodeList.getLength(); ++i) {
+            valueList.add(localize(quantitativeValueNodeList.item(i)));
         }
-        dataQualityObjectQuantitativeResult.setValue(valueValueList);
+        dataQualityObjectQuantitativeResult.setValue(valueList);
 
-        Node quantitativeValueNode = (Node) XPATH_QUANTITATIVE_RESULT_VALUE.evaluate(parentNode, XPathConstants.NODE);
-        dataQualityObjectQuantitativeResult.setErrorStatistic(localize(quantitativeValueNode));
+        Node quantitativeResultErrorStatisticNode = (Node) XPATH_QUANTITATIVE_RESULT_ERROR_STATISTIC.evaluate(parentNode, XPathConstants.NODE);
+        dataQualityObjectQuantitativeResult.setErrorStatistic(localize(quantitativeResultErrorStatisticNode));
 
         return dataQualityObjectQuantitativeResult;
     }

--- a/service-csw/src/main/java/fi/nls/oskari/csw/helper/CSWISORecordParser.java
+++ b/service-csw/src/main/java/fi/nls/oskari/csw/helper/CSWISORecordParser.java
@@ -47,26 +47,7 @@ public class CSWISORecordParser {
     private XPath xpath = XPathFactory.newInstance().newXPath();
 
     private XPathExpression XPATH_DATA_QUALITY = null;
-    private XPathExpression XPATH_DATA_QUALITY_CONFORMANCES = null;
-    private XPathExpression XPATH_DATA_QUALITY_LINEAGE = null;
     private XPathExpression XPATH_DISTRIBUTION_INFO = null;
-    private XPathExpression XPATH_DATA_QUALITY_ABSOLUTE_EXTERNAL_POSITIONAL_ACCURACY = null;
-    private XPathExpression XPATH_DATA_QUALITY_ACCURACY_OF_TIME_MEASUREMENT = null;
-    private XPathExpression XPATH_DATA_QUALITY_COMPLETENESS_COMMISSION = null;
-    private XPathExpression XPATH_DATA_QUALITY_COMPLETENESS_OMISSION = null;
-    private XPathExpression XPATH_DATA_QUALITY_CONCEPTUAL_CONSISTENCY = null;
-    private XPathExpression XPATH_DATA_QUALITY_DOMAIN_CONSISTENCY = null;
-    private XPathExpression XPATH_DATA_QUALITY_FORMAT_CONSISTENCY = null;
-    private XPathExpression XPATH_DATA_QUALITY_GRIDDED_DATA_POSITIONAL_ACCURACY = null;
-    private XPathExpression XPATH_DATA_QUALITY_NON_QUANTITATIVE_ATTRIBUTE_ACCURACY = null;
-    private XPathExpression XPATH_DATA_QUALITY_QUANTITATIVE_ATTRIBUTE_ACCURACY = null;
-    private XPathExpression XPATH_DATA_QUALITY_RELATIVE_INTERNAL_POSITIONAL_ACCURACY = null;
-    private XPathExpression XPATH_DATA_QUALITY_TEMPORAL_CONSISTENCY = null;
-    private XPathExpression XPATH_DATA_QUALITY_TEMPORAL_VALIDITY = null;
-    private XPathExpression XPATH_DATA_QUALITY_THEMATIC_CLASSIFICATION_CORRECTNESS = null;
-    private XPathExpression XPATH_DATA_QUALITY_TOPOLOGICAL_CONSISTENCY = null;
-    private XPathExpression XPATH_DATA_QUALITY_NODE_CHARACTER_STRINGS = null;    
-    private XPathExpression XPATH_DATA_QUALITY_NODE_PASS = null;
     private XPathExpression XPATH_DISTRIBUTION_INFO_DISTRIBUTION_FORMATS = null;
     private XPathExpression XPATH_DISTRIBUTION_INFO_DISTRIBUTION_FORMAT_NAME = null;
     private XPathExpression XPATH_DISTRIBUTION_INFO_DISTRIBUTION_FORMAT_VERSION = null;
@@ -123,49 +104,6 @@ public class CSWISORecordParser {
         //(0..*)
         XPATH_DATA_QUALITY = xpath.compile(
                 "./gmd:dataQualityInfo/gmd:DQ_DataQuality");
-
-        XPATH_DATA_QUALITY_CONFORMANCES = xpath.compile(
-                "./gmd:report/gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:specification/gmd:CI_Citation/gmd:title/gco:CharacterString");
-
-        XPATH_DATA_QUALITY_LINEAGE = xpath.compile(
-                "./gmd:lineage/gmd:LI_Lineage/gmd:statement/gco:CharacterString");
-
-        XPATH_DATA_QUALITY_ABSOLUTE_EXTERNAL_POSITIONAL_ACCURACY = xpath.compile(
-                "./gmd:report/gmd:DQ_AbsoluteExternalPositionalAccuracy/gmd:result/gmd:DQ_ConformanceResult");
-        XPATH_DATA_QUALITY_ACCURACY_OF_TIME_MEASUREMENT = xpath.compile(
-                "./gmd:report/gmd:DQ_AccuracyOfATimeMeasurement/gmd:result/gmd:DQ_ConformanceResult");
-        XPATH_DATA_QUALITY_COMPLETENESS_COMMISSION = xpath.compile(
-                "./gmd:report/gmd:DQ_CompletenessCommission/gmd:result/gmd:DQ_ConformanceResult");
-        XPATH_DATA_QUALITY_COMPLETENESS_OMISSION = xpath.compile(
-                "./gmd:report/gmd:DQ_CompletenessOmission/gmd:result/gmd:DQ_ConformanceResult");
-        XPATH_DATA_QUALITY_CONCEPTUAL_CONSISTENCY = xpath.compile(
-                "./gmd:report/gmd:DQ_ConceptualConsistency/gmd:result/gmd:DQ_ConformanceResult");
-        XPATH_DATA_QUALITY_DOMAIN_CONSISTENCY = xpath.compile(
-                "./gmd:report/gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult");
-        XPATH_DATA_QUALITY_FORMAT_CONSISTENCY = xpath.compile(
-                "./gmd:report/gmd:DQ_FormatConsistency/gmd:result/gmd:DQ_ConformanceResult");
-        XPATH_DATA_QUALITY_GRIDDED_DATA_POSITIONAL_ACCURACY = xpath.compile(
-                "./gmd:report/gmd:DQ_GriddedDataPositionalAccuracy/gmd:result/gmd:DQ_ConformanceResult");
-        XPATH_DATA_QUALITY_NON_QUANTITATIVE_ATTRIBUTE_ACCURACY = xpath.compile(
-                "./gmd:report/gmd:DQ_NonQuantitativeAttributeAccuracy/gmd:result/gmd:DQ_ConformanceResult");
-        XPATH_DATA_QUALITY_QUANTITATIVE_ATTRIBUTE_ACCURACY = xpath.compile(
-                "./gmd:report/gmd:DQ_AbsoluteExternalPositionalAccuracy/gmd:result/gmd:DQ_ConformanceResult");
-        XPATH_DATA_QUALITY_RELATIVE_INTERNAL_POSITIONAL_ACCURACY = xpath.compile(
-                "./gmd:report/gmd:DQ_RelativeInternalPositionalAccuracy/gmd:result/gmd:DQ_ConformanceResult");
-        XPATH_DATA_QUALITY_TEMPORAL_CONSISTENCY = xpath.compile(
-                "./gmd:report/gmd:DQ_TemporalConsistency/gmd:result/gmd:DQ_ConformanceResult");
-        XPATH_DATA_QUALITY_TEMPORAL_VALIDITY = xpath.compile(
-                "./gmd:report/gmd:DQ_TemporalValidity/gmd:result/gmd:DQ_ConformanceResult");
-        XPATH_DATA_QUALITY_THEMATIC_CLASSIFICATION_CORRECTNESS = xpath.compile(
-                "./gmd:report/gmd:DQ_ThematicClassificationCorrectness/gmd:result/gmd:DQ_ConformanceResult");
-        
-        XPATH_DATA_QUALITY_TOPOLOGICAL_CONSISTENCY = xpath.compile(
-                "./gmd:report/gmd:DQ_TopologicalConsistency/gmd:result/gmd:DQ_ConformanceResult");
-        /*parse the character strings from a qualitynode*/
-        XPATH_DATA_QUALITY_NODE_CHARACTER_STRINGS = xpath.compile(".//gco:CharacterString");
-
-        /*parse the "pass" tag from a qualitynode*/
-        XPATH_DATA_QUALITY_NODE_PASS = xpath.compile(".//gmd:pass/gco:Boolean");
 
         //(0..1)
         XPATH_DISTRIBUTION_INFO = xpath.compile(

--- a/service-csw/src/main/java/fi/nls/oskari/csw/helper/CSWISORecordParser.java
+++ b/service-csw/src/main/java/fi/nls/oskari/csw/helper/CSWISORecordParser.java
@@ -354,7 +354,7 @@ public class CSWISORecordParser {
         if (nodeList.getLength() > 0) {
             try {
                 CSWISORecordDataQualityParser dataQualityParser = new CSWISORecordDataQualityParser();
-                record.setDataQualityObject(dataQualityParser.parseDataQualities(nodeList, locale));
+                record.setDataQualityObject(dataQualityParser.parseDataQualities(nodeList, pathToLocalizedValue));
             }
             catch (Exception e) {
                 log.warn("parseDataQualities FAIL! "+e.getMessage());


### PR DESCRIPTION
Data quality nodes' free text content was parsed from parent node, which caused the issue where localized contents were also included in data quality results. Now free text is parsed from CharacterString node and if localized content was found then from LocalisedCharacterString.

Lineage statements were parsed only if them were in the same dataqualityinfo node(s) with dataQuality information nodes. Now lineage statements are parsed separately and returned outside of DataQuality object (reports).
Response:
dataQualities: [DataQuality]
lineageStatements:[String]
(Previously: dataQualityObject.dataQualityNodes:[DataQuality])

Quantitative result's error statistic and value were parsed wrongly.
Removed some unused code and also some refactoring.