### PR TITLE
Add myplaces2 handling for myplaces3

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/view/modifier/bundle/MapfullHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/view/modifier/bundle/MapfullHandler.java
@@ -25,6 +25,7 @@ import fi.nls.oskari.util.ConversionHelper;
 import fi.nls.oskari.util.JSONHelper;
 import fi.nls.oskari.view.modifier.ModifierException;
 import fi.nls.oskari.view.modifier.ModifierParams;
+import fi.nls.oskari.view.modifier.ViewModifier;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -61,6 +62,7 @@ public class MapfullHandler extends BundleHandler {
     private static final String PREFIX_MYPLACES = "myplaces_";
     private static final String PREFIX_ANALYSIS = "analysis_";
     private static final String PREFIX_USERLAYERS = "userlayer_";
+    private static final Set<String> BUNDLES_HANDLING_MYPLACES_LAYERS = ConversionHelper.asSet(ViewModifier.BUNDLE_MYPLACES2, ViewModifier.BUNDLE_MYPLACES3);
 
     private static final String PLUGIN_LAYERSELECTION = "Oskari.mapframework.bundle.mapmodule.plugin.LayerSelectionPlugin";
     private static final String PLUGIN_GEOLOCATION = "Oskari.mapframework.bundle.mapmodule.plugin.GeoLocationPlugin";
@@ -332,6 +334,14 @@ public class MapfullHandler extends BundleHandler {
         }
     }
 
+    private static boolean isMyplacesBundlePresent(Set<String> bundleIdList) {
+        for(String bundleId : BUNDLES_HANDLING_MYPLACES_LAYERS) {
+            if(bundleIdList.contains(bundleId)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     private static void appendMyPlacesLayers(final JSONArray layerList,
                                              final List<Long> publishedMyPlaces,
@@ -344,7 +354,7 @@ public class MapfullHandler extends BundleHandler {
         if (publishedMyPlaces.isEmpty()) {
             return;
         }
-        final boolean myPlacesBundlePresent = bundleIds.contains(BUNDLE_MYPLACES2);
+        final boolean myPlacesBundlePresent = isMyplacesBundlePresent(bundleIds);
         // get myplaces categories from service and generate layer jsons
         final String uuid = user.getUuid();
         final List<MyPlaceCategory> myPlacesLayers = myPlaceService

--- a/control-myplaces/src/main/java/fi/nls/oskari/control/view/modifier/Myplaces3Handler.java
+++ b/control-myplaces/src/main/java/fi/nls/oskari/control/view/modifier/Myplaces3Handler.java
@@ -1,0 +1,8 @@
+package fi.nls.oskari.control.view.modifier;
+
+import fi.nls.oskari.annotation.OskariViewModifier;
+
+@OskariViewModifier("myplaces3")
+public class Myplaces3Handler extends Myplaces2Handler {
+    // just do the same stuff as for myplaces2
+}

--- a/service-control/src/main/java/fi/nls/oskari/view/modifier/ViewModifier.java
+++ b/service-control/src/main/java/fi/nls/oskari/view/modifier/ViewModifier.java
@@ -18,6 +18,7 @@ public abstract class ViewModifier {
     
     public static final String BUNDLE_MAPFULL = "mapfull";
     public static final String BUNDLE_MYPLACES2 = "myplaces2";
+    public static final String BUNDLE_MYPLACES3 = "myplaces3";
     public static final String BUNDLE_INFOBOX = "infobox";
     public static final String BUNDLE_POSTPROCESSOR = "postprocessor";
     public static final String BUNDLE_ADMINLAYERSELECTOR = "admin-layerselector";


### PR DESCRIPTION
The "my places" functionality has some special handling if the layers are used in the geoportal view or a published map. Since the OpenLayers 4 version of my places functionality is added as a new bundle named myplaces3 it requires the same handling as myplaces2 bundle.

For users this fixes an issue where myplaces layers are referenced in a link or in a saved view. Without this handling layers are not listed properly and the frontend console has warnings about duplicate layer ids. The layer that is part of the initial "selected layers" will prevent any further my places layers to be added as it's already registered as a WMS-layer when the frontend tries to add it as a "my places" layer.

This is a quick fix for the issue. A better one would be to rename myplaces3 -> myplaces2 as they both share the same config and other characteristics. The other is an OL4 implementation of the previous functionality. 