### PR TITLE
Fix secure flag so unsecure services are proxied like before

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/layer/GetMapLayerGroupsHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/GetMapLayerGroupsHandler.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 
 import fi.nls.oskari.map.layer.OskariLayerService;
 import fi.nls.oskari.map.layer.OskariLayerServiceIbatisImpl;
+import fi.nls.oskari.util.EnvHelper;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -76,7 +77,7 @@ public class GetMapLayerGroupsHandler extends ActionHandler {
         final User user = params.getUser();
         final String lang = params.getHttpParam(PARAM_LANGUAGE, params.getLocale().getLanguage());
         final String crs = params.getHttpParam(PARAM_SRS);
-        final boolean isSecure = false;
+        final boolean isSecure = EnvHelper.isSecure(params);
         final boolean isPublished = false;
 
         final String permissionType = OskariLayerWorker.getPermissionType(isPublished);


### PR DESCRIPTION
The isSecure flag is used to detect if services running in http-urls should be proxied through oskari-server. It was hardcoded to false in #145 and with the change in this PR the flag is detected from the request as before. Fixes an issue where Oskari instance running as https-service would try to reference wms-services using http-requests causing mixed content warnings in the browser.