### PR TITLE
Appsetup mapOptions are optional

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/view/AppSetupHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/view/AppSetupHandler.java
@@ -379,7 +379,9 @@ public class AppSetupHandler extends RestActionHandler {
         }
         JSONObject mapOptions = publisherView.getMapOptions();
         if (mapOptions == null) {
-            throw new ActionParamsException("Could not get the mapOptions from appsetup for uuid " + publisherUUID);
+            LOG.info("Could not get the mapOptions from appsetup for uuid", publisherUUID,
+                    "the embedded maps will use defaults from frontend code");
+            mapOptions = new JSONObject();
         }
         JSONHelper.putValue(mapOptions, KEY_CROSSHAIR, crosshairEnabled(input));
         JSONHelper.putValue(mapOptions, KEY_STYLE, style);

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/view/View.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/view/View.java
@@ -277,9 +277,6 @@ public class View implements Serializable {
             return null;
         }
         JSONObject config = mapfull.getConfigJSON();
-        if(config == null) {
-            return null;
-        }
         return JSONHelper.getJSONObject(config, "mapOptions");
     }
 

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/view/View.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/view/View.java
@@ -277,6 +277,9 @@ public class View implements Serializable {
             return null;
         }
         JSONObject config = mapfull.getConfigJSON();
+        if(config == null) {
+            return null;
+        }
         return JSONHelper.getJSONObject(config, "mapOptions");
     }
 


### PR DESCRIPTION
Previously publishing a map from an appsetup that didn't have mapOptions configured resulted in an error. While missing mapOptions is an issue when there's multiple projections used in the system it isn't an issue when the system is relying on the defaults used by the frontend code.

Now detecting missing mapOptions is just logged as a possible misconfiguration issue instead of treating it as a show-blocker preventing creation of published maps.