### PR TITLE
Downgrade jQuery to fix myplaces (and break hierarchical layerselector)

### DIFF
--- a/servlet-map/src/main/resources/META-INF/resources/spring-map-jsp/index.jsp
+++ b/servlet-map/src/main/resources/META-INF/resources/spring-map-jsp/index.jsp
@@ -6,7 +6,7 @@
 <html>
 <head>
     <title>Oskari - ${viewName}</title>
-    <script type="text/javascript" src="//code.jquery.com/jquery-1.10.2.min.js">
+    <script type="text/javascript" src="//code.jquery.com/jquery-1.7.2.min.js">
     </script>
 
     <!-- ############# css ################# -->


### PR DESCRIPTION
jQuery was updated in PR #145 to accommodate a new library jstree used in the new bundle for hierarchical layerselector. Jstree requires the minimum jQuery version of 1.9.0, but the same version does no longer include some functions like jQuery.live() that is used in for example myplaces functionality. Therefore a quick fix for this is to downgrade jQuery while continuing the work on making the upgrade possible.