### PR TITLE
Calculate UserLayer extent one time when UserLayer is created

### DIFF
--- a/content-resources/src/main/java/flyway/userlayer/V1_0_11__populate_userlayer_wkt.java
+++ b/content-resources/src/main/java/flyway/userlayer/V1_0_11__populate_userlayer_wkt.java
@@ -1,0 +1,63 @@
+package flyway.userlayer;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
+
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.util.PropertyUtil;
+
+public class V1_0_11__populate_userlayer_wkt implements JdbcMigration {
+
+    private static final Logger LOG = LogFactory.getLogger(V1_0_11__populate_userlayer_wkt.class);
+    private static final int WGS84_SRID = 4326;
+
+    public void migrate(Connection connection) throws Exception {
+        //if srs is not found from properties, tries to find from oskari_maplayer
+        String srsName = PropertyUtil.get("oskari.native.srs", getSrsName(connection));
+        if (srsName == null){
+            LOG.error("Cannot get srs name for userlayer data");
+            throw new IllegalArgumentException("Cannot get srs name for userlayer data");
+        }
+        int srid = getSRID(srsName);
+        String geometryColumn = PropertyUtil.get("userlayer.geometry.name", "geometry");
+
+        String subselect = String.format("SELECT ST_AsText(ST_Transform(ST_SetSRID(ST_Extent(b.%s),%d),%d)) "
+                + "FROM user_layer_data b "
+                + "WHERE a.id = b.user_layer_id",
+                geometryColumn, srid, WGS84_SRID);
+        String sql = "UPDATE user_layer a SET wkt = (" + subselect + ")";
+        LOG.debug(sql);
+
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            int updated = ps.executeUpdate();
+            LOG.info("Updated wkt for ", updated, "user_layer rows");
+        }
+    }
+
+    private int getSRID(String srsName) {
+        int i = srsName.lastIndexOf(':');
+        int srid = Integer.parseInt(srsName.substring(i + 1));
+        LOG.debug("Parsed SRID", srid, "from", srsName);
+        return srid;
+    }
+
+    private String getSrsName(Connection conn) throws SQLException {
+        int baselayerId = PropertyUtil.getOptional("userlayer.baselayer.id", -1);
+        String sql = "SELECT srs_name FROM oskari_maplayer WHERE id=?";
+        try (PreparedStatement statement = conn.prepareStatement(sql)) {
+            statement.setInt(1, baselayerId);
+            try (ResultSet rs = statement.executeQuery()) {
+                if (rs.next()){
+                    return rs.getString("srs_name");
+                }
+                return null;
+            }
+        }
+    }
+
+}

--- a/content-resources/src/main/java/flyway/userlayer/V1_0_11__populate_userlayer_wkt.java
+++ b/content-resources/src/main/java/flyway/userlayer/V1_0_11__populate_userlayer_wkt.java
@@ -17,8 +17,7 @@ public class V1_0_11__populate_userlayer_wkt implements JdbcMigration {
     private static final int WGS84_SRID = 4326;
 
     public void migrate(Connection connection) throws Exception {
-        //if srs is not found from properties, tries to find from oskari_maplayer
-        String srsName = PropertyUtil.get("oskari.native.srs", getSrsName(connection));
+        String srsName = getSrsName(connection);
         if (srsName == null){
             LOG.error("Cannot get srs name for userlayer data");
             throw new IllegalArgumentException("Cannot get srs name for userlayer data");
@@ -47,6 +46,11 @@ public class V1_0_11__populate_userlayer_wkt implements JdbcMigration {
     }
 
     private String getSrsName(Connection conn) throws SQLException {
+        String fromProperty = PropertyUtil.getOptionalNonLocalized("oskari.native.srs");
+        if (fromProperty != null && !fromProperty.isEmpty()) {
+            return fromProperty;
+        }
+        LOG.debug("Could not find 'oskari.native.srs' property");
         int baselayerId = PropertyUtil.getOptional("userlayer.baselayer.id", -1);
         String sql = "SELECT srs_name FROM oskari_maplayer WHERE id=?";
         try (PreparedStatement statement = conn.prepareStatement(sql)) {

--- a/content-resources/src/main/resources/flyway/userlayer/V1_0_10__alter_table_user_layer_add_column_wkt.sql
+++ b/content-resources/src/main/resources/flyway/userlayer/V1_0_10__alter_table_user_layer_add_column_wkt.sql
@@ -1,0 +1,1 @@
+ALTER TABLE user_layer ADD COLUMN wkt VARCHAR(512) DEFAULT ''::varchar;

--- a/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java
+++ b/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java
@@ -26,9 +26,7 @@ import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.referencing.CRS;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
-import org.opengis.referencing.operation.TransformException;
 import org.oskari.map.userlayer.input.FeatureCollectionParser;
 import org.oskari.map.userlayer.input.FeatureCollectionParsers;
 import org.oskari.map.userlayer.service.UserLayerDataService;
@@ -319,13 +317,10 @@ public class CreateUserLayerHandler extends ActionHandler {
             throw new ActionException("Failed to encode feature as GeoJSON");
         } catch (ServiceException e) {
             throw new ActionException("Failed to store features to database");
-        } catch (FactoryException | TransformException e) {
-            throw new ActionException("Failed to transform bounding extent");
         }
     }
 
-    private UserLayer createUserLayer(SimpleFeatureCollection fc, String uuid, Map<String, String> formParams)
-            throws FactoryException, TransformException {
+    private UserLayer createUserLayer(SimpleFeatureCollection fc, String uuid, Map<String, String> formParams) {
         String name = formParams.get(KEY_NAME);
         String desc = formParams.get(KEY_DESC);
         String source = formParams.get(KEY_SOURCE);

--- a/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java
+++ b/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java
@@ -26,7 +26,9 @@ import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.referencing.CRS;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.referencing.operation.TransformException;
 import org.oskari.map.userlayer.input.FeatureCollectionParser;
 import org.oskari.map.userlayer.input.FeatureCollectionParsers;
 import org.oskari.map.userlayer.service.UserLayerDataService;
@@ -317,10 +319,13 @@ public class CreateUserLayerHandler extends ActionHandler {
             throw new ActionException("Failed to encode feature as GeoJSON");
         } catch (ServiceException e) {
             throw new ActionException("Failed to store features to database");
+        } catch (FactoryException | TransformException e) {
+            throw new ActionException("Failed to transform bounding extent");
         }
     }
 
-    private UserLayer createUserLayer(SimpleFeatureCollection fc, String uuid, Map<String, String> formParams) {
+    private UserLayer createUserLayer(SimpleFeatureCollection fc, String uuid, Map<String, String> formParams)
+            throws FactoryException, TransformException {
         String name = formParams.get(KEY_NAME);
         String desc = formParams.get(KEY_DESC);
         String source = formParams.get(KEY_SOURCE);

--- a/control-userlayer/src/main/java/org/oskari/control/userlayer/EditUserLayerHandler.java
+++ b/control-userlayer/src/main/java/org/oskari/control/userlayer/EditUserLayerHandler.java
@@ -1,4 +1,4 @@
-package fi.nls.oskari.control.data;
+package org.oskari.control.userlayer;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -13,7 +13,6 @@ import fi.nls.oskari.control.ActionParamsException;
 import fi.nls.oskari.domain.map.userlayer.UserLayer;
 import fi.nls.oskari.domain.map.userlayer.UserLayerStyle;
 import fi.nls.oskari.service.OskariComponentManager;
-import fi.nls.oskari.util.ConversionHelper;
 import fi.nls.oskari.util.JSONHelper;
 import fi.nls.oskari.util.ResponseHelper;
 import org.oskari.map.userlayer.service.UserLayerDataService;

--- a/control-userlayer/src/main/java/org/oskari/control/userlayer/GetUserLayerStyleHandler.java
+++ b/control-userlayer/src/main/java/org/oskari/control/userlayer/GetUserLayerStyleHandler.java
@@ -1,4 +1,4 @@
-package org.oskari.control.userlayer.data;
+package org.oskari.control.userlayer;
 
 import org.json.JSONObject;
 
@@ -11,7 +11,6 @@ import fi.nls.oskari.control.ActionParamsException;
 import fi.nls.oskari.domain.map.userlayer.UserLayerStyle;
 import fi.nls.oskari.domain.map.userlayer.UserLayer;
 import fi.nls.oskari.service.OskariComponentManager;
-import fi.nls.oskari.util.ConversionHelper;
 import fi.nls.oskari.util.ResponseHelper;
 import org.oskari.map.userlayer.service.UserLayerDbService;
 

--- a/control-userlayer/src/main/java/org/oskari/control/userlayer/GetUserLayersHandler.java
+++ b/control-userlayer/src/main/java/org/oskari/control/userlayer/GetUserLayersHandler.java
@@ -2,6 +2,7 @@ package org.oskari.control.userlayer;
 
 import fi.mml.map.mapwindow.util.OskariLayerWorker;
 import fi.nls.oskari.annotation.OskariActionRoute;
+import fi.nls.oskari.control.ActionConstants;
 import fi.nls.oskari.control.ActionException;
 import fi.nls.oskari.control.ActionHandler;
 import fi.nls.oskari.control.ActionParameters;
@@ -25,7 +26,6 @@ import java.util.List;
 public class GetUserLayersHandler extends ActionHandler {
 
     private UserLayerDbService userLayerService;
-    private final UserLayerDataService userLayerDataService = new UserLayerDataService();
 
     private static final String JSKEY_USERLAYERS = "userlayers";
 
@@ -43,12 +43,14 @@ public class GetUserLayersHandler extends ActionHandler {
         final User user = params.getUser();
         if (!user.isGuest()) {
             final List<UserLayer> list = userLayerService.getUserLayerByUuid(user.getUuid());
-            final OskariLayer baseLayer = userLayerDataService.getBaseLayer();
+            final OskariLayer baseLayer = UserLayerDataService.getBaseLayer();
             for (UserLayer ul : list) {
                 // Parse userlayer data to userlayer
-                final JSONObject userLayer = userLayerDataService.parseUserLayer2JSON(ul, baseLayer);
+                final JSONObject userLayer = UserLayerDataService.parseUserLayer2JSON(ul, baseLayer);
                 JSONObject permissions = OskariLayerWorker.getAllowedPermissions();
                 JSONHelper.putValue(userLayer, "permissions", permissions);
+                // transform WKT for layers now that we know SRS
+                OskariLayerWorker.transformWKTGeom(userLayer, params.getHttpParam(ActionConstants.PARAM_SRS));
                 layers.put(userLayer);
             }
         }

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/userlayer/UserLayer.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/userlayer/UserLayer.java
@@ -77,10 +77,13 @@ public class UserLayer extends UserDataLayer {
     public void setFeatures_skipped (int noGeometry){
         this.features_skipped = noGeometry;
     }
-    public String getWkt (){
-        return this.wkt;
+
+    public String getWkt() {
+        return wkt;
     }
-    public void setWkt (String wkt){
+
+    public void setWkt(String wkt) {
         this.wkt = wkt;
     }
+
 }

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERLAYER.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERLAYER.java
@@ -51,7 +51,7 @@ public class LayerJSONFormatterUSERLAYER extends LayerJSONFormatter {
         // user layer rendering url - override DB url if property is defined
         JSONHelper.putValue(layerJson, "url", getUserLayerTileUrl());
         JSONHelper.putValue(layerJson, "renderingElement", userlayerRenderingElement);
-        // JSONHelper.putValue(layerJson, "geom", userLayerService.getUserLayerExtent(ulayer.getId()));
+        JSONHelper.putValue(layerJson, "geom", ulayer.getWkt());
 
         return layerJson;
     }

--- a/service-userlayer/src/main/java/org/oskari/map/userlayer/service/UserLayerDataService.java
+++ b/service-userlayer/src/main/java/org/oskari/map/userlayer/service/UserLayerDataService.java
@@ -73,7 +73,7 @@ public class UserLayerDataService {
                     extentWGS84.getMaxY());
         } catch (FactoryException | TransformException e) {
             // This shouldn't really happen since EPSG:4326 shouldn't be problematic
-            // and converting to it should always work. But if it does happen
+            // and transforming into it should always work. But if it does happen
             // there's probably something wrong with the geometries of the features
             throw new ServiceRuntimeException("Failed to transform bounding extent", e);
         }

--- a/service-userlayer/src/main/java/org/oskari/map/userlayer/service/UserLayerDataService.java
+++ b/service-userlayer/src/main/java/org/oskari/map/userlayer/service/UserLayerDataService.java
@@ -1,8 +1,19 @@
 package org.oskari.map.userlayer.service;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.domain.map.userlayer.UserLayer;
+import fi.nls.oskari.domain.map.userlayer.UserLayerData;
+import fi.nls.oskari.domain.map.userlayer.UserLayerStyle;
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.map.geometry.WKTHelper;
+import fi.nls.oskari.map.layer.OskariLayerService;
+import fi.nls.oskari.map.layer.OskariLayerServiceIbatisImpl;
+import fi.nls.oskari.map.layer.formatters.LayerJSONFormatterUSERLAYER;
+import fi.nls.oskari.service.ServiceException;
+import fi.nls.oskari.util.ConversionHelper;
+import fi.nls.oskari.util.JSONHelper;
+import fi.nls.oskari.util.PropertyUtil;
 
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureIterator;
@@ -20,20 +31,9 @@ import org.opengis.referencing.operation.TransformException;
 import org.oskari.geojson.GeoJSON;
 import org.oskari.geojson.GeoJSONWriter;
 
-import fi.nls.oskari.domain.map.OskariLayer;
-import fi.nls.oskari.domain.map.userlayer.UserLayer;
-import fi.nls.oskari.domain.map.userlayer.UserLayerData;
-import fi.nls.oskari.domain.map.userlayer.UserLayerStyle;
-import fi.nls.oskari.log.LogFactory;
-import fi.nls.oskari.log.Logger;
-import fi.nls.oskari.map.geometry.WKTHelper;
-import fi.nls.oskari.map.layer.OskariLayerService;
-import fi.nls.oskari.map.layer.OskariLayerServiceIbatisImpl;
-import fi.nls.oskari.map.layer.formatters.LayerJSONFormatterUSERLAYER;
-import fi.nls.oskari.service.ServiceException;
-import fi.nls.oskari.util.ConversionHelper;
-import fi.nls.oskari.util.JSONHelper;
-import fi.nls.oskari.util.PropertyUtil;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 public class UserLayerDataService {
 

--- a/service-userlayer/src/main/java/org/oskari/map/userlayer/service/UserLayerMapper.java
+++ b/service-userlayer/src/main/java/org/oskari/map/userlayer/service/UserLayerMapper.java
@@ -9,24 +9,26 @@ import org.apache.ibatis.annotations.Param;
 import java.util.List;
 
 public interface UserLayerMapper {
-        //UserLayer related
-        public void insertUserLayerRow(final UserLayer userlayer);        
-        public int updateUserLayerCols(final UserLayer userlayer);
-        public UserLayer findUserLayer(long id);
-        public List<UserLayer> findUserLayerByUuid(String uuid);
-        public void deleteUserLayerRow(final long id) throws ServiceException;
-        public int updatePublisherName(@Param ("id") long id, @Param ("uuid") String uuid, @Param ("publisher_name") String name);
-        public String getUserLayerBbox (final long userLayerId);
 
-        //UserLayerStyle related
-        public void insertUserLayerStyleRow(final UserLayerStyle userLayerStyle);
-        public void deleteUserLayerStyleRow(final long id);
-		public UserLayerStyle findUserLayerStyle(final long id);
-		public int updateUserLayerStyleCols (final UserLayerStyle userLayeStyle);
+    //UserLayer related
+    public void insertUserLayerRow(final UserLayer userlayer);
+    public int updateUserLayerCols(final UserLayer userlayer);
+    public UserLayer findUserLayer(long id);
+    public List<UserLayer> findUserLayerByUuid(String uuid);
+    public void deleteUserLayerRow(final long id) throws ServiceException;
+    public int updatePublisherName(@Param ("id") long id, @Param ("uuid") String uuid, @Param ("publisher_name") String name);
+    public String getUserLayerBbox (final long userLayerId);
 
-        //UserLayerData related
-        public void insertUserLayerDataRow(@Param ("user_layer_data") final UserLayerData userLayeData, @Param("user_layer_id") final long userLayerId);
-        public int updateUserLayerDataCols(final UserLayerData userLayerData);        
-        public void deleteUserLayerDataByLayerId (final long userLayerId);
-        public void deleteUserLayerDataRow (final long id);
+    //UserLayerStyle related
+    public void insertUserLayerStyleRow(final UserLayerStyle userLayerStyle);
+    public void deleteUserLayerStyleRow(final long id);
+    public UserLayerStyle findUserLayerStyle(final long id);
+    public int updateUserLayerStyleCols (final UserLayerStyle userLayeStyle);
+
+    //UserLayerData related
+    public void insertUserLayerDataRow(@Param ("user_layer_data") final UserLayerData userLayeData, @Param("user_layer_id") final long userLayerId);
+    public int updateUserLayerDataCols(final UserLayerData userLayerData);
+    public void deleteUserLayerDataByLayerId (final long userLayerId);
+    public void deleteUserLayerDataRow (final long id);
+
 }

--- a/service-userlayer/src/main/resources/org/oskari/map/userlayer/service/UserLayerMapper.xml
+++ b/service-userlayer/src/main/resources/org/oskari/map/userlayer/service/UserLayerMapper.xml
@@ -26,7 +26,8 @@
         layer_source,
         fields,
         publisher_name,
-        style_id)
+        style_id,
+        wkt)
         VALUES (
         #{uuid},
         #{layer_name},
@@ -34,7 +35,8 @@
         #{layer_source},
         CAST (#{fields} as json),
         #{publisher_name},
-        #{style_id})
+        #{style_id},
+        #{wkt})
     </insert>
 	
 	<update id="updateUserLayerCols">
@@ -45,7 +47,8 @@
         layer_source = #{layer_source},
         fields =  CAST (#{fields} as json),
         publisher_name = #{publisher_name},
-        style_id = #{style_id}
+        style_id = #{style_id},
+        wkt = #{wkt}
         where id = #{id} and uuid = #{uuid}
     </update>
 


### PR DESCRIPTION
Fixes the issues created by #104. The functionality fixed here was disabled in #126.
Previously UserLayer extent was calculated from the data every time GetMapLayers was requested and it was also returned in the wrong projection to the functions requesting it (in the native srs where as it should have been in EPSG:4326).
Now we store the extent of UserLayer geometries in WGS84 as WKT directly at the user_layer level in the same INSERT statement that creates the user_layer row.

