### PR TITLE
Add admin route for flushing a cache

### DIFF
--- a/service-base/src/main/java/fi/nls/oskari/cache/Cache.java
+++ b/service-base/src/main/java/fi/nls/oskari/cache/Cache.java
@@ -158,6 +158,10 @@ public class Cache<T> {
         return (lastFlush + expiration < now);
     }
 
+    public long getTimeToExpirationMs() {
+        return expiration - (currentTime() - lastFlush);
+    }
+
     private static long currentTime() {
         return System.nanoTime() / 1000000L;
     }


### PR DESCRIPTION
This adds the ability to make a POST request to /action?action_route=Cache&name=[cache name] when logged in as admin to flush a given cache. Also adds a more user-friendly formatting for the "time to expiration" info.