### PR TITLE
Domain check is now case-insensitive

### DIFF
--- a/service-control/src/main/java/fi/nls/oskari/util/RequestHelper.java
+++ b/service-control/src/main/java/fi/nls/oskari/util/RequestHelper.java
@@ -110,7 +110,7 @@ public class RequestHelper {
         }
         try {
             final URL url = new URL(referrer);
-            return url.getHost();
+            return url.getHost().toLowerCase();
         } catch (Exception e) {
             log.warn("Error getting referer from URL:", referrer);
         }

--- a/service-map/src/main/java/fi/nls/oskari/map/view/util/ViewHelper.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/view/util/ViewHelper.java
@@ -59,11 +59,11 @@ public class ViewHelper {
         }
         log.debug("Unrestricted domains:", UNRESTRICTED_USAGE_DOMAINS);
         for (String domain : UNRESTRICTED_USAGE_DOMAINS) {
-            if(domain.equals("*") || referer.endsWith(domain)) {
+            if(domain.equals("*") || referer.endsWith(domain.toLowerCase())) {
                 return true;
             }
         }
-        return referer.endsWith(pubdomain);
+        return referer.endsWith(pubdomain.toLowerCase());
     }
 
     public static JSONObject getConfiguration(final View view) throws ViewException {


### PR DESCRIPTION
The domain given by the user when publishing a map doesn't need to be lowercase anymore.