### PR TITLE
Add env specific urls to GetAppSetup response

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/util/EnvHelper.java
+++ b/control-base/src/main/java/fi/nls/oskari/util/EnvHelper.java
@@ -42,8 +42,10 @@ public class EnvHelper {
     private static final String KEY_REGISTER = "register";
     private static final String KEY_LOGIN = "login";
     private static final String KEY_LOGOUT = "logout";
+    private static final String KEY_PROFILE = "profile";
 
     private static final String registerUrl = PropertyUtil.get("auth.register.url", "/user");
+    private static final String profileUrl = PropertyUtil.get("auth.profile.url", "/user");
     private static final String loginUrl = PropertyUtil.get("auth.login.url", "/j_security_check");
     private static final String logoutUrl = PropertyUtil.get("auth.logout.url", "/logout");
     private static final String PROPERTY_AJAXURL = "oskari.ajax.url.prefix";
@@ -93,6 +95,7 @@ public class EnvHelper {
         JSONHelper.putValue(urlConfig, KEY_LOGIN, getLoginUrl());
         JSONHelper.putValue(urlConfig, KEY_REGISTER, getRegisterUrl());
         JSONHelper.putValue(urlConfig, KEY_LOGOUT, getLogoutUrl());
+        JSONHelper.putValue(urlConfig, KEY_PROFILE, getProfileUrl());
         JSONHelper.putValue(env, KEY_URLS, urlConfig);
 
         // setup appsetup info
@@ -150,5 +153,8 @@ public class EnvHelper {
     }
     public static String getLogoutUrl() {
         return logoutUrl;
+    }
+    public static String getProfileUrl() {
+        return profileUrl;
     }
 }

--- a/control-base/src/main/java/fi/nls/oskari/util/EnvHelper.java
+++ b/control-base/src/main/java/fi/nls/oskari/util/EnvHelper.java
@@ -73,7 +73,8 @@ public class EnvHelper {
         final JSONObject env = new JSONObject();
 
         // setup locale info
-        JSONHelper.putValue(env, ActionConstants.PARAM_LANGUAGE, params.getLocale().getLanguage());
+        final String language = params.getLocale().getLanguage();
+        JSONHelper.putValue(env, ActionConstants.PARAM_LANGUAGE, language);
         JSONHelper.putValue(env, KEY_SUPPORTED_LOCALES, PropertyUtil.getSupportedLocales());
         final DecimalFormatSymbols dfs = new DecimalFormatSymbols(params.getLocale());
         JSONHelper.putValue(env, KEY_DECIMAL_SEPARATOR, Character.toString(dfs.getDecimalSeparator()));
@@ -86,10 +87,10 @@ public class EnvHelper {
         // setup env urls info (api, terms of use, "geoportal url?")
         JSONObject urlConfig = new JSONObject();
         JSONHelper.putValue(urlConfig, KEY_API, getAPIurl(params));
-        JSONHelper.putValue(urlConfig, KEY_LOGIN, getLoginUrl());
-        JSONHelper.putValue(urlConfig, KEY_REGISTER, getRegisterUrl());
-        JSONHelper.putValue(urlConfig, KEY_LOGOUT, getLogoutUrl());
-        JSONHelper.putValue(urlConfig, KEY_PROFILE, getProfileUrl());
+        JSONHelper.putValue(urlConfig, KEY_LOGIN, getLoginUrl(language));
+        JSONHelper.putValue(urlConfig, KEY_REGISTER, getRegisterUrl(language));
+        JSONHelper.putValue(urlConfig, KEY_LOGOUT, getLogoutUrl(language));
+        JSONHelper.putValue(urlConfig, KEY_PROFILE, getProfileUrl(language));
         JSONHelper.putValue(env, KEY_URLS, urlConfig);
 
         // setup appsetup info
@@ -140,23 +141,54 @@ public class EnvHelper {
     }
 
     public static String getLoginUrl() {
-        return PropertyUtil.get("auth.login.url", null);
+        return getLoginUrl(PropertyUtil.getDefaultLanguage());
     }
 
-    public static String getRegisterUrl() {
-        if(!isRegistrationAllowed()) {
-            return null;
-        }
-        return PropertyUtil.get("auth.register.url", "/user");
-    }
-    public static String getLogoutUrl() {
-        return PropertyUtil.get("auth.logout.url", "/logout");
-    }
-    public static String getProfileUrl() {
-        return PropertyUtil.get("auth.profile.url", getRegisterUrl());
+    public static String getLoginUrl(String lang) {
+        return PropertyUtil.getWithOptionalModifier("auth.login.url", lang, PropertyUtil.getDefaultLanguage());
     }
 
     public static boolean isRegistrationAllowed() {
         return PropertyUtil.getOptional("allow.registration", false);
     }
+
+    public static String getRegisterUrl() {
+        return getRegisterUrl(PropertyUtil.getDefaultLanguage());
+    }
+
+    public static String getRegisterUrl(String lang) {
+        if(!isRegistrationAllowed()) {
+            return null;
+        }
+        final String url = PropertyUtil.getWithOptionalModifier("auth.register.url", lang, PropertyUtil.getDefaultLanguage());
+        if(url != null) {
+            return url;
+        }
+        return "/user";
+    }
+
+    public static String getProfileUrl() {
+        return getProfileUrl(PropertyUtil.getDefaultLanguage());
+    }
+
+    public static String getProfileUrl(String lang) {
+        final String url = PropertyUtil.getWithOptionalModifier("auth.profile.url", lang, PropertyUtil.getDefaultLanguage());
+        if(url != null) {
+            return url;
+        }
+        return getRegisterUrl();
+    }
+
+    public static String getLogoutUrl() {
+        return getLogoutUrl(PropertyUtil.getDefaultLanguage());
+    }
+
+    public static String getLogoutUrl(String lang) {
+        final String url = PropertyUtil.getWithOptionalModifier("auth.logout.url", lang, PropertyUtil.getDefaultLanguage());
+        if(url != null) {
+            return url;
+        }
+        return "/logout";
+    }
+
 }

--- a/control-base/src/main/java/fi/nls/oskari/util/EnvHelper.java
+++ b/control-base/src/main/java/fi/nls/oskari/util/EnvHelper.java
@@ -5,7 +5,6 @@ import fi.nls.oskari.control.ActionParameters;
 import fi.nls.oskari.domain.map.view.View;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
-import fi.nls.oskari.map.view.ViewService;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -13,9 +12,7 @@ import org.json.JSONObject;
 import java.io.InputStream;
 import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import static fi.nls.oskari.control.ActionConstants.*;
 
@@ -31,20 +28,35 @@ import static fi.nls.oskari.control.ActionConstants.*;
 public class EnvHelper {
     private static final Logger LOGGER = LogFactory.getLogger(EnvHelper.class);
 
-    private static final String KEY_DECIMAL_SEPARATOR = "decimalSeparator";
+    // localization
     private static final String KEY_SUPPORTED_LOCALES = "locales";
+    private static final String KEY_DECIMAL_SEPARATOR = "decimalSeparator";
+
+    // markers
     private static final String KEY_SVG_MARKERS = "svgMarkers";
-    private static final String KEY_USER = "user";
+    private static final String SVG_MARKERS_JSON = "svg-markers.json";
+
+    // urls
     private static final String KEY_URLS = "urls";
+    private static final String KEY_API = "api";
+    private static final String KEY_REGISTER = "register";
+    private static final String KEY_LOGIN = "login";
+    private static final String KEY_LOGOUT = "logout";
+
+    private static final String registerUrl = PropertyUtil.get("auth.register.url", "/user");
+    private static final String loginUrl = PropertyUtil.get("auth.login.url", "/j_security_check");
+    private static final String logoutUrl = PropertyUtil.get("auth.logout.url", "/logout");
+    private static final String PROPERTY_AJAXURL = "oskari.ajax.url.prefix";
+
+    // user
+    private static final String KEY_USER = "user";
+    private static final String KEY_APIKEY = "apikey";
+
+    // appsetups
     private static final String KEY_APPSETUP = "app";
     private static final String KEY_DEFAULT_VIEWS = "defaultApps";
-    private static final String KEY_API = "api";
-    private static final String KEY_APIKEY = "apikey";
     private static final String KEY_ISPUBLIC = "public";
     private static final List<JSONObject> DEFAULT_VIEWS = new ArrayList<>();
-
-    public static final String SVG_MARKERS_JSON = "svg-markers.json";
-    public static final String PROPERTY_AJAXURL = "oskari.ajax.url.prefix";
 
     public static void setupViews(List<View> views) {
         DEFAULT_VIEWS.clear();
@@ -78,6 +90,9 @@ public class EnvHelper {
         // setup env urls info (api, terms of use, "geoportal url?")
         JSONObject urlConfig = new JSONObject();
         JSONHelper.putValue(urlConfig, KEY_API, getAPIurl(params));
+        JSONHelper.putValue(urlConfig, KEY_LOGIN, getLoginUrl());
+        JSONHelper.putValue(urlConfig, KEY_REGISTER, getRegisterUrl());
+        JSONHelper.putValue(urlConfig, KEY_LOGOUT, getLogoutUrl());
         JSONHelper.putValue(env, KEY_URLS, urlConfig);
 
         // setup appsetup info
@@ -125,5 +140,15 @@ public class EnvHelper {
      */
     public static boolean isSecure(final ActionParameters params) {
         return params.getHttpParam(PARAM_SECURE, params.getRequest().isSecure());
+    }
+
+    public static String getLoginUrl() {
+        return loginUrl;
+    }
+    public static String getRegisterUrl() {
+        return registerUrl;
+    }
+    public static String getLogoutUrl() {
+        return logoutUrl;
     }
 }

--- a/control-base/src/main/java/fi/nls/oskari/util/EnvHelper.java
+++ b/control-base/src/main/java/fi/nls/oskari/util/EnvHelper.java
@@ -44,12 +44,6 @@ public class EnvHelper {
     private static final String KEY_LOGOUT = "logout";
     private static final String KEY_PROFILE = "profile";
 
-    private static final String registerUrl = PropertyUtil.get("auth.register.url", "/user");
-    private static final String profileUrl = PropertyUtil.get("auth.profile.url", "/user");
-    private static final String loginUrl = PropertyUtil.get("auth.login.url", "/j_security_check");
-    private static final String logoutUrl = PropertyUtil.get("auth.logout.url", "/logout");
-    private static final String PROPERTY_AJAXURL = "oskari.ajax.url.prefix";
-
     // user
     private static final String KEY_USER = "user";
     private static final String KEY_APIKEY = "apikey";
@@ -127,7 +121,7 @@ public class EnvHelper {
     }
 
     public static String getAPIurl(final ActionParameters params) {
-        final String baseAjaxUrl = PropertyUtil.get(params.getLocale(), PROPERTY_AJAXURL);
+        final String baseAjaxUrl = PropertyUtil.get(params.getLocale(), "oskari.ajax.url.prefix");
         if (isSecure(params)) {
             // this isn't really necessary any more
             return PropertyUtil.get("actionhandler.GetAppSetup.secureAjaxUrlPrefix", "") + baseAjaxUrl;
@@ -146,15 +140,23 @@ public class EnvHelper {
     }
 
     public static String getLoginUrl() {
-        return loginUrl;
+        return PropertyUtil.get("auth.login.url", null);
     }
+
     public static String getRegisterUrl() {
-        return registerUrl;
+        if(!isRegistrationAllowed()) {
+            return null;
+        }
+        return PropertyUtil.get("auth.register.url", "/user");
     }
     public static String getLogoutUrl() {
-        return logoutUrl;
+        return PropertyUtil.get("auth.logout.url", "/logout");
     }
     public static String getProfileUrl() {
-        return profileUrl;
+        return PropertyUtil.get("auth.profile.url", getRegisterUrl());
+    }
+
+    public static boolean isRegistrationAllowed() {
+        return PropertyUtil.getOptional("allow.registration", false);
     }
 }

--- a/control-base/src/test/java/fi/nls/oskari/control/view/GetAppSetupHandlerTest.java
+++ b/control-base/src/test/java/fi/nls/oskari/control/view/GetAppSetupHandlerTest.java
@@ -28,6 +28,7 @@ import fi.nls.test.control.JSONActionRouteTest;
 import fi.nls.test.util.ResourceHelper;
 import fi.nls.test.view.BundleTestHelper;
 import fi.nls.test.view.ViewTestHelper;
+import org.json.JSONObject;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -102,6 +103,32 @@ public class GetAppSetupHandlerTest extends JSONActionRouteTest {
     @AfterClass
     public static void teardown() {
         PropertyUtil.clearProperties();
+    }
+
+    @Test
+    public void testURLsWithRegistrationAllowed() throws Exception {
+        PropertyUtil.addProperty("allow.registration", "true");
+        final ActionParameters params = createActionParams();
+        handler.handleAction(params);
+
+        JSONObject responseUrls = getResponseJSON().optJSONObject("env").optJSONObject("urls");
+        assertEquals("Should have default register url", "/user", responseUrls.opt("register"));
+        assertEquals("Should have default profile url", "/user", responseUrls.opt("profile"));
+
+        teardown();
+        addLocales();
+    }
+
+    @Test
+    public void testLoginUrl() throws Exception {
+        PropertyUtil.addProperty("auth.login.url", "/login");
+        final ActionParameters params = createActionParams();
+        handler.handleAction(params);
+
+        JSONObject responseUrls = getResponseJSON().optJSONObject("env").optJSONObject("urls");
+        assertEquals("Should have login url", "/login", responseUrls.opt("login"));
+        teardown();
+        addLocales();
     }
 
 

--- a/control-base/src/test/java/fi/nls/oskari/control/view/GetAppSetupHandlerTest.java
+++ b/control-base/src/test/java/fi/nls/oskari/control/view/GetAppSetupHandlerTest.java
@@ -127,6 +127,7 @@ public class GetAppSetupHandlerTest extends JSONActionRouteTest {
 
         JSONObject responseUrls = getResponseJSON().optJSONObject("env").optJSONObject("urls");
         assertEquals("Should have login url", "/login", responseUrls.opt("login"));
+        assertNull("Should NOT have register url as allow.registration not set", responseUrls.opt("register"));
         teardown();
         addLocales();
     }

--- a/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-coordinate-params.json
+++ b/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-coordinate-params.json
@@ -10,10 +10,7 @@
     "defaultApps": [],
     "urls": {
       "api": "--oskari.ajax.url.prefix--",
-      "login": "/j_security_check",
-      "logout": "/logout",
-      "register": "/user",
-      "profile": "/user"
+      "logout": "/logout"
     },
     "app": {
       "public": true,

--- a/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-coordinate-params.json
+++ b/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-coordinate-params.json
@@ -12,7 +12,8 @@
       "api": "--oskari.ajax.url.prefix--",
       "login": "/j_security_check",
       "logout": "/logout",
-      "register": "/user"
+      "register": "/user",
+      "profile": "/user"
     },
     "app": {
       "public": true,

--- a/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-coordinate-params.json
+++ b/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-coordinate-params.json
@@ -8,7 +8,12 @@
       "en_EN"
     ],
     "defaultApps": [],
-    "urls": {"api": "--oskari.ajax.url.prefix--"},
+    "urls": {
+      "api": "--oskari.ajax.url.prefix--",
+      "login": "/j_security_check",
+      "logout": "/logout",
+      "register": "/user"
+    },
     "app": {
       "public": true,
       "type": "user",

--- a/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-3.json
+++ b/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-3.json
@@ -15,10 +15,7 @@
     "defaultApps": [],
     "urls": {
       "api": "--oskari.ajax.url.prefix--",
-      "login": "/j_security_check",
-      "logout": "/logout",
-      "register": "/user",
-      "profile": "/user"
+      "logout": "/logout"
     },
     "user": {
       "apikey": "testkey",

--- a/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-3.json
+++ b/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-3.json
@@ -13,7 +13,12 @@
       "uuid": "aaaa-bbbbb-cccc"
     },
     "defaultApps": [],
-    "urls": {"api": "--oskari.ajax.url.prefix--"},
+    "urls": {
+      "api": "--oskari.ajax.url.prefix--",
+      "login": "/j_security_check",
+      "logout": "/logout",
+      "register": "/user"
+    },
     "user": {
       "apikey": "testkey",
       "email": "",

--- a/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-3.json
+++ b/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-3.json
@@ -17,7 +17,8 @@
       "api": "--oskari.ajax.url.prefix--",
       "login": "/j_security_check",
       "logout": "/logout",
-      "register": "/user"
+      "register": "/user",
+      "profile": "/user"
     },
     "user": {
       "apikey": "testkey",

--- a/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-guest.json
+++ b/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-guest.json
@@ -15,10 +15,7 @@
     "defaultApps": [],
     "urls": {
       "api": "--oskari.ajax.url.prefix--",
-      "login": "/j_security_check",
-      "logout": "/logout",
-      "register": "/user",
-      "profile": "/user"
+      "logout": "/logout"
     },
     "user": {
       "apikey": "testkey",

--- a/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-guest.json
+++ b/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-guest.json
@@ -13,7 +13,12 @@
       "uuid": "aaaa-bbbbb-cccc"
     },
     "defaultApps": [],
-    "urls": {"api": "--oskari.ajax.url.prefix--"},
+    "urls": {
+      "api": "--oskari.ajax.url.prefix--",
+      "login": "/j_security_check",
+      "logout": "/logout",
+      "register": "/user"
+    },
     "user": {
       "apikey": "testkey",
       "email": "",

--- a/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-guest.json
+++ b/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-guest.json
@@ -17,7 +17,8 @@
       "api": "--oskari.ajax.url.prefix--",
       "login": "/j_security_check",
       "logout": "/logout",
-      "register": "/user"
+      "register": "/user",
+      "profile": "/user"
     },
     "user": {
       "apikey": "testkey",

--- a/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-loggedin.json
+++ b/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-loggedin.json
@@ -15,10 +15,7 @@
     "defaultApps": [],
     "urls": {
       "api": "--oskari.ajax.url.prefix--",
-      "login": "/j_security_check",
-      "logout": "/logout",
-      "register": "/user",
-      "profile": "/user"
+      "logout": "/logout"
     },
     "user": {
       "apikey": "testkey",

--- a/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-loggedin.json
+++ b/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-loggedin.json
@@ -17,7 +17,8 @@
       "api": "--oskari.ajax.url.prefix--",
       "login": "/j_security_check",
       "logout": "/logout",
-      "register": "/user"
+      "register": "/user",
+      "profile": "/user"
     },
     "user": {
       "apikey": "testkey",

--- a/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-loggedin.json
+++ b/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-loggedin.json
@@ -13,7 +13,12 @@
       "uuid": "aaaa-bbbbb-cccc"
     },
     "defaultApps": [],
-    "urls": {"api": "--oskari.ajax.url.prefix--"},
+    "urls": {
+      "api": "--oskari.ajax.url.prefix--",
+      "login": "/j_security_check",
+      "logout": "/logout",
+      "register": "/user"
+    },
     "user": {
       "apikey": "testkey",
       "email": "test@oskari.org",

--- a/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-roles-from-properties-admin.json
+++ b/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-roles-from-properties-admin.json
@@ -8,7 +8,12 @@
       "en_EN"
     ],
     "defaultApps": [],
-    "urls": {"api": "--oskari.ajax.url.prefix--"},
+    "urls": {
+      "api": "--oskari.ajax.url.prefix--",
+      "login": "/j_security_check",
+      "logout": "/logout",
+      "register": "/user"
+    },
     "app": {
       "public": true,
       "type": "default",

--- a/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-roles-from-properties-admin.json
+++ b/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-roles-from-properties-admin.json
@@ -10,10 +10,7 @@
     "defaultApps": [],
     "urls": {
       "api": "--oskari.ajax.url.prefix--",
-      "login": "/j_security_check",
-      "logout": "/logout",
-      "register": "/user",
-      "profile": "/user"
+      "logout": "/logout"
     },
     "app": {
       "public": true,

--- a/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-roles-from-properties-admin.json
+++ b/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-roles-from-properties-admin.json
@@ -12,7 +12,8 @@
       "api": "--oskari.ajax.url.prefix--",
       "login": "/j_security_check",
       "logout": "/logout",
-      "register": "/user"
+      "register": "/user",
+      "profile": "/user"
     },
     "app": {
       "public": true,

--- a/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-roles-from-properties.json
+++ b/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-roles-from-properties.json
@@ -8,7 +8,12 @@
       "en_EN"
     ],
     "defaultApps": [],
-    "urls": {"api": "--oskari.ajax.url.prefix--"},
+    "urls": {
+      "api": "--oskari.ajax.url.prefix--",
+      "login": "/j_security_check",
+      "logout": "/logout",
+      "register": "/user"
+    },
     "app": {
       "public": true,
       "type": "default",

--- a/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-roles-from-properties.json
+++ b/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-roles-from-properties.json
@@ -10,10 +10,7 @@
     "defaultApps": [],
     "urls": {
       "api": "--oskari.ajax.url.prefix--",
-      "login": "/j_security_check",
-      "logout": "/logout",
-      "register": "/user",
-      "profile": "/user"
+      "logout": "/logout"
     },
     "app": {
       "public": true,

--- a/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-roles-from-properties.json
+++ b/control-base/src/test/resources/fi/nls/oskari/control/view/GetAppSetupHandlerTest-view-roles-from-properties.json
@@ -12,7 +12,8 @@
       "api": "--oskari.ajax.url.prefix--",
       "login": "/j_security_check",
       "logout": "/logout",
-      "register": "/user"
+      "register": "/user",
+      "profile": "/user"
     },
     "app": {
       "public": true,

--- a/service-base/src/main/java/fi/nls/oskari/util/PropertyUtil.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/PropertyUtil.java
@@ -215,6 +215,27 @@ public class PropertyUtil {
     }
 
     /**
+     * Easier way to find a single localizable property that defaults to default language and to no modifier:
+     *   PropertyUtil.getWithOptionalModifier("auth.register.url", "fi", PropertyUtil.getDefaultLanguage());
+     *   Will try:
+     *   1) auth.register.url.fi
+     *   2) auth.register.url.en
+     *   3) auth.register.url
+     *   And return the first one without null value or null if not found in any of these
+     * @param key
+     * @param modifiers
+     * @return
+     */
+    public static String getWithOptionalModifier(final String key, String... modifiers) {
+        for(String mod: modifiers) {
+            final String value = getOptional(key + "." + mod);
+            if(value != null) {
+                return value;
+            }
+        }
+        return getOptional(key);
+    }
+    /**
      *
      * @param key
      * @param defaultValue

--- a/service-base/src/test/java/fi/nls/oskari/util/PropertyUtilTest.java
+++ b/service-base/src/test/java/fi/nls/oskari/util/PropertyUtilTest.java
@@ -143,4 +143,18 @@ public class PropertyUtilTest {
         assertEquals("Finnish Value should match", value + " fi", values.get("fi"));
     }
 
+    @Test
+    public void testLocalizablePropertyWithModifier() throws Exception {
+        final String KEY = "my.key";
+        final String value = "test value";
+        PropertyUtil.addProperty(KEY, value);
+        PropertyUtil.addProperty(KEY + ".en", value + " en");
+        PropertyUtil.addProperty(KEY + ".fi", value + " fi");
+        String o = PropertyUtil.getWithOptionalModifier(KEY, "fi", "en");
+        assertEquals("English value should match", value + " en", PropertyUtil.getWithOptionalModifier(KEY, "en"));
+        assertEquals("Finnish value should match", value + " fi", PropertyUtil.getWithOptionalModifier(KEY, "fi", "en"));
+        assertEquals("Missing value should fallback to english", value + " en", PropertyUtil.getWithOptionalModifier(KEY, "sv", "en"));
+        assertEquals("Missing value with spanish default should match default key", value, PropertyUtil.getWithOptionalModifier(KEY, "sv", "es"));
+    }
+
 }

--- a/servlet-map/src/main/java/fi/nls/oskari/MapController.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/MapController.java
@@ -133,7 +133,7 @@ public class MapController {
                     model.addAttribute("_login_field_user", env.getParam_username());
                     model.addAttribute("_login_field_pass", env.getParam_password());
                 }
-                if(PropertyUtil.getOptional("allow.registration", false)) {
+                if(env.isRegistrationAllowed()) {
                     model.addAttribute("_registration_uri", env.getRegisterUrl());
                 }
             }

--- a/servlet-map/src/main/java/fi/nls/oskari/MapController.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/MapController.java
@@ -10,7 +10,7 @@ import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.map.view.ViewService;
 import fi.nls.oskari.map.view.ViewServiceIbatisImpl;
 import fi.nls.oskari.map.view.util.ViewHelper;
-import fi.nls.oskari.spring.EnvHelper;
+import fi.nls.oskari.spring.SpringEnvHelper;
 import fi.nls.oskari.spring.extension.OskariParam;
 import fi.nls.oskari.util.*;
 import org.json.JSONObject;
@@ -52,7 +52,7 @@ public class MapController {
     private final Set<String> paramHandlers = new HashSet<String>();
 
     @Autowired
-    private EnvHelper env;
+    private SpringEnvHelper env;
 
     public MapController() {
         // check if we have development flag -> serve non-minified js

--- a/servlet-map/src/main/java/fi/nls/oskari/spring/SpringEnvHelper.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/spring/SpringEnvHelper.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
  * To change this template use File | Settings | File Templates.
  */
 @Component
-public class EnvHelper {
+public class SpringEnvHelper {
 
     public static final String PROFILE_LOGIN_DB = "LoginDatabase";
     public static final String PROFILE_LOGIN_SAML = "LoginSAML";
@@ -33,7 +33,7 @@ public class EnvHelper {
     @Autowired
     private Environment springEnvironment;
 
-    public EnvHelper() {
+    public SpringEnvHelper() {
         mapUrl = PropertyUtil.get("oskari.map.url", "/");
         // login related properties
         logoutUrl = PropertyUtil.get("auth.logout.url", "/logout");

--- a/servlet-map/src/main/java/fi/nls/oskari/spring/SpringEnvHelper.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/spring/SpringEnvHelper.java
@@ -1,5 +1,6 @@
 package fi.nls.oskari.spring;
 
+import fi.nls.oskari.util.EnvHelper;
 import fi.nls.oskari.util.PropertyUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
@@ -20,10 +21,7 @@ public class SpringEnvHelper {
 
     // login related properties
     private boolean handleLoginForm;
-    private String loginUrl;
     private String loginUrlSAML = "/saml/login";
-    private String logoutUrl;
-    private String registerUrl;
     private String loggedOutPage;
     private String param_username;
     private String param_password;
@@ -36,11 +34,8 @@ public class SpringEnvHelper {
     public SpringEnvHelper() {
         mapUrl = PropertyUtil.get("oskari.map.url", "/");
         // login related properties
-        logoutUrl = PropertyUtil.get("auth.logout.url", "/logout");
-        registerUrl = PropertyUtil.get("auth.register.url", "/user");
         loggedOutPage = PropertyUtil.get("auth.loggedout.page", PropertyUtil.get("oskari.map.url", "/"));
         handleLoginForm = PropertyUtil.getOptional("oskari.request.handleLoginForm", true);
-        loginUrl = PropertyUtil.get("auth.login.url", "/j_security_check");
         param_username = PropertyUtil.get("auth.login.field.user", "j_username");
         param_password = PropertyUtil.get("auth.login.field.pass", "j_password");
     }
@@ -56,20 +51,11 @@ public class SpringEnvHelper {
         return handleLoginForm;
     }
 
-    public String getLoginUrl() {
-        return loginUrl;
-    }
-    public String getRegisterUrl() {
-        return registerUrl;
-    }
 
     public String getLoginUrlSAML() {
         return loginUrlSAML;
     }
 
-    public String getLogoutUrl() {
-        return logoutUrl;
-    }
 
     public String getLoggedOutPage() {
         return loggedOutPage;
@@ -85,5 +71,15 @@ public class SpringEnvHelper {
 
     public String getMapUrl() {
         return mapUrl;
+    }
+
+    public String getLoginUrl() {
+        return EnvHelper.getLoginUrl();
+    }
+    public String getRegisterUrl() {
+        return EnvHelper.getRegisterUrl();
+    }
+    public String getLogoutUrl() {
+        return EnvHelper.getLogoutUrl();
     }
 }

--- a/servlet-map/src/main/java/fi/nls/oskari/spring/SpringEnvHelper.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/spring/SpringEnvHelper.java
@@ -74,7 +74,14 @@ public class SpringEnvHelper {
     }
 
     public String getLoginUrl() {
-        return EnvHelper.getLoginUrl();
+        String url = EnvHelper.getLoginUrl();
+        if(url != null && !url.isEmpty()) {
+            return url;
+        }
+        return "/j_security_check";
+    }
+    public boolean isRegistrationAllowed() {
+        return EnvHelper.isRegistrationAllowed();
     }
     public String getRegisterUrl() {
         return EnvHelper.getRegisterUrl();

--- a/servlet-map/src/main/java/fi/nls/oskari/spring/SpringInitializer.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/spring/SpringInitializer.java
@@ -36,7 +36,7 @@ public class SpringInitializer implements WebApplicationInitializer {
 
     private AnnotationConfigWebApplicationContext getContext() {
         final AnnotationConfigWebApplicationContext context = new AnnotationConfigWebApplicationContext();
-        context.getEnvironment().setDefaultProfiles(EnvHelper.PROFILE_LOGIN_DB);
+        context.getEnvironment().setDefaultProfiles(SpringEnvHelper.PROFILE_LOGIN_DB);
         final String[] configuredProfiles = PropertyUtil.getCommaSeparatedList("oskari.profiles");
         if (configuredProfiles.length > 0) {
             log.info("Using profiles:", configuredProfiles);

--- a/servlet-map/src/main/java/fi/nls/oskari/spring/security/OskariCommonSecurityConfig.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/spring/security/OskariCommonSecurityConfig.java
@@ -2,7 +2,7 @@ package fi.nls.oskari.spring.security;
 
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
-import fi.nls.oskari.spring.EnvHelper;
+import fi.nls.oskari.spring.SpringEnvHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
@@ -22,7 +22,7 @@ public class OskariCommonSecurityConfig extends WebSecurityConfigurerAdapter {
     private Logger log = LogFactory.getLogger(OskariCommonSecurityConfig.class);
 
     @Autowired
-    private EnvHelper env;
+    private SpringEnvHelper env;
 
     protected void configure(HttpSecurity http) throws Exception {
         log.info("Configuring common security options");

--- a/servlet-map/src/main/java/fi/nls/oskari/spring/security/database/OskariDatabaseSecurityConfig.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/spring/security/database/OskariDatabaseSecurityConfig.java
@@ -2,7 +2,7 @@ package fi.nls.oskari.spring.security.database;
 
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
-import fi.nls.oskari.spring.EnvHelper;
+import fi.nls.oskari.spring.SpringEnvHelper;
 import fi.nls.oskari.spring.security.OskariLoginFailureHandler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
@@ -15,7 +15,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 /**
  * Database based authentication on Oskari
  */
-@Profile(EnvHelper.PROFILE_LOGIN_DB)
+@Profile(SpringEnvHelper.PROFILE_LOGIN_DB)
 @Configuration
 @EnableWebSecurity
 @Order(1)
@@ -23,7 +23,7 @@ public class OskariDatabaseSecurityConfig extends WebSecurityConfigurerAdapter {
     private Logger log = LogFactory.getLogger(OskariDatabaseSecurityConfig.class);
 
     @Autowired
-    private EnvHelper env;
+    private SpringEnvHelper env;
 
     protected void configure(HttpSecurity http) throws Exception {
         log.info("Configuring database login");

--- a/servlet-saml-config/src/main/java/fi/nls/oskari/spring/security/saml/OskariSAMLSecurityConfig.java
+++ b/servlet-saml-config/src/main/java/fi/nls/oskari/spring/security/saml/OskariSAMLSecurityConfig.java
@@ -6,7 +6,7 @@ package fi.nls.oskari.spring.security.saml;
 
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
-import fi.nls.oskari.spring.EnvHelper;
+import fi.nls.oskari.spring.SpringEnvHelper;
 import fi.nls.oskari.spring.security.OskariLoginFailureHandler;
 import fi.nls.oskari.util.PropertyUtil;
 import org.apache.commons.httpclient.HttpClient;
@@ -75,7 +75,7 @@ import java.util.*;
  * - Generate new keystore: keytool -genkey -alias oskari -keyalg RSA -keystore oskariSAML.jks -keysize 2048
  * - Add key to keystore: keytool -genkeypair -alias oskariKey -keypass oskariPass -keystore oskariSAML.jks
  */
-@Profile(EnvHelper.PROFILE_LOGIN_SAML)
+@Profile(SpringEnvHelper.PROFILE_LOGIN_SAML)
 @Configuration
 @EnableWebMvcSecurity
 @EnableGlobalMethodSecurity(securedEnabled = true)


### PR DESCRIPTION
Configured with oskari-ext.properties.

Previously had:
- "api" with value from property "oskari.ajax.url.prefix"

This PR adds:
- "login" with value from property "auth.login.url" if configured
- "logout" with value from property "auth.logout.url" or "/logout" if not configured
- "profile" with value from property "auth.profile.url" or the same value as "register" URL if not configured (no value if "allow.registration" is not "true" AND "auth.profile.url" is NOT configured)

If "allow.registration" property has a value of "true":
- "register" with value from property "auth.register.url" or "/user" if not configured

Note! allows localized urls with language postfix to properties like "auth.register.url.en" etc.

As these urls are usually not appsetup specific this reduces the amount of configuration needed/appsetup in bundles supporting the Oskari.urls.getLocation(). Register url and login url are left out without configuration since otherwise some frontend-bundles might show links with the default values.