### PR TITLE
Accept more ZIP files in UserLayer import

### DIFF
--- a/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java
+++ b/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java
@@ -148,7 +148,7 @@ public class CreateUserLayerHandler extends ActionHandler {
         try {
             for (Charset cs : POSSIBLE_CHARSETS_USED_IN_ZIP_FILE_NAMES) {
                 try (InputStream in = zipFile.getInputStream();
-                        ZipInputStream zis = new ZipInputStream(in)) {
+                        ZipInputStream zis = new ZipInputStream(in, cs)) {
                     while (zis.getNextEntry() != null) {
                         // Get next
                     }
@@ -293,7 +293,7 @@ public class CreateUserLayerHandler extends ActionHandler {
 
     private File unZip(FileItem zipFile, Charset cs, Set<String> validFiles, File dir) throws ActionException {
         try (InputStream in = zipFile.getInputStream();
-                ZipInputStream zis = new ZipInputStream(in)) {
+                ZipInputStream zis = new ZipInputStream(in, cs)) {
             ZipEntry ze;
             File mainFile = null;
             while ((ze = zis.getNextEntry()) != null) {

--- a/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java
+++ b/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java
@@ -266,10 +266,17 @@ public class CreateUserLayerHandler extends ActionHandler {
             ZipEntry ze;
             File mainFile = null;
             while ((ze = zis.getNextEntry()) != null) {
+                if (ze.isDirectory()) {
+                    continue;
+                }
                 String name = ze.getName();
                 if (!validFiles.contains(name)) {
                     continue;
                 }
+                // Beyond this point all files in the root directory of the zip have a non-empty file extension
+                // Also we've checked that no two files share the same file extension
+                // Save all the files to $TEMP/{random_uuid_dir}/a.{ext} to eliminate the possibility of illegal characters in the filename
+                name = "a" + name.substring(name.lastIndexOf('.'));
                 File file = new File(dir, name);
                 try (FileOutputStream fos = new FileOutputStream(file)) {
                     IOHelper.copy(zis, fos);

--- a/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java
+++ b/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java
@@ -5,6 +5,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.List;
@@ -34,11 +35,11 @@ import org.oskari.map.userlayer.service.UserLayerDbServiceMybatisImpl;
 
 import fi.mml.map.mapwindow.util.OskariLayerWorker;
 import fi.nls.oskari.annotation.OskariActionRoute;
+import fi.nls.oskari.control.ActionConstants;
 import fi.nls.oskari.control.ActionException;
 import fi.nls.oskari.control.ActionHandler;
 import fi.nls.oskari.control.ActionParameters;
 import fi.nls.oskari.control.ActionParamsException;
-import fi.nls.oskari.control.ActionConstants;
 import fi.nls.oskari.domain.map.userlayer.UserLayer;
 import fi.nls.oskari.domain.map.userlayer.UserLayerData;
 import fi.nls.oskari.domain.map.userlayer.UserLayerStyle;
@@ -74,6 +75,12 @@ public class CreateUserLayerHandler extends ActionHandler {
     private static final String PROPERTY_USERLAYER_MAX_FILE_SIZE_MB = "userlayer.max.filesize.mb";
     private static final String PROPERTY_TARGET_EPSG = "oskari.native.srs";
     private static final int MAX_FILES_IN_ZIP = 10;
+
+    private static final Charset[] POSSIBLE_CHARSETS_USED_IN_ZIP_FILE_NAMES = {
+            StandardCharsets.UTF_8,
+            Charset.forName("CP437"),
+            Charset.forName("CP866")
+    };
 
     private static final String PARAM_SOURCE_EPSG_KEY = "sourceEpsg";
     private static final String KEY_NAME = "layer-name";
@@ -123,8 +130,9 @@ public class CreateUserLayerHandler extends ActionHandler {
                     .findAny() // If there are more files we'll get the zip or fail miserably
                     .orElseThrow(() -> new ActionParamsException("No file entries"));
             log.debug("Using value from field:", zipFile.getFieldName(), "as the zip file");
-            Set<String> validFiles = checkZip(zipFile);
-            fc = parseFeatures(zipFile, validFiles, sourceCRS, targetCRS);
+            Charset cs = determineCharsetForZipFileNames(zipFile);
+            Set<String> validFiles = checkZip(zipFile, cs);
+            fc = parseFeatures(zipFile, cs, validFiles, sourceCRS, targetCRS);
             formParams = getFormParams(fileItems);
             log.debug("Parsed form parameters:", formParams);
         } finally {
@@ -133,6 +141,25 @@ public class CreateUserLayerHandler extends ActionHandler {
 
         UserLayer userLayer = store(fc, params.getUser().getUuid(), formParams);
         writeResponse(params, userLayer);
+    }
+
+    private Charset determineCharsetForZipFileNames(FileItem zipFile) throws ActionException {
+        try {
+            for (Charset cs : POSSIBLE_CHARSETS_USED_IN_ZIP_FILE_NAMES) {
+                try (InputStream in = zipFile.getInputStream();
+                        ZipInputStream zis = new ZipInputStream(in)) {
+                    while (zis.getNextEntry() != null) {
+                        // Get next
+                    }
+                    return cs;
+                } catch (IllegalArgumentException ignore) {
+                    log.debug("Failed to read zip file names with encoding:", cs.name());
+                }
+            }
+            throw new ActionException("Failed to decode file names in the zip file");
+        } catch (IOException e) {
+            throw new ActionException("Unexpected IOException occured", e);
+        }
     }
 
     private CoordinateReferenceSystem decodeCRS(String epsg) throws ActionParamsException {
@@ -154,9 +181,9 @@ public class CreateUserLayerHandler extends ActionHandler {
         }
     }
 
-    private Set<String> checkZip(FileItem zipFile) throws ActionException {
+    private Set<String> checkZip(FileItem zipFile, Charset cs) throws ActionException {
         try (InputStream in = zipFile.getInputStream();
-                ZipInputStream zis = new ZipInputStream(in)) {
+                ZipInputStream zis = new ZipInputStream(in, cs)) {
             Set<String> validFiles = new HashSet<>();
             Set<String> extensions = new HashSet<>();
             ZipEntry ze;
@@ -208,13 +235,13 @@ public class CreateUserLayerHandler extends ActionHandler {
     }
 
     private SimpleFeatureCollection parseFeatures(FileItem zipFile,
-            Set<String> validFiles,
+            Charset cs, Set<String> validFiles,
             CoordinateReferenceSystem sourceCRS,
             CoordinateReferenceSystem targetCRS) throws ActionException {
         File dir = null;
         try {
             dir = makeRandomTempDirectory();
-            File mainFile = unZip(zipFile, validFiles, dir);
+            File mainFile = unZip(zipFile, cs, validFiles, dir);
             FeatureCollectionParser parser = getParser(mainFile);
             return parse(parser, mainFile, sourceCRS, targetCRS);
         } finally {
@@ -260,7 +287,7 @@ public class CreateUserLayerHandler extends ActionHandler {
         }
     }
 
-    private File unZip(FileItem zipFile, Set<String> validFiles, File dir) throws ActionException {
+    private File unZip(FileItem zipFile, Charset cs, Set<String> validFiles, File dir) throws ActionException {
         try (InputStream in = zipFile.getInputStream();
                 ZipInputStream zis = new ZipInputStream(in)) {
             ZipEntry ze;

--- a/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java
+++ b/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java
@@ -170,10 +170,11 @@ public class CreateUserLayerHandler extends ActionHandler {
                     continue;
                 }
                 String name = ze.getName();
-                String ext = getFileExt(name).toLowerCase();
+                String ext = getFileExt(name);
                 if (ext == null) {
                     continue;
                 }
+                ext = ext.toLowerCase();
                 if (!extensions.add(ext)) {
                     throw new ActionParamsException("Zip contains multiple files with same extension");
                 }

--- a/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java
+++ b/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java
@@ -1,7 +1,6 @@
 package org.oskari.control.userlayer;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -15,7 +14,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
-import java.util.zip.ZipException;
 import java.util.zip.ZipInputStream;
 
 import javax.servlet.http.HttpServletRequest;
@@ -80,6 +78,7 @@ public class CreateUserLayerHandler extends ActionHandler {
 
     private static final Charset[] POSSIBLE_CHARSETS_USED_IN_ZIP_FILE_NAMES = {
             StandardCharsets.UTF_8,
+            StandardCharsets.ISO_8859_1,
             Charset.forName("CP437"),
             Charset.forName("CP866")
     };

--- a/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java
+++ b/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java
@@ -1,6 +1,7 @@
 package org.oskari.control.userlayer;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -14,6 +15,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
+import java.util.zip.ZipException;
 import java.util.zip.ZipInputStream;
 
 import javax.servlet.http.HttpServletRequest;
@@ -197,6 +199,9 @@ public class CreateUserLayerHandler extends ActionHandler {
                     continue;
                 }
                 String name = ze.getName();
+                if (name.indexOf('/') >= 0) {
+                    continue;
+                }
                 String ext = getFileExt(name);
                 if (ext == null) {
                     continue;


### PR DESCRIPTION
Handle ZIP files where filenames aren't encoded in UTF8 (for example Windows ZIP utility does this).
Actually ignore files in subdirectories (not just the directory entries)
Name all temporary files as `a.{ext}` to avoid illegal characters in filename (if the extension part contains illegal characters for a filename this still fails)