### PR TITLE
Id fix for myplaces/userlayer json generator

### DIFF
--- a/service-myplaces/src/main/java/fi/nls/oskari/myplaces/MyPlacesService.java
+++ b/service-myplaces/src/main/java/fi/nls/oskari/myplaces/MyPlacesService.java
@@ -66,7 +66,6 @@ public abstract class MyPlacesService extends OskariComponent {
                                                 final String uuid, final boolean modifyURLs) {
 
         final OskariLayer layer = new OskariLayer();
-        layer.setExternalId(MYPLACES_LAYERID_PREFIX + mpLayer.getId());
         layer.setName(MYPLACES_WMS_NAME);
         layer.setType(OskariLayer.TYPE_WMS);
         layer.setName(lang, mpLayer.getCategory_name());
@@ -101,8 +100,7 @@ java.lang.RuntimeException: Unable to encode filter [[ geometry bbox POLYGON ((4
         JSONObject myPlaceLayer = JSON_FORMATTER.getJSON(layer, lang, modifyURLs, null, capabilities);
         // flag with metaType for frontend
         JSONHelper.putValue(myPlaceLayer, "metaType", "published");
+        JSONHelper.putValue(myPlaceLayer, "id", MYPLACES_LAYERID_PREFIX + mpLayer.getId());
         return myPlaceLayer;
     }
-
-
 }

--- a/service-userlayer/src/main/java/org/oskari/map/userlayer/service/UserLayerDataService.java
+++ b/service-userlayer/src/main/java/org/oskari/map/userlayer/service/UserLayerDataService.java
@@ -180,6 +180,7 @@ public class UserLayerDataService {
             baseLayer.setType(OskariLayer.TYPE_USERLAYER);
             // create the JSON
             final JSONObject json = FORMATTER.getJSON(baseLayer, PropertyUtil.getDefaultLanguage(), false, null, ulayer);
+            JSONHelper.putValue(json, "id", USERLAYER_LAYER_PREFIX + ulayer.getId());
 
             // restore the previous values for baseLayer
             baseLayer.setExternalId(id);


### PR DESCRIPTION
As LayerJSONFormatter no longer writes out the external id of layers as id a change is required for myplaces and userlayer functionality. After JSON has been created the id is overwritten with the generated id of myplaces_[id] or userlayer_[id]. Otherwise the frontend will receive a -1 id.