### PR TITLE
Statistics maps regionsets handling

### DIFF
--- a/control-statistics/src/main/java/fi/nls/oskari/control/StatsgridHandler.java
+++ b/control-statistics/src/main/java/fi/nls/oskari/control/StatsgridHandler.java
@@ -74,12 +74,12 @@ public class StatsgridHandler extends BundleHandler {
         Collection<JSONObject> regionsets = pluginManager.getDatasources().stream()
                 // get layers from sources
                 .map(src -> src.getLayers())
-                .flatMap(layer -> layer.stream())
-                // get distinct layers
+                .flatMap(layerList -> layerList.stream())
+                // get distinct layers by creating a map with layer ids as keys
                 .collect(Collectors.toMap(DatasourceLayer::getMaplayerId, Function.identity(), (a,b) -> a))
                 .values().stream()
-                // TODO: check permissions
-                .filter(l -> l.getMaplayerId() != -1)
+                // check permissions
+                .filter(l -> l.hasPermission(params.getUser()))
                 // write to JSON
                 .map(l -> toJSON(l, language))
                 .collect(Collectors.toList());

--- a/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/StatisticalDatasourceFactory.java
+++ b/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/StatisticalDatasourceFactory.java
@@ -1,5 +1,6 @@
 package fi.nls.oskari.control.statistics.plugins;
 
+import fi.mml.portti.domain.permissions.Permissions;
 import fi.nls.oskari.control.statistics.plugins.db.DatasourceLayer;
 import fi.nls.oskari.control.statistics.plugins.db.DatasourceLayerMapper;
 import fi.nls.oskari.control.statistics.plugins.db.StatisticalDatasource;
@@ -13,9 +14,14 @@ import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 import org.apache.ibatis.transaction.TransactionFactory;
 import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
+import org.oskari.service.util.ServiceFactory;
 
 import javax.sql.DataSource;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Used to create plugin instances for source
@@ -28,13 +34,35 @@ public abstract class StatisticalDatasourceFactory extends OskariComponent {
         final DatasourceHelper helper = DatasourceHelper.getInstance();
         final DataSource dataSource = helper.getDataSource(helper.getOskariDataSourceName());
         final SqlSessionFactory factory = initializeIBatis(dataSource);
-        final SqlSession session = factory.openSession();
-        try {
+        try (final SqlSession session = factory.openSession()) {
             final List<DatasourceLayer> layerRows = session.getMapper(DatasourceLayerMapper.class).getLayersForDatasource(source.getId());
+
+            // fetch a list of permissions for the regionset layers
+            Map<Long, List<Permissions>> permissions = ServiceFactory.getPermissionsService()
+                    .getPermissionsForLayers(layerRows.stream()
+                            .map(DatasourceLayer::getMaplayerId)
+                            .collect(Collectors.toList()), Permissions.PERMISSION_TYPE_VIEW_LAYER);
+            // attach role ids that are permitted to see this regionset for each layer
+            layerRows.forEach(
+                    layer -> layer.addRoles(getRoleIdsForLayer(
+                            permissions.get(layer.getMaplayerId()))));
             source.setLayers(layerRows);
-        } finally {
-            session.close();
         }
+    }
+
+    /**
+     * Returns a list of role ids
+     * @param permissions
+     * @return
+     */
+    private Set<Long> getRoleIdsForLayer(List<Permissions> permissions) {
+        if(permissions == null) {
+            return Collections.emptySet();
+        }
+        return permissions.stream()
+                .filter(p -> p.getExternalIdType().equals(Permissions.EXTERNAL_TYPE_ROLE))
+                .map(p -> Long.parseLong(p.getExternalId()))
+                .collect(Collectors.toSet());
     }
 
     private SqlSessionFactory initializeIBatis(final DataSource dataSource) {

--- a/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/db/DatasourceLayer.java
+++ b/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/db/DatasourceLayer.java
@@ -1,5 +1,6 @@
 package fi.nls.oskari.control.statistics.plugins.db;
 
+import fi.nls.oskari.util.PropertyUtil;
 import org.json.JSONObject;
 
 /**
@@ -27,6 +28,9 @@ public class DatasourceLayer {
      *  These are the layer names used by the plugin.
      */
     private JSONObject config;
+
+    // {"fi":{"name":"Pohjois-Karjalan maakuntakaava: Aluevaraukset"}}} from oskari_maplayer.locale
+    private JSONObject locale;
 
     public long getDatasourceId() {
         return datasourceId;
@@ -56,5 +60,35 @@ public class DatasourceLayer {
 
     public void setConfig(JSONObject config) {
         this.config = config;
+    }
+
+
+    public String getTitle(String lang) {
+        JSONObject langJSON = getLocalized(lang);
+        if(langJSON == null) {
+            return null;
+        }
+        return langJSON.optString("name");
+    }
+    private JSONObject getLocalized(String lang) {
+        if(locale == null || locale.length() == 0) {
+            return null;
+        }
+        if (lang == null) {
+            lang = PropertyUtil.getDefaultLanguage();
+        }
+        final JSONObject value = locale.optJSONObject(lang);
+        if(value != null) {
+            return value;
+        }
+
+        if (!lang.equalsIgnoreCase(PropertyUtil.getDefaultLanguage())) {
+            final JSONObject defaultValue = locale.optJSONObject(PropertyUtil.getDefaultLanguage());
+            if(defaultValue != null) {
+                return defaultValue;
+            }
+        }
+        final String randomLang = (String) locale.keys().next();
+        return locale.optJSONObject(randomLang);
     }
 }

--- a/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/db/DatasourceLayer.java
+++ b/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/db/DatasourceLayer.java
@@ -1,7 +1,13 @@
 package fi.nls.oskari.control.statistics.plugins.db;
 
+import fi.nls.oskari.domain.Role;
+import fi.nls.oskari.domain.User;
 import fi.nls.oskari.util.PropertyUtil;
 import org.json.JSONObject;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * This is the value object for the statistical datasource layer
@@ -30,7 +36,10 @@ public class DatasourceLayer {
     private JSONObject config;
 
     // {"fi":{"name":"Pohjois-Karjalan maakuntakaava: Aluevaraukset"}}} from oskari_maplayer.locale
+    // set by mybatis mapper
     private JSONObject locale;
+
+    private Set<Long> allowedRoles = new HashSet<>();
 
     public long getDatasourceId() {
         return datasourceId;
@@ -62,6 +71,15 @@ public class DatasourceLayer {
         this.config = config;
     }
 
+    public void addRoles(Collection<Long> roleIds) {
+        allowedRoles.addAll(roleIds);
+    }
+
+    public boolean hasPermission(User user) {
+        return user.getRoles().stream()
+                .map(Role::getId)
+                .anyMatch(id -> allowedRoles.contains(id));
+    }
 
     public String getTitle(String lang) {
         JSONObject langJSON = getLocalized(lang);

--- a/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/db/DatasourceLayerMapper.java
+++ b/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/db/DatasourceLayerMapper.java
@@ -12,9 +12,9 @@ import java.util.List;
  */
 public interface DatasourceLayerMapper {
 
-    @Select("SELECT datasource_id, layer_id, config" +
-            " FROM oskari_statistical_layer WHERE " +
-            " datasource_id = #{datasourceId}")
+    @Select("SELECT s.datasource_id, s.layer_id, s.config, l.locale" +
+            " FROM oskari_statistical_layer s JOIN oskari_maplayer l ON l.id = s.layer_id WHERE " +
+            " s.datasource_id = #{datasourceId}")
     @Results({
             @Result(property = "datasourceId", column = "datasource_id"),
             @Result(property = "maplayerId", column = "layer_id")


### PR DESCRIPTION
Statistics regionsets are currently handled as maplayers, but they don't really function too well outside the thematic maps user interface. This change adds a listing of regionsets with id and name to the statsgrid bundle config. These can be used to create the vectorlayers that the thematic map uses without having the regionsets as "normal" maplayers in the frontend.

This a step towards removing statslayers from the maplayer listing on the frontend and allows the frontend to use this information instead of searching for maplayers of type "statslayer". After the frontend change the statslayer maplayers can be removed from the layers response going to the frontend.