### PR TITLE
Add timeseries flag for indicators

### DIFF
--- a/control-statistics/src/main/java/fi/nls/oskari/control/statistics/StatisticsHelper.java
+++ b/control-statistics/src/main/java/fi/nls/oskari/control/statistics/StatisticsHelper.java
@@ -99,6 +99,9 @@ public class StatisticsHelper {
             JSONObject selectorJSON = new JSONObject();
             selectorJSON.put("id", selector.getId());
             selectorJSON.put("name", selector.getName());
+            if(selectors.isTimeVariable(selector)) {
+                selectorJSON.put("time", true);
+            }
             selectorJSON.put("allowedValues", toJSON(selector.getAllowedValues()));
             // Note: Values are not given here, they are null anyhow in this phase.
             selectorsJSON.put(selectorJSON);

--- a/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/data/StatisticalIndicatorDataModel.java
+++ b/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/data/StatisticalIndicatorDataModel.java
@@ -14,8 +14,28 @@ public class StatisticalIndicatorDataModel {
     /**
      * The dimensions have a defined order.
      */
-    private List<StatisticalIndicatorDataDimension> dimensions =
-            new ArrayList<StatisticalIndicatorDataDimension>();
+    private List<StatisticalIndicatorDataDimension> dimensions = new ArrayList<>();
+
+    // this is the id of the dimension that re-presents time -> enables time-series analyzes
+    private String timeVariable;
+    public String getTimeVariable() {
+        return timeVariable;
+    }
+
+    public boolean isTimeVariable(StatisticalIndicatorDataDimension selector) {
+        if (selector == null || getTimeVariable() == null) {
+            return false;
+        }
+        String id = selector.getId();
+        if (id == null) {
+            return false;
+        }
+        return id.equalsIgnoreCase(getTimeVariable());
+    }
+
+    public void setTimeVariable(String timeVariable) {
+        this.timeVariable = timeVariable;
+    }
     /**
      * @return A mutable list of dimensions.
      */

--- a/service-statistics-common/src/test/resources/fi/nls/oskari/control/statistics/plugins/indicator_full.json
+++ b/service-statistics-common/src/test/resources/fi/nls/oskari/control/statistics/plugins/indicator_full.json
@@ -12,6 +12,7 @@
     "params" : {}
   }],
   "dataModel": {
+    "timeVariable": null,
     "dimensions": [{
       "id": "sex",
       "value": null,

--- a/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/PxwebConfig.java
+++ b/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/PxwebConfig.java
@@ -16,12 +16,16 @@ public class PxwebConfig {
     private String regionKey;
     private String indicatorKey;
     private Set<String> ignoredVariables = new HashSet<>();
+    private String timeVariableId = null;
 
     public PxwebConfig(JSONObject json, long id) {
         datasourceId = id;
         url = json.optString("url");
         regionKey = json.optString("regionKey");
         indicatorKey = json.optString("indicatorKey");
+
+        // allow override with db config
+        timeVariableId = json.optString("timeVariable", timeVariableId);
         JSONArray ignored = json.optJSONArray("ignoredVariables");
         if(ignored != null) {
             for (int i = 0; i < ignored.length(); i++) {
@@ -57,5 +61,9 @@ public class PxwebConfig {
 
     public Set<String> getIgnoredVariables() {
         return ignoredVariables;
+    }
+
+    public String getTimeVariableId() {
+        return timeVariableId;
     }
 }

--- a/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/json/VariablesItem.java
+++ b/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/json/VariablesItem.java
@@ -23,6 +23,10 @@ public class VariablesItem {
         return code;
     }
 
+    public boolean isTimeVariable() {
+        return time;
+    }
+
     public String getLabel() {
         if(text == null) {
             return getCode();

--- a/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/parser/PxwebIndicatorsParser.java
+++ b/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/parser/PxwebIndicatorsParser.java
@@ -172,6 +172,7 @@ public class PxwebIndicatorsParser {
     protected StatisticalIndicatorDataModel getModel(PxTableItem table) {
         // selectors are shared between indicators in pxweb
         final StatisticalIndicatorDataModel selectors = new StatisticalIndicatorDataModel();
+        selectors.setTimeVariable(config.getTimeVariableId());
         for (VariablesItem item: table.getSelectors()) {
             if(config.getIgnoredVariables().contains(item.getCode())) {
                 continue;

--- a/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/parser/PxwebIndicatorsParser.java
+++ b/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/parser/PxwebIndicatorsParser.java
@@ -181,6 +181,10 @@ public class PxwebIndicatorsParser {
             selector.setName(item.getLabel());
             selector.setAllowedValues(item.getLabels());
             selectors.addDimension(selector);
+            if (item.isTimeVariable()) {
+                // override the time variable config for datasource if we get the information from the API
+                selectors.setTimeVariable(selector.getId());
+            }
         }
         return selectors;
     }

--- a/service-statistics-sotka/src/main/java/fi/nls/oskari/control/statistics/plugins/sotka/SotkaConfig.java
+++ b/service-statistics-sotka/src/main/java/fi/nls/oskari/control/statistics/plugins/sotka/SotkaConfig.java
@@ -7,13 +7,13 @@ public class SotkaConfig {
     private long datasourceId;
     private String url;
     // default to year as it's the time variable on sotkanet
-    private String timeVariableName = "year";
+    private String timeVariableId = "year";
 
     public SotkaConfig(JSONObject json, long id) {
         datasourceId = id;
         url = json.optString("url");
         // allow override with db config
-        timeVariableName = json.optString("timeVariable", timeVariableName);
+        timeVariableId = json.optString("timeVariable", timeVariableId);
     }
 
     public long getId() {
@@ -31,7 +31,7 @@ public class SotkaConfig {
         this.url = url;
     }
 
-    public String getTimeVariableName() {
-        return timeVariableName;
+    public String getTimeVariableId() {
+        return timeVariableId;
     }
 }

--- a/service-statistics-sotka/src/main/java/fi/nls/oskari/control/statistics/plugins/sotka/SotkaConfig.java
+++ b/service-statistics-sotka/src/main/java/fi/nls/oskari/control/statistics/plugins/sotka/SotkaConfig.java
@@ -2,17 +2,18 @@ package fi.nls.oskari.control.statistics.plugins.sotka;
 
 import org.json.JSONObject;
 
-/**
- * Created by SMAKINEN on 30.3.2016.
- */
 public class SotkaConfig {
 
     private long datasourceId;
     private String url;
+    // default to year as it's the time variable on sotkanet
+    private String timeVariableName = "year";
 
     public SotkaConfig(JSONObject json, long id) {
         datasourceId = id;
         url = json.optString("url");
+        // allow override with db config
+        timeVariableName = json.optString("timeVariable", timeVariableName);
     }
 
     public long getId() {
@@ -28,5 +29,9 @@ public class SotkaConfig {
 
     public void setUrl(String url) {
         this.url = url;
+    }
+
+    public String getTimeVariableName() {
+        return timeVariableName;
     }
 }

--- a/service-statistics-sotka/src/main/java/fi/nls/oskari/control/statistics/plugins/sotka/parser/SotkaIndicatorParser.java
+++ b/service-statistics-sotka/src/main/java/fi/nls/oskari/control/statistics/plugins/sotka/parser/SotkaIndicatorParser.java
@@ -110,6 +110,7 @@ public class SotkaIndicatorParser {
     private StatisticalIndicatorDataModel createModel(JSONObject jsonObject) throws JSONException {
         // Note that the key "region" must be skipped, because it was already serialized as layers.
         StatisticalIndicatorDataModel selectors = new StatisticalIndicatorDataModel();
+        selectors.setTimeVariable(config.getTimeVariableName());
         @SuppressWarnings("unchecked")
         Iterator<String> names = jsonObject.keys();
         while (names.hasNext()) {

--- a/service-statistics-sotka/src/main/java/fi/nls/oskari/control/statistics/plugins/sotka/parser/SotkaIndicatorParser.java
+++ b/service-statistics-sotka/src/main/java/fi/nls/oskari/control/statistics/plugins/sotka/parser/SotkaIndicatorParser.java
@@ -110,7 +110,7 @@ public class SotkaIndicatorParser {
     private StatisticalIndicatorDataModel createModel(JSONObject jsonObject) throws JSONException {
         // Note that the key "region" must be skipped, because it was already serialized as layers.
         StatisticalIndicatorDataModel selectors = new StatisticalIndicatorDataModel();
-        selectors.setTimeVariable(config.getTimeVariableName());
+        selectors.setTimeVariable(config.getTimeVariableId());
         @SuppressWarnings("unchecked")
         Iterator<String> names = jsonObject.keys();
         while (names.hasNext()) {

--- a/service-statistics/src/main/java/org/oskari/statistics/user/StatisticalIndicatorServiceMybatisImpl.java
+++ b/service-statistics/src/main/java/org/oskari/statistics/user/StatisticalIndicatorServiceMybatisImpl.java
@@ -137,7 +137,8 @@ public class StatisticalIndicatorServiceMybatisImpl extends StatisticalIndicator
         }
         ind.setPublic(userIndicator.published);
 
-        // Initialize the year dimension as the only one.
+        // Initialize the year dimension as the only one and flag it as time variable to be used in time-series ops.
+        ind.getDataModel().setTimeVariable("year");
         StatisticalIndicatorDataDimension dim = new StatisticalIndicatorDataDimension("year");
         ind.getDataModel().addDimension(dim);
         return ind;


### PR DESCRIPTION
This adds support to flag an indicator variable/selector that describes time. This is supported by user indicators without any configuration. Datasources using the SotkaNet and PXWeb adapters can be configured to treat a predefined variable as the time variable. For SotkaNet it's preconfigured to be "year" as this is the case by default, but it can be overridden by config in database. Similar config can be given to PXWeb datasources and IF the API gives the metadata (variable flagged as "time=true" in the PX-table response) this configuration is overridden.