### PR TITLE
Reverse processing order for loading statistics indicators list

### DIFF
--- a/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/DataSourceUpdater.java
+++ b/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/DataSourceUpdater.java
@@ -81,7 +81,7 @@ public class DataSourceUpdater implements Runnable {
         final List<StatisticalIndicator> processIndicators = new ArrayList<>();
 
         // read work queue to Java classes
-        String json = JedisManager.popList(workCacheKey);
+        String json = JedisManager.popList(workCacheKey, true);
         while(json != null) {
             try {
                 StatisticalIndicator indicator = MAPPER.readValue(json, StatisticalIndicator.class);
@@ -89,7 +89,7 @@ public class DataSourceUpdater implements Runnable {
             } catch (IOException ex) {
                 LOG.error(ex, "Couldn't read indicator data from work queue:", json);
             }
-            json = JedisManager.popList(workCacheKey);
+            json = JedisManager.popList(workCacheKey, true);
         }
         return processIndicators;
     }


### PR DESCRIPTION
When indicator metadatas are being processed by oskari-server they are first saved under temp-key as a list in Redis. When the information in the temporary list is written to the actual cache the results are processed from the last to the first item in the listing (using RPOP on Redis). This results in the list being in reversed order compared to the original one from the service. This change makes the processing take the first item/head of the list (using LPOP on Redis) to correct the order of the listing.