### PR TITLE
GetWSCapabilitiesHandler improvements

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/layer/GetWSCapabilitiesHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/GetWSCapabilitiesHandler.java
@@ -64,12 +64,12 @@ public class GetWSCapabilitiesHandler extends ActionHandler {
         ResponseHelper.writeResponse(params, capabilities);
     }
 
-    private JSONObject getCapabilities(String url, String type, String version,
+    protected JSONObject getCapabilities(String url, String type, String version,
             String user, String pw, String currentCrs) throws ActionException {
         try {
             switch (type) {
             case OskariLayer.TYPE_WMS:
-                return GetGtWMSCapabilities.getWMSCapabilities(url, user, pw, version, currentCrs);
+                return GetGtWMSCapabilities.getWMSCapabilities(capabilitiesService, url, user, pw, version, currentCrs);
             case OskariLayer.TYPE_WFS:
                 return GetGtWFSCapabilities.getWFSCapabilities(url, version, user, pw, currentCrs);
             case OskariLayer.TYPE_WMTS:

--- a/control-base/src/main/java/fi/nls/oskari/control/layer/GetWSCapabilitiesHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/GetWSCapabilitiesHandler.java
@@ -31,60 +31,60 @@ public class GetWSCapabilitiesHandler extends ActionHandler {
     private static final String PARM_PW = "pw";
     private static final String PARM_CRS = "crs";
 
-    private final CapabilitiesCacheService capabilitiesService = OskariComponentManager.getComponentOfType(CapabilitiesCacheService.class);
-    private String[] permittedRoles = new String[0];
+    private final CapabilitiesCacheService capabilitiesService;
+    private String[] permittedRoles;
+
+    public GetWSCapabilitiesHandler() {
+        this(OskariComponentManager.getComponentOfType(CapabilitiesCacheService.class));
+    }
+
+    public GetWSCapabilitiesHandler(CapabilitiesCacheService capabilitiesService) {
+        this.capabilitiesService = capabilitiesService;
+    }
 
     @Override
     public void init() {
-        super.init();
         permittedRoles = PropertyUtil.getCommaSeparatedList("actionhandler.GetWSCapabilitiesHandler.roles");
     }
 
     public void handleAction(ActionParameters params) throws ActionException {
-
         if (!params.getUser().hasAnyRoleIn(permittedRoles)) {
             throw new ActionDeniedException("Unauthorized user tried to proxy via capabilities");
         }
+
         final String url = params.getRequiredParam(PARM_URL).trim();
-        final String layerType = params.getHttpParam(PARM_TYPE, OskariLayer.TYPE_WMS);
+        final String type = params.getHttpParam(PARM_TYPE, OskariLayer.TYPE_WMS);
         final String version = params.getHttpParam(PARM_VERSION, "");
         final String user = params.getHttpParam(PARM_USER, "");
         final String pw = params.getHttpParam(PARM_PW, "");
         final String currentCrs = params.getHttpParam(PARM_CRS, "EPSG:3067");
 
-        log.debug("Trying to get capabilities for type:", layerType, "with url:", url);
+        log.debug("Trying to get capabilities for type:", type, "with url:", url);
+        JSONObject capabilities = getCapabilities(url, type, version, user, pw, currentCrs);
+        ResponseHelper.writeResponse(params, capabilities);
+    }
+
+    private JSONObject getCapabilities(String url, String type, String version,
+            String user, String pw, String currentCrs) throws ActionException {
         try {
-            if(OskariLayer.TYPE_WMS.equals(layerType)) {
-                // New method for parsing WMSCetGapabilites to Oskari layers structure
-                final JSONObject capabilities = GetGtWMSCapabilities.getWMSCapabilities(url, user, pw, version, currentCrs);
-                ResponseHelper.writeResponse(params, capabilities);
+            switch (type) {
+            case OskariLayer.TYPE_WMS:
+                return GetGtWMSCapabilities.getWMSCapabilities(url, user, pw, version, currentCrs);
+            case OskariLayer.TYPE_WFS:
+                return GetGtWFSCapabilities.getWFSCapabilities(url, version, user, pw, currentCrs);
+            case OskariLayer.TYPE_WMTS:
+                OskariLayerCapabilities caps = capabilitiesService.getCapabilities(url, OskariLayer.TYPE_WMTS, user, pw, version);
+                String capabilitiesXML = caps.getData();
+                WMTSCapabilities wmtsCaps = WMTSCapabilitiesParser.parseCapabilities(capabilitiesXML);
+                JSONObject resultJSON = WMTSCapabilitiesParser.asJSON(wmtsCaps, url, currentCrs);
+                JSONHelper.putValue(resultJSON, "xml", caps.getData());
+                return resultJSON;
+            default:
+                throw new ActionParamsException("Couldn't determine operation based on parameters");
             }
-            else {
-                if (OskariLayer.TYPE_WMTS.equals(layerType)) {
-                    // setup capabilities URL
-                    OskariLayerCapabilities caps  = capabilitiesService.getCapabilities(url, OskariLayer.TYPE_WMTS, user, pw, version);
-                    String capabilitiesXML = caps.getData();
-                    if(capabilitiesXML == null || capabilitiesXML.trim().isEmpty()) {
-                        // retry from service - might get empty xml from db
-                        caps = capabilitiesService.getCapabilities(url, OskariLayer.TYPE_WMTS, user, pw, version, true);
-                        capabilitiesXML = caps.getData();
-                    }
-                    WMTSCapabilities wmtsCaps = WMTSCapabilitiesParser.parseCapabilities(capabilitiesXML);
-                    JSONObject resultJSON = WMTSCapabilitiesParser.asJSON(wmtsCaps, url, currentCrs);
-                    JSONHelper.putValue(resultJSON, "xml", caps.getData());
-                    ResponseHelper.writeResponse(params, resultJSON);
-                }
-                else if(OskariLayer.TYPE_WFS.equals(layerType)) {
-                    // New method for parsing WFSCetGapabilites to Oskari layers structure
-                    final JSONObject capabilities = GetGtWFSCapabilities.getWFSCapabilities(url, version, user, pw, currentCrs);
-                    ResponseHelper.writeResponse(params, capabilities);
-                }
-                else {
-                    throw new ActionParamsException("Couldn't determine operation based on parameters");
-                }
-            }
-        } catch (Exception ee) {
-            throw new ActionException("WMS Capabilities parsing failed: ", ee);
+        } catch (Exception e) {
+            throw new ActionException("WMS Capabilities parsing failed: ", e);
         }
     }
+
 }

--- a/service-map/src/main/java/fi/nls/oskari/wms/GetGtWMSCapabilities.java
+++ b/service-map/src/main/java/fi/nls/oskari/wms/GetGtWMSCapabilities.java
@@ -9,7 +9,6 @@ import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.map.layer.formatters.LayerJSONFormatterWMS;
 import fi.nls.oskari.service.ServiceException;
 import fi.nls.oskari.service.capabilities.CapabilitiesCacheService;
-import fi.nls.oskari.service.capabilities.CapabilitiesCacheServiceMybatisImpl;
 import fi.nls.oskari.service.capabilities.OskariLayerCapabilities;
 import fi.nls.oskari.util.JSONHelper;
 import fi.nls.oskari.util.PropertyUtil;
@@ -18,15 +17,23 @@ import org.geotools.data.ows.WMSCapabilities;
 import org.geotools.data.wms.xml.MetadataURL;
 import org.geotools.data.wms.xml.WMSSchema;
 import org.geotools.xml.DocumentFactory;
+import org.geotools.xml.XMLSAXHandler;
 import org.geotools.xml.handlers.DocumentHandler;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.xml.sax.SAXException;
+
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.logging.Level;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
 
 /**
  * Methods for parsing WMS capabilities data
@@ -71,13 +78,12 @@ public class GetGtWMSCapabilities {
      * @return
      * @throws ServiceException
      */
-    public static JSONObject getWMSCapabilities(final String rurl, final String user, final String pwd,
-                                                final String version, final String currentCrs)
-            throws ServiceException {
+    public static JSONObject getWMSCapabilities(final CapabilitiesCacheService service,
+            final String rurl, final String user, final String pwd,
+            final String version, final String currentCrs) throws ServiceException {
         try {
             /*check url validity*/
             new URL(rurl);
-            CapabilitiesCacheService service = new CapabilitiesCacheServiceMybatisImpl();
             OskariLayerCapabilities capabilities = service.getCapabilities(rurl, OskariLayer.TYPE_WMS, user, pwd, version);
             String capabilitiesXML = capabilities.getData();
             if(capabilitiesXML == null || capabilitiesXML.trim().isEmpty()) {
@@ -349,4 +355,5 @@ OnlineResource xlink:type="simple" xlink:href="http://www.paikkatietohakemisto.f
         }
         return null;
     }
+
 }


### PR DESCRIPTION
* Add possibility to inject the `CapabilitiesCacheService` via constructor.
* Re-use the same `CapabilitiesCacheService` in `GetGtWMSCapabilities.getWMSCapabilities()`
* Refactor `GetWSCapabilitiesHandler` to use switch (String) and remove double checking whether or not WMTS Capabilities was missing from the cache (`CapabilitiesService#getCapabilities()` checks this already)