### PR TITLE
Fix metres per points calculation in PDF printouts

### DIFF
--- a/service-print/src/main/java/org/oskari/print/PDF.java
+++ b/service-print/src/main/java/org/oskari/print/PDF.java
@@ -274,7 +274,7 @@ public class PDF {
             return;
         }
 
-        double mppt = mppx * Units.PDF_DPI / Units.OGC_DPI;
+        double mppt = mppx * Units.OGC_DPI / Units.PDF_DPI;
 
         // Draw atleast 50pt
         double minDistance = mppt * 50;


### PR DESCRIPTION
The length of the scale line was calculated wrong.