### PR TITLE
Commit user indicator delete ops

### DIFF
--- a/service-statistics/src/main/java/org/oskari/statistics/user/StatisticalIndicatorServiceMybatisImpl.java
+++ b/service-statistics/src/main/java/org/oskari/statistics/user/StatisticalIndicatorServiceMybatisImpl.java
@@ -88,13 +88,16 @@ public class StatisticalIndicatorServiceMybatisImpl extends StatisticalIndicator
 
     public boolean delete(long id, long userId) {
         try (final SqlSession session = factory.openSession()) {
-            return getMapper(session).delete(id, userId) != 0;
+            int count = getMapper(session).delete(id, userId);
+            session.commit();
+            return count != 0;
         }
     }
 
     public void deleteByUser(long userId) {
         try (final SqlSession session = factory.openSession()) {
             getMapper(session).deleteByUser(userId);
+            session.commit();
         }
     }
 
@@ -192,6 +195,7 @@ public class StatisticalIndicatorServiceMybatisImpl extends StatisticalIndicator
     public boolean deleteIndicatorData(long indicator, long regionset, int year) {
         try (final SqlSession session = factory.openSession()) {
             int updated = getMapper(session).deleteData(indicator, regionset, year);
+            session.commit();
             return updated != 0;
         }
     }

--- a/service-statistics/src/main/java/org/oskari/statistics/user/StatisticalIndicatorServiceMybatisImpl.java
+++ b/service-statistics/src/main/java/org/oskari/statistics/user/StatisticalIndicatorServiceMybatisImpl.java
@@ -157,6 +157,10 @@ public class StatisticalIndicatorServiceMybatisImpl extends StatisticalIndicator
     }
 
     private void addDimension(StatisticalIndicator ind, UserIndicatorDataRow row) {
+        if(row.regionsetId == 0) {
+            // no data for indicator
+            return;
+        }
         if(ind.getLayer(row.regionsetId) == null) {
             ind.addLayer(new StatisticalIndicatorLayer(row.regionsetId, ind.getId()));
         }


### PR DESCRIPTION
Delete database ops were not completed properly with commit() missing. Also removal of the last dataset made indicator have a regionset with id 0 and year 0. Fixes the 0 data as well.