### PR TITLE
Add regionset info for datasource/indicator listings

### DIFF
--- a/control-statistics/src/main/java/fi/nls/oskari/control/StatsgridHandler.java
+++ b/control-statistics/src/main/java/fi/nls/oskari/control/StatsgridHandler.java
@@ -2,6 +2,7 @@ package fi.nls.oskari.control;
 
 import fi.nls.oskari.annotation.OskariViewModifier;
 import fi.nls.oskari.control.statistics.plugins.StatisticalDatasourcePluginManager;
+import fi.nls.oskari.control.statistics.plugins.db.DatasourceLayer;
 import fi.nls.oskari.control.statistics.plugins.db.StatisticalDatasource;
 import fi.nls.oskari.control.view.modifier.bundle.BundleHandler;
 import fi.nls.oskari.util.JSONHelper;
@@ -12,6 +13,7 @@ import org.json.JSONObject;
 import static fi.nls.oskari.control.ActionConstants.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Injects datasource list to statsgrid config
@@ -40,6 +42,7 @@ public class StatsgridHandler extends BundleHandler {
 
     private static final String KEY_DATASOURCES = "sources";
     private static final String KEY_INFO = "info";
+    private static final String KEY_REGIONSETS = "regionsets";
 
     private static final StatisticalDatasourcePluginManager pluginManager = StatisticalDatasourcePluginManager.getInstance();
 
@@ -59,6 +62,12 @@ public class StatsgridHandler extends BundleHandler {
             JSONHelper.putValue(item, KEY_NAME, src.getName(params.getLocale().getLanguage()));
             JSONHelper.putValue(item, KEY_TYPE, getType(src.getPlugin()));
             JSONHelper.putValue(item, KEY_INFO, src.getConfigJSON().optJSONObject(KEY_INFO));
+            // add layer ids as available regionsets for the datasource
+            JSONHelper.putValue(item, KEY_REGIONSETS, new JSONArray(src
+                    .getLayers()
+                    .stream()
+                    .map(DatasourceLayer::getMaplayerId)
+                    .collect(Collectors.toSet())));
 
             sourcesList.put(item);
         }

--- a/control-statistics/src/main/java/fi/nls/oskari/control/statistics/GetIndicatorListHandler.java
+++ b/control-statistics/src/main/java/fi/nls/oskari/control/statistics/GetIndicatorListHandler.java
@@ -6,14 +6,19 @@ import fi.nls.oskari.control.ActionHandler;
 import fi.nls.oskari.control.ActionParameters;
 import fi.nls.oskari.control.ActionParamsException;
 import fi.nls.oskari.control.statistics.data.IndicatorSet;
+import fi.nls.oskari.control.statistics.data.StatisticalIndicatorLayer;
 import fi.nls.oskari.control.statistics.plugins.StatisticalDatasourcePlugin;
 import fi.nls.oskari.control.statistics.plugins.StatisticalDatasourcePluginManager;
 import fi.nls.oskari.control.statistics.data.StatisticalIndicator;
+import fi.nls.oskari.control.statistics.plugins.db.DatasourceLayer;
 import fi.nls.oskari.domain.User;
 import fi.nls.oskari.util.JSONHelper;
 import fi.nls.oskari.util.ResponseHelper;
 import org.json.JSONArray;
 import org.json.JSONObject;
+
+import java.util.stream.Collectors;
+
 import static fi.nls.oskari.control.ActionConstants.*;
 
 /**
@@ -31,6 +36,7 @@ public class GetIndicatorListHandler extends ActionHandler {
 
     private static final String KEY_COMPLETE = "complete";
     private static final String KEY_INDICATORS = "indicators";
+    private static final String KEY_REGIONSETS = "regionsets";
     private static final String PARAM_DATASOURCE = "datasource";
     /**
      * For now, this uses pretty much static global store for the plugins.
@@ -73,6 +79,12 @@ public class GetIndicatorListHandler extends ActionHandler {
         final JSONObject json = new JSONObject();
         JSONHelper.putValue(json, KEY_ID, indicator.getId());
         JSONHelper.putValue(json, KEY_NAME, indicator.getName(language));
+        // add layer ids as available regionsets for the indicator
+        JSONHelper.putValue(json, KEY_REGIONSETS, new JSONArray(indicator
+                .getLayers()
+                .stream()
+                .map(StatisticalIndicatorLayer::getOskariLayerId)
+                .collect(Collectors.toSet())));
         return json;
     }
 }


### PR DESCRIPTION
This will enable filtering datasources/indicator listing based on regionsets in the frontend.