### PR TITLE
Improve .gpx importing

### DIFF
--- a/service-userlayer/src/main/java/org/oskari/map/userlayer/input/FeatureCollectionParsers.java
+++ b/service-userlayer/src/main/java/org/oskari/map/userlayer/input/FeatureCollectionParsers.java
@@ -16,7 +16,12 @@ import org.opengis.referencing.operation.MathTransform;
 
 import com.vividsolutions.jts.geom.Geometry;
 
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+
 public class FeatureCollectionParsers {
+
+    private static final Logger LOG = LogFactory.getLogger(FeatureCollectionParsers.class);
 
     private FeatureCollectionParsers() {}
 
@@ -74,6 +79,8 @@ public class FeatureCollectionParsers {
                 if (g != null) {
                     Geometry transformed = JTS.transform((Geometry) g, transform);
                     copy.setDefaultGeometry(transformed);
+                } else {
+                    LOG.debug("No default geometry, feature id {}", f.getID());
                 }
                 fc.add(copy);
             }

--- a/service-userlayer/src/main/java/org/oskari/map/userlayer/input/FeatureCollectionParsers.java
+++ b/service-userlayer/src/main/java/org/oskari/map/userlayer/input/FeatureCollectionParsers.java
@@ -16,12 +16,7 @@ import org.opengis.referencing.operation.MathTransform;
 
 import com.vividsolutions.jts.geom.Geometry;
 
-import fi.nls.oskari.log.LogFactory;
-import fi.nls.oskari.log.Logger;
-
 public class FeatureCollectionParsers {
-
-    private static final Logger LOG = LogFactory.getLogger(FeatureCollectionParsers.class);
 
     private FeatureCollectionParsers() {}
 
@@ -79,8 +74,6 @@ public class FeatureCollectionParsers {
                 if (g != null) {
                     Geometry transformed = JTS.transform((Geometry) g, transform);
                     copy.setDefaultGeometry(transformed);
-                } else {
-                    LOG.debug("No default geometry, feature id:", f.getID());
                 }
                 fc.add(copy);
             }

--- a/service-userlayer/src/main/java/org/oskari/map/userlayer/input/FeatureCollectionParsers.java
+++ b/service-userlayer/src/main/java/org/oskari/map/userlayer/input/FeatureCollectionParsers.java
@@ -80,7 +80,7 @@ public class FeatureCollectionParsers {
                     Geometry transformed = JTS.transform((Geometry) g, transform);
                     copy.setDefaultGeometry(transformed);
                 } else {
-                    LOG.debug("No default geometry, feature id {}", f.getID());
+                    LOG.debug("No default geometry, feature id:", f.getID());
                 }
                 fc.add(copy);
             }

--- a/service-userlayer/src/main/java/org/oskari/map/userlayer/input/GPXParser.java
+++ b/service-userlayer/src/main/java/org/oskari/map/userlayer/input/GPXParser.java
@@ -1,7 +1,6 @@
 package org.oskari.map.userlayer.input;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -56,15 +55,15 @@ public class GPXParser implements FeatureCollectionParser {
             LOG.debug("Found typeNames from GPX:", storeTypeNames);
             for (String typeName : TYPENAMES) {
                 if (!contains(storeTypeNames, typeName)) {
+                    LOG.debug("typeName not found from GPX:", typeName);
                     continue;
                 }
                 SimpleFeatureSource source = store.getFeatureSource(typeName);
                 SimpleFeatureCollection collection = FeatureCollectionParsers.read(source, sourceCRS, targetCRS);
-                if (collection.isEmpty()) {
-                    LOG.info("FeatureCollection was empty, typeName:", typeName);
-                } else {
+                if (!collection.isEmpty()) {
                     return collection;
                 }
+                LOG.info("FeatureCollection was empty, typeName:", typeName);
             }
             throw new ServiceException("Could not find any un-empty FeatureCollections from GPX file");
         } catch (Exception e) {
@@ -84,4 +83,5 @@ public class GPXParser implements FeatureCollectionParser {
         }
         return false;
     }
+
 }

--- a/service-userlayer/src/main/java/org/oskari/map/userlayer/input/GPXParser.java
+++ b/service-userlayer/src/main/java/org/oskari/map/userlayer/input/GPXParser.java
@@ -20,7 +20,7 @@ import fi.nls.oskari.service.ServiceException;
 
 public class GPXParser implements FeatureCollectionParser {
 
-    private static final Logger LOG = LogFactory.getLogger(KMLParser.class);
+    private static final Logger LOG = LogFactory.getLogger(GPXParser.class);
 
     public static final String SUFFIX = "GPX";
 

--- a/service-userlayer/src/main/java/org/oskari/map/userlayer/input/GPXParser.java
+++ b/service-userlayer/src/main/java/org/oskari/map/userlayer/input/GPXParser.java
@@ -65,7 +65,7 @@ public class GPXParser implements FeatureCollectionParser {
                 }
                 LOG.info("FeatureCollection was empty, typeName:", typeName);
             }
-            throw new ServiceException("Could not find any un-empty FeatureCollections from GPX file");
+            throw new ServiceException("Could not find any non-empty FeatureCollections from GPX file");
         } catch (Exception e) {
             throw new ServiceException("GPX parsing failed", e);
         } finally {

--- a/service-userlayer/src/main/java/org/oskari/map/userlayer/input/GPXParser.java
+++ b/service-userlayer/src/main/java/org/oskari/map/userlayer/input/GPXParser.java
@@ -1,6 +1,7 @@
 package org.oskari.map.userlayer.input;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -54,7 +55,7 @@ public class GPXParser implements FeatureCollectionParser {
             String[] storeTypeNames = store.getTypeNames();
             LOG.debug("Found typeNames from GPX:", storeTypeNames);
             for (String typeName : TYPENAMES) {
-                if (!contains(storeTypeNames, typeName)) {
+                if (Arrays.stream(storeTypeNames).noneMatch(s -> s.equals(typeName))) {
                     LOG.debug("typeName not found from GPX:", typeName);
                     continue;
                 }
@@ -73,15 +74,6 @@ public class GPXParser implements FeatureCollectionParser {
                 store.dispose();
             }
         }
-    }
-
-    private boolean contains(String[] a, String k) {
-        for (String s : a) {
-            if (s.equals(k)) {
-                return true;
-            }
-        }
-        return false;
     }
 
 }

--- a/service-userlayer/src/main/java/org/oskari/map/userlayer/input/GPXParser.java
+++ b/service-userlayer/src/main/java/org/oskari/map/userlayer/input/GPXParser.java
@@ -53,7 +53,7 @@ public class GPXParser implements FeatureCollectionParser {
         try {
             store = factory.createDataStore(connectionParams);
             String[] storeTypeNames = store.getTypeNames();
-            LOG.debug("gpx typeNames {}", Arrays.toString(storeTypeNames));
+            LOG.debug("Found typeNames from GPX:", storeTypeNames);
             for (String typeName : TYPENAMES) {
                 if (!contains(storeTypeNames, typeName)) {
                     continue;
@@ -61,7 +61,7 @@ public class GPXParser implements FeatureCollectionParser {
                 SimpleFeatureSource source = store.getFeatureSource(typeName);
                 SimpleFeatureCollection collection = FeatureCollectionParsers.read(source, sourceCRS, targetCRS);
                 if (collection.isEmpty()) {
-                    LOG.info("FeatureCollection was empty, typeName {}", typeName);
+                    LOG.info("FeatureCollection was empty, typeName:", typeName);
                 } else {
                     return collection;
                 }


### PR DESCRIPTION
Currently .gpx import uses the first typeName GeoTools reports (that is not `track_points`). This typeName can easily be empty leading to errors in later stages of the importing process. Instead search the file for typeNames `tracks`, `routes`, `waypoints` (in that order) and use the first one that returns a non-empty collection of Features.
Also add a maximum (100) number of attempts we make to create a unique temporary directory. While the current implementation should never end up in an infinite loop this change makes sure it will never happen.
And also move away from Files.copy(), don't want to deal with CopyOptions (even though current implementation _might_ be correct)