### PR TITLE
Compatibility fix for maplayer dataprovider/group admin

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/data/MapLayerGroupsHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/data/MapLayerGroupsHandler.java
@@ -5,21 +5,15 @@ import fi.mml.map.mapwindow.service.db.OskariMapLayerGroupServiceIbatisImpl;
 import fi.nls.oskari.annotation.OskariActionRoute;
 import fi.nls.oskari.control.*;
 import fi.nls.oskari.domain.map.MaplayerGroup;
-import fi.nls.oskari.domain.map.view.View;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
-import fi.nls.oskari.map.view.util.ViewHelper;
-import fi.nls.oskari.util.IOHelper;
+import fi.nls.oskari.util.ConversionHelper;
 import fi.nls.oskari.util.JSONHelper;
 import fi.nls.oskari.util.ResponseHelper;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import javax.servlet.http.HttpServletRequest;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.List;
 
@@ -103,7 +97,10 @@ public class MapLayerGroupsHandler extends RestActionHandler {
     public void handlePost(ActionParameters params) throws ActionException {
         params.requireAdminUser();
         MaplayerGroup maplayerGroup = populateFromRequest(params.getPayLoadJSON());
-        maplayerGroup.setId(params.getRequiredParamInt(PARAM_ID));
+        if(maplayerGroup.getId() == -1) {
+            // hierarchical admin apparently sends id as separate param
+            maplayerGroup.setId(params.getRequiredParamInt(PARAM_ID));
+        }
         oskariMapLayerGroupService.update(maplayerGroup);
         ResponseHelper.writeResponse(params, maplayerGroup.getAsJSON());
     }
@@ -157,8 +154,10 @@ public class MapLayerGroupsHandler extends RestActionHandler {
         MaplayerGroup maplayerGroup = new MaplayerGroup();
         try{
             JSONObject locales = mapLayerGroupJSON.getJSONObject(KEY_LOCALES);
-            int parentId = mapLayerGroupJSON.optInt(KEY_PARENT_ID, -1);
-            boolean selectable = mapLayerGroupJSON.optBoolean(KEY_SELECTABLE, true);
+            // The classic admin sends id as part of the JSON payload (as string, but with number value...)
+            maplayerGroup.setId(ConversionHelper.getInt(mapLayerGroupJSON.optString("id"), -1));
+            maplayerGroup.setParentId(mapLayerGroupJSON.optInt(KEY_PARENT_ID, -1));
+            maplayerGroup.setSelectable(mapLayerGroupJSON.optBoolean(KEY_SELECTABLE, true));
             Iterator<?> keys = locales.keys();
 
             while( keys.hasNext() ) {
@@ -166,8 +165,6 @@ public class MapLayerGroupsHandler extends RestActionHandler {
                 String name = locales.getString(locale);
                 maplayerGroup.setName(locale, name);
             }
-            maplayerGroup.setParentId(parentId);
-            maplayerGroup.setSelectable(selectable);
         } catch(JSONException ex) {
             throw new ActionException("Cannot populate maplayer group from request", ex);
         }

--- a/control-base/src/main/java/fi/nls/oskari/control/layer/DeleteOrganizationHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/DeleteOrganizationHandler.java
@@ -1,44 +1,44 @@
 package fi.nls.oskari.control.layer;
 
+import fi.nls.oskari.control.*;
+import fi.nls.oskari.domain.map.DataProvider;
+import fi.nls.oskari.util.ResponseHelper;
 import org.oskari.service.util.ServiceFactory;
 
 import fi.nls.oskari.annotation.OskariActionRoute;
-import fi.nls.oskari.control.ActionDeniedException;
-import fi.nls.oskari.control.ActionException;
-import fi.nls.oskari.control.ActionHandler;
-import fi.nls.oskari.control.ActionParameters;
-import fi.nls.oskari.log.LogFactory;
-import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.map.layer.DataProviderService;
 import fi.nls.oskari.util.ConversionHelper;
+import static fi.nls.oskari.control.ActionConstants.PARAM_ID;
 
 /**
- * Admin WMS organization layer delete
- * 
- * 
+ * For deleting a dataprovider/organization
  */
 @OskariActionRoute("DeleteOrganization")
 public class DeleteOrganizationHandler extends ActionHandler {
 
     private DataProviderService groupService = ServiceFactory.getDataProviderService();
-    private static final Logger log = LogFactory.getLogger(DeleteOrganizationHandler.class);
-    private static final String PARAM_GROUP_ID = "id";
 
     @Override
     public void handleAction(ActionParameters params) throws ActionException {
 
-        final int groupId = ConversionHelper.getInt(params.getRequiredParam(PARAM_GROUP_ID), -1);
+        final int groupId = params.getRequiredParamInt(PARAM_ID);
         
         if(!groupService.hasPermissionToUpdate(params.getUser(), groupId)) {
             throw new ActionDeniedException("Unauthorized user tried to remove layer group and its map layers - group id=" + groupId);
         }
-       
+
         try {
+            DataProvider organization = groupService.find(groupId);
+            if(organization == null) {
+                throw new ActionParamsException("Dataprovider not found with id " + groupId);
+            }
             // cascade in db will handle that layers are deleted
             groupService.delete(groupId);
+
+            // write deleted organization as response
+            ResponseHelper.writeResponse(params, organization.getAsJSON());
         } catch (Exception e) {
-            throw new ActionException("Couldn't delete layer group and its map layers - id:" + groupId,
-                    e);
+            throw new ActionException("Couldn't delete layer group and its map layers - id:" + groupId, e);
         }
     }
 

--- a/control-base/src/main/java/fi/nls/oskari/control/layer/SaveLayerHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/SaveLayerHandler.java
@@ -324,11 +324,13 @@ public class SaveLayerHandler extends ActionHandler {
             }
         }
 
-        String groupId = params.getHttpParam(PARAM_MAPLAYER_GROUPS, "-1");
-        ml.emptyMaplayerGroups();
-        for (String id: groupId.split(",")) {
-            MaplayerGroup maplayerGroup = oskariMapLayerGroupService.find(ConversionHelper.getInt(id, -1));
-            ml.addGroup(maplayerGroup);
+        String groupId = params.getHttpParam(PARAM_MAPLAYER_GROUPS);
+        if(groupId != null) {
+            ml.emptyMaplayerGroups();
+            for (String id: groupId.split(",")) {
+                MaplayerGroup maplayerGroup = oskariMapLayerGroupService.find(ConversionHelper.getInt(id, -1));
+                ml.addGroup(maplayerGroup);
+            }
         }
 
         ml.setVersion(params.getHttpParam(PARAM_VERSION, ""));

--- a/control-base/src/main/java/fi/nls/oskari/control/layer/SaveOrganizationHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/SaveOrganizationHandler.java
@@ -6,11 +6,14 @@ import fi.nls.oskari.domain.map.DataProvider;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.map.layer.DataProviderService;
+import fi.nls.oskari.util.ConversionHelper;
+import fi.nls.oskari.util.JSONHelper;
 import fi.nls.oskari.util.RequestHelper;
 import fi.nls.oskari.util.ResponseHelper;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.json.JSONObject;
 import org.oskari.service.util.ServiceFactory;
 
 import java.util.Map;
@@ -32,19 +35,28 @@ public class SaveOrganizationHandler extends ActionHandler {
     public void handleAction(ActionParameters params) throws ActionException {
 
         final HttpServletRequest request = params.getRequest();
-        try {
-            final int dataProviderId = params.getHttpParam(PARAM_ID, -1);
-            final DataProvider dataProvider = new DataProvider();
-            dataProvider.setId(dataProviderId);
-            handleLocalizations(dataProvider, PARAM_NAME_PREFIX, request);
-            if (dataProvider.getLocale() == null) {
-                throw new ActionParamsException("Missing names for layer dataprovider group!");
-            }
+        final DataProvider dataProvider = new DataProvider();
+        // hierarchical admin frontend sends separate params
+        dataProvider.setId(params.getHttpParam(PARAM_ID, -1));
+        dataProvider.setNames(RequestHelper.parsePrefixedParamsMap(request, PARAM_NAME_PREFIX));
 
+        if (dataProvider.getLocale() == null) {
+            // the classical layer admin sends JSON payload
+            // locale as payload  { id: "124", locales: {en: "name en", fi: "name fi"}}
+            JSONObject payload = params.getPayLoadJSON();
+            dataProvider.setId(ConversionHelper.getInt(payload.optString("id"), -1));
+            dataProvider.setNames(JSONHelper.getObjectAsMap(payload.optJSONObject("locales")));
+        }
+
+        if (dataProvider.getLocale() == null) {
+            throw new ActionParamsException("Missing names for layer dataprovider!");
+        }
+
+        try {
             // ************** UPDATE ************************
-            if (dataProviderId != -1) {
-                if (!dataProviderService.hasPermissionToUpdate(params.getUser(), dataProviderId)) {
-                    throw new ActionDeniedException("Unauthorized user tried to update layer dataprovider group - id=" + dataProviderId);
+            if (dataProvider.getId() != -1) {
+                if (!dataProviderService.hasPermissionToUpdate(params.getUser(), dataProvider.getId())) {
+                    throw new ActionDeniedException("Unauthorized user tried to update layer dataprovider - id=" + dataProvider.getId());
                 }
                 dataProviderService.update(dataProvider);
                 ResponseHelper.writeResponse(params, dataProvider.getAsJSON());
@@ -55,18 +67,11 @@ public class SaveOrganizationHandler extends ActionHandler {
                 dataProvider.setId(id);
                 ResponseHelper.writeResponse(params, dataProvider.getAsJSON());
             } else {
-                throw new ActionDeniedException("Unauthorized user tried to update layer dataprovider group - id=" + dataProviderId);
+                throw new ActionDeniedException("Unauthorized user tried to update layer dataprovider - id=" + dataProvider.getId());
             }
 
         } catch (Exception e) {
-            throw new ActionException("Couldn't update/insert map layer dataprovider group", e);
-        }
-    }
-
-    private void handleLocalizations(final DataProvider lc, final String nameprefix, final HttpServletRequest request) {
-        final Map<String, String> parsed = RequestHelper.parsePrefixedParamsMap(request, nameprefix);
-        for(Map.Entry<String, String> entry : parsed.entrySet()) {
-            lc.setName(entry.getKey(), entry.getValue());
+            throw new ActionException("Couldn't update/insert map layer dataprovider", e);
         }
     }
 }

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/JSONLocalizedName.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/JSONLocalizedName.java
@@ -2,13 +2,6 @@ package fi.nls.oskari.domain.map;
 
 import java.util.Map;
 
-/**
- * Created with IntelliJ IDEA.
- * User: TMIKKOLAINEN
- * Date: 9.9.2013
- * Time: 12:26
- * To change this template use File | Settings | File Templates.
- */
 public class JSONLocalizedName extends JSONLocalized {
     public String getName(final String language) {
         return getLocalizedValue(language, LOCALE_NAME);
@@ -23,8 +16,8 @@ public class JSONLocalizedName extends JSONLocalized {
     }
 
     public void setNames(Map<String, String> names) {
-        for (String lang : names.keySet()) {
-            setName(lang, names.get(lang));
+        for (Map.Entry<String, String> entry : names.entrySet()) {
+            setName(entry.getKey(), entry.getValue());
         }
     }
 }


### PR DESCRIPTION
The frontend for administrating layer dataproviders/groups were changed with oskariorg/oskari-frontend#270, oskariorg/oskari-frontend#263 and  #145 which broke the "classic" user interface for these features. This change makes the server handle both payloads. In the future the frontend should be harmonized to use the same input from each UI.