### PR TITLE
Limit proxy

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/layer/GetMapLayerGroupsHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/GetMapLayerGroupsHandler.java
@@ -45,6 +45,11 @@ public class GetMapLayerGroupsHandler extends ActionHandler {
     private static final String KEY_ID = "id";
     private static final String KEY_ORDER_NUMBER = "orderNumber";
 
+    private static final List<String> PROXY_LYR_TYPES = Arrays.asList(
+            OskariLayer.TYPE_WMS,
+            OskariLayer.TYPE_WMTS,
+            OskariLayer.TYPE_ARCGIS93);
+
     private OskariLayerService layerService;
     private PermissionsService permissionsService;
     private OskariMapLayerGroupService groupService;
@@ -96,12 +101,14 @@ public class GetMapLayerGroupsHandler extends ActionHandler {
 
         if (forceProxy) {
             layers.forEach(lyr -> {
-                JSONObject attributes = lyr.getAttributes();
-                if (attributes == null) {
-                    attributes = new JSONObject();
+                if (PROXY_LYR_TYPES.contains(lyr.getType())) {
+                    JSONObject attributes = lyr.getAttributes();
+                    if (attributes == null) {
+                        attributes = new JSONObject();
+                    }
+                    JSONHelper.putValue(attributes, "forceProxy",true);
+                    lyr.setAttributes(attributes);
                 }
-                JSONHelper.putValue(attributes, "forceProxy",true);
-                lyr.setAttributes(attributes);
             });
         }
 

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/OskariLayer.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/OskariLayer.java
@@ -18,6 +18,7 @@ public class OskariLayer extends JSONLocalizedNameAndTitle implements Comparable
     public static final String TYPE_ANALYSIS = "analysislayer";
     public static final String TYPE_USERLAYER = "userlayer";
     public static final String TYPE_ARCGIS93 = "arcgis93layer";
+    public static final String TYPE_3DTILES = "tiles3dlayer";
 
     private int id = -1;
     private int parentId = -1;


### PR DESCRIPTION
When proxying all layers is requested on loading the layers data, limits proxying to affect only layers of specified types .