### PR TITLE
Add WGS84 bounds check to WKTHelper.transformLayerCoverage(String wkt, String targetSRS)

### DIFF
--- a/service-map/src/main/java/fi/nls/oskari/map/geometry/GeometryHelper.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/geometry/GeometryHelper.java
@@ -31,7 +31,7 @@ public class GeometryHelper {
      * Linear interpolation for a LineString
      * @param line
      *      LineString to interpolate
-     * @param threshhold
+     * @param threshold
      *      if the distance between two consecutive points in the linestring is greater
      *      than this value new points will be added to the returned coordinate sequence
      * @param gf
@@ -39,7 +39,7 @@ public class GeometryHelper {
      * @return
      *      sequence of coordinates that
      */
-    public static CoordinateSequence interpolateLinear(LineString line, double threshhold, GeometryFactory gf) {
+    public static CoordinateSequence interpolateLinear(LineString line, double threshold, GeometryFactory gf) {
         double[] tempPointArray = new double[128];
         int i = 0;
 
@@ -56,7 +56,7 @@ public class GeometryHelper {
             double dx = x1 - x0;
             double dy = y1 - y0;
             if (dy == 0) {
-                int nSeg = (int) Math.ceil(Math.abs(dx) / threshhold);
+                int nSeg = (int) Math.ceil(Math.abs(dx) / threshold);
                 for (int j = 0; j < nSeg - 1; j++) {
                     if (i == tempPointArray.length) {
                         tempPointArray = grow(tempPointArray);
@@ -66,7 +66,7 @@ public class GeometryHelper {
                     tempPointArray[i++] = y0;
                 }
             } else if (dx == 0) {
-                int nSeg = (int) Math.ceil(Math.abs(dy) / threshhold);
+                int nSeg = (int) Math.ceil(Math.abs(dy) / threshold);
                 for (int j = 0; j < nSeg - 1; j++) {
                     if (i == tempPointArray.length) {
                         tempPointArray = grow(tempPointArray);
@@ -76,7 +76,7 @@ public class GeometryHelper {
                 }
             } else {
                 double c = Math.sqrt(dx * dx + dy * dy);
-                int nSeg = (int) Math.ceil(c / threshhold);
+                int nSeg = (int) Math.ceil(c / threshold);
                 for (int j = 0; j < nSeg - 1; j++) {
                     if (i == tempPointArray.length) {
                         tempPointArray = grow(tempPointArray);

--- a/service-map/src/main/java/fi/nls/oskari/map/geometry/GeometryHelper.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/geometry/GeometryHelper.java
@@ -1,5 +1,6 @@
 package fi.nls.oskari.map.geometry;
 
+import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.CoordinateSequence;
 import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.geom.LineString;
@@ -109,6 +110,29 @@ public class GeometryHelper {
         double[] arr2 = new double[len * 2];
         System.arraycopy(arr, 0, arr2, 0, len);
         return arr2;
+    }
+
+    public static boolean isWithin(final CoordinateSequence cs,
+            final double minX, final double minY,
+            final double maxX, final double maxY) {
+        if (maxX < minX) {
+            throw new IllegalArgumentException("maxX < minX");
+        }
+        if (maxY < minY) {
+            throw new IllegalArgumentException("maxY < minY");
+        }
+        for (int i = 0; i < cs.size(); i++) {
+            Coordinate c = cs.getCoordinate(i);
+            double x = c.x;
+            double y = c.y;
+            if (x < minX || x > maxX) {
+                return false;
+            }
+            if (y < minY || y > maxY) {
+                return false;
+            }
+        }
+        return true;
     }
 
 }

--- a/service-map/src/main/java/fi/nls/oskari/map/geometry/WKTHelper.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/geometry/WKTHelper.java
@@ -24,7 +24,7 @@ public class WKTHelper {
     private static final Logger log = LogFactory.getLogger(WKTHelper.class);
     public final static CoordinateReferenceSystem CRS_EPSG_4326 = getCRS(PROJ_EPSG_4326);
 
-    private static final double INTEPOLATE_THRESHHOLD = 1.0;
+    private static final double INTEPOLATE_THRESHOLD = 1.0;
     private static final double WGS84_LON_MIN = -180.0;
     private static final double WGS84_LON_MAX=   180.0;
     private static final double WGS84_LAT_MIN =  -90.0;
@@ -102,7 +102,7 @@ public class WKTHelper {
             log.info("Layer coverage not within WGS84 bounds, not interpolating or transforming extent");
             return wkt;
         }
-        CoordinateSequence cs = GeometryHelper.interpolateLinear(exterior, INTEPOLATE_THRESHHOLD, gf);
+        CoordinateSequence cs = GeometryHelper.interpolateLinear(exterior, INTEPOLATE_THRESHOLD, gf);
         polygon = gf.createPolygon(cs);
         // input axis orientation is / must be x=lon y=lat
         CoordinateReferenceSystem targetCrs = getCRS(targetSRS);

--- a/service-map/src/test/java/fi/nls/oskari/map/geometry/GeometryHelperTest.java
+++ b/service-map/src/test/java/fi/nls/oskari/map/geometry/GeometryHelperTest.java
@@ -1,6 +1,9 @@
 package fi.nls.oskari.map.geometry;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.vividsolutions.jts.geom.CoordinateSequence;
 import com.vividsolutions.jts.geom.GeometryFactory;
@@ -28,4 +31,32 @@ public class GeometryHelperTest {
         }
     }
 
+    @Test
+    public void testIsWithin() {
+        GeometryFactory gf = new GeometryFactory();
+        CoordinateSequence cs = gf.getCoordinateSequenceFactory().create(2, 2);
+        cs.setOrdinate(0, 0, -180.0);
+        cs.setOrdinate(0, 1,  -45.0);
+        cs.setOrdinate(1, 0,  180.0);
+        cs.setOrdinate(1, 1,   45.0);
+
+        assertTrue("Happy", GeometryHelper.isWithin(cs,  -180.0, -45.0, 180.0,  45.0));
+        assertFalse("< minX", GeometryHelper.isWithin(cs, -160.0, -45.0, 180.0,  45.0));
+        assertFalse("> maxX", GeometryHelper.isWithin(cs, -180.0, -45.0, 130.0,  45.0));
+        assertFalse("< minY", GeometryHelper.isWithin(cs, -180.0,  20.0, 180.0,  45.0));
+        assertFalse("> maxY", GeometryHelper.isWithin(cs, -180.0, -45.0, 180.0,   5.0));
+
+        try {
+            GeometryHelper.isWithin(cs, 2, 5, 1, 6);
+            fail();
+        } catch (IllegalArgumentException ignore) {
+            assertEquals("maxX < minX", ignore.getMessage());
+        }
+        try {
+            GeometryHelper.isWithin(cs, 1, -5, 2, -7);
+            fail();
+        } catch (IllegalArgumentException ignore) {
+            assertEquals("maxY < minY", ignore.getMessage());
+        }
+    }
 }


### PR DESCRIPTION
`WKTHelper.transformLayerCoverage(String wkt, String targetSRS)` clearly states that it should only be called with a WKT that uses WGS84 coordinates, but it does not really enforce it. Interpolating with a tiny threshhold value of 1.0 (meant to be used only with deegrees) can easily lead to OutOfMemoryExceptions when executed on coordinates that are in a metric projection.

The logic is to check that for all coordinates in the WKT extent:
- the `x` value (first number) must be within [-180.0, 180.0]
- the `y` value (second) must be within [-90.0, 90.0].