### PR TITLE
Decrease time spent in GetHierarchicalMapLayerGroups

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/layer/GetMapLayerGroupsHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/GetMapLayerGroupsHandler.java
@@ -4,12 +4,12 @@ import static fi.nls.oskari.control.ActionConstants.PARAM_LANGUAGE;
 import static fi.nls.oskari.control.ActionConstants.PARAM_SRS;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
+import fi.nls.oskari.map.layer.OskariLayerService;
 import fi.nls.oskari.map.layer.OskariLayerServiceIbatisImpl;
-import fi.nls.oskari.util.ConversionHelper;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -17,11 +17,17 @@ import org.json.JSONObject;
 import fi.mml.map.mapwindow.service.db.OskariMapLayerGroupService;
 import fi.mml.map.mapwindow.service.db.OskariMapLayerGroupServiceIbatisImpl;
 import fi.mml.map.mapwindow.util.OskariLayerWorker;
+import fi.mml.map.mapwindow.util.PermissionCollection;
+import fi.mml.portti.domain.permissions.Permissions;
+import fi.mml.portti.service.db.permissions.PermissionsService;
+import fi.mml.portti.service.db.permissions.PermissionsServiceIbatisImpl;
 import fi.nls.oskari.annotation.OskariActionRoute;
 import fi.nls.oskari.control.ActionException;
 import fi.nls.oskari.control.ActionHandler;
 import fi.nls.oskari.control.ActionParameters;
+import fi.nls.oskari.domain.User;
 import fi.nls.oskari.domain.map.MaplayerGroup;
+import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.util.ResponseHelper;
@@ -35,7 +41,17 @@ public class GetMapLayerGroupsHandler extends ActionHandler {
     private static Logger log = LogFactory.getLogger(GetMapLayerGroupsHandler.class);
 
     private static final String KEY_GROUPS = "groups";
+    private OskariLayerService layerService;
+    private PermissionsService permissionsService;
     private OskariMapLayerGroupService oskariMapLayerGroupService;
+
+    public void setLayerService(OskariLayerService layerService) {
+        this.layerService = layerService;
+    }
+
+    public void setPermissionsService(PermissionsService permissionsService) {
+        this.permissionsService = permissionsService;
+    }
 
     public void setOskariMapLayerGroupService(final OskariMapLayerGroupService service) {
         oskariMapLayerGroupService = service;
@@ -43,7 +59,13 @@ public class GetMapLayerGroupsHandler extends ActionHandler {
 
     @Override
     public void init() {
-        // setup service if it hasn't been initialized
+        // setup services if they haven't been initialized
+        if (layerService == null) {
+            setLayerService(new OskariLayerServiceIbatisImpl());
+        }
+        if (permissionsService == null) {
+            setPermissionsService(new PermissionsServiceIbatisImpl());
+        }
         if (oskariMapLayerGroupService == null) {
             setOskariMapLayerGroupService(new OskariMapLayerGroupServiceIbatisImpl());
         }
@@ -51,8 +73,23 @@ public class GetMapLayerGroupsHandler extends ActionHandler {
 
     @Override
     public void handleAction(ActionParameters params) throws ActionException {
+        final User user = params.getUser();
+        final String lang = params.getHttpParam(PARAM_LANGUAGE, params.getLocale().getLanguage());
+        final String crs = params.getHttpParam(PARAM_SRS);
+        final boolean isSecure = false;
+        final boolean isPublished = false;
+
+        final String permissionType = OskariLayerWorker.getPermissionType(isPublished);
+        final List<String> resources = permissionsService.getResourcesWithGrantedPermissions(Permissions.RESOURCE_TYPE_MAP_LAYER, user, permissionType);
+
+        final Map<Integer, OskariLayer> layersById = layerService.findAll().stream()
+                .filter(layer -> layer.getParentId() != -1 || resources.contains(OskariLayerWorker.getPermissionKey(layer)))
+                .collect(Collectors.toMap(layer -> layer.getId(), layer -> layer));
+
+        final PermissionCollection permissionCollection = OskariLayerWorker.getPermissionCollection(user);
+
         log.debug("Getting layer groups");
-        JSONArray json = getGroupJSON(-1, params);
+        JSONArray json = getGroupJSON(layersById, user, lang, isSecure, crs, resources, permissionCollection, -1);
         log.debug("Got layer groups");
         ResponseHelper.writeResponse(params, json);
     }
@@ -61,32 +98,48 @@ public class GetMapLayerGroupsHandler extends ActionHandler {
     /**
      * Get group JSON recursive
      *
-     * @param parentId parent id
+     * @param parentGroupId parent id
      * @param params   params
      * @return
      * @throws ActionException
      */
-    private JSONArray getGroupJSON(int parentId, ActionParameters params) throws ActionException {
-        final String lang = params.getHttpParam(PARAM_LANGUAGE, params.getLocale().getLanguage());
-        List<MaplayerGroup> layerGroups = oskariMapLayerGroupService.findByParentId(parentId);
-        JSONArray json = new JSONArray();
+    private JSONArray getGroupJSON(final Map<Integer, OskariLayer> layersById, final User user,
+            final String lang, final boolean isSecure, final String crs, final List<String> resources,
+            final PermissionCollection permissionCollection, int parentGroupId) throws ActionException {
         try {
-            // Loop groups and their subgroups (max depth is 3)
+            List<MaplayerGroup> layerGroups = oskariMapLayerGroupService.findByParentId(parentGroupId);
+            if (layerGroups.isEmpty()) {
+                return null;
+            }
+
+            JSONArray json = new JSONArray();
             for (MaplayerGroup group : layerGroups) {
-                final JSONObject layers = OskariLayerWorker.getListOfMapLayersByIdList(oskariMapLayerGroupService.findMaplayersByGroup(group.getId()), params.getUser(), lang, params.getHttpParam(PARAM_SRS));
+                int groupId = group.getId();
+
+                List<Integer> layerIds = oskariMapLayerGroupService.findMaplayersByGroup(groupId);
+                List<OskariLayer> groupsLayers = new ArrayList<>();
+                for (Integer layerId : layerIds) {
+                    OskariLayer layer = layersById.get(layerId);
+                    if (layer != null) {
+                        groupsLayers.add(layer);
+                    }
+                }
+
+                final JSONObject layers = OskariLayerWorker.getListOfMapLayers(groupsLayers, user, lang, isSecure, crs, resources, permissionCollection);
                 JSONArray layerList = layers.optJSONArray(OskariLayerWorker.KEY_LAYERS);
                 group.setLayers(layerList);
 
                 JSONObject groupJson = group.getAsJSON();
-                JSONArray subGroupsJSON = getGroupJSON(group.getId(), params);
-                groupJson.put(KEY_GROUPS, subGroupsJSON);
+                JSONArray subGroupsJSON = getGroupJSON(layersById, user, lang, isSecure, crs, resources, permissionCollection, groupId);
+                if (subGroupsJSON != null) {
+                    groupJson.put(KEY_GROUPS, subGroupsJSON);
+                }
                 json.put(groupJson);
             }
+            return json;
         } catch (JSONException ex) {
             throw new ActionException("Cannot get groupped layerlist", ex);
         }
-        return json;
     }
-
 
 }

--- a/control-base/src/main/java/fi/nls/oskari/control/layer/GetMapLayerGroupsHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/GetMapLayerGroupsHandler.java
@@ -108,10 +108,6 @@ public class GetMapLayerGroupsHandler extends ActionHandler {
             final PermissionCollection permissionCollection, int parentGroupId) throws ActionException {
         try {
             List<MaplayerGroup> layerGroups = oskariMapLayerGroupService.findByParentId(parentGroupId);
-            if (layerGroups.isEmpty()) {
-                return null;
-            }
-
             JSONArray json = new JSONArray();
             for (MaplayerGroup group : layerGroups) {
                 int groupId = group.getId();
@@ -130,10 +126,10 @@ public class GetMapLayerGroupsHandler extends ActionHandler {
                 group.setLayers(layerList);
 
                 JSONObject groupJson = group.getAsJSON();
+
                 JSONArray subGroupsJSON = getGroupJSON(layersById, user, lang, isSecure, crs, resources, permissionCollection, groupId);
-                if (subGroupsJSON != null) {
-                    groupJson.put(KEY_GROUPS, subGroupsJSON);
-                }
+                groupJson.put(KEY_GROUPS, subGroupsJSON);
+
                 json.put(groupJson);
             }
             return json;

--- a/service-map/src/main/java/fi/mml/map/mapwindow/util/PermissionCollection.java
+++ b/service-map/src/main/java/fi/mml/map/mapwindow/util/PermissionCollection.java
@@ -1,0 +1,38 @@
+package fi.mml.map.mapwindow.util;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class PermissionCollection {
+
+    private final Set<String> permissionsList;
+    private final Set<String> downloadPermissionsList;
+    private final Set<String> editAccessList;
+    private final Map<String, List<String>> dynamicPermissions;
+
+    public PermissionCollection(Set<String> permissionsList, Set<String> downloadPermissionsList,
+            Set<String> editAccessList, Map<String, List<String>> dynamicPermissions) {
+        this.permissionsList = permissionsList;
+        this.downloadPermissionsList = downloadPermissionsList;
+        this.editAccessList = editAccessList;
+        this.dynamicPermissions = dynamicPermissions;
+    }
+
+    public Set<String> getPermissionsList() {
+        return permissionsList;
+    }
+
+    public Set<String> getDownloadPermissionsList() {
+        return downloadPermissionsList;
+    }
+
+    public Set<String> getEditAccessList() {
+        return editAccessList;
+    }
+
+    public Map<String, List<String>> getDynamicPermissions() {
+        return dynamicPermissions;
+    }
+
+}


### PR DESCRIPTION
GetHierarchicalMapLayerGroups reloads all the permissions from the database for each and every group and their subgroup. This PR changes the logic so that the permissions are only loaded once per Action call. The price to pay is that the function header for the recursive function
`GetMapLayerGroupsHandler#getGroupJSON()` got really ugly. `OskariLayerWorker` was already passing Sets of permissions around functions. A `PermissionCollection` class is introduced here, with the sole purpose of wrapping those permission Sets into a single object that is easier to pass around.

The effect is quite noticeable (these are from my dev environment with no js minifying or gzip enabled):
Current version (Waiting 21.22s):
![getlayers](https://user-images.githubusercontent.com/2799041/38057912-acd517c4-32e9-11e8-82c5-eefe8a328592.png)
After (Waiting 4.05s):
![getlayers2](https://user-images.githubusercontent.com/2799041/38057918-b0b39230-32e9-11e8-9695-80b47b01ebea.png)

