### PR TITLE
Remove unused database table: portti_stats_layer

### DIFF
--- a/content-resources/src/main/resources/flyway/oskari/V1_47_0__remove_portti_stats_layer.sql
+++ b/content-resources/src/main/resources/flyway/oskari/V1_47_0__remove_portti_stats_layer.sql
@@ -1,0 +1,1 @@
+DROP table IF EXISTS portti_stats_layer;


### PR DESCRIPTION
The refactored statistics serverside code doesn't use the table anymore so removing it from the database