### PR TITLE
Fix logout after enabling CSRF

### DIFF
--- a/servlet-map/src/main/java/fi/nls/oskari/spring/security/OskariCommonSecurityConfig.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/spring/security/OskariCommonSecurityConfig.java
@@ -34,8 +34,9 @@ public class OskariCommonSecurityConfig extends WebSecurityConfigurerAdapter {
         // FIXME: When we want to use SAML singleLogout, we should disable this and call /saml/SingleLogout
         http
             .headers().frameOptions().disable()
-            .and().antMatcher(logoutUrl).logout()
-                .logoutRequestMatcher(new AntPathRequestMatcher(logoutUrl))
+            .and()
+                // NOTE! With CSRF enabled, logout needs to happen with POST request
+                .logout()
                 .logoutUrl(logoutUrl)
                 .invalidateHttpSession(true)
                 .deleteCookies("oskaristate")

--- a/servlet-map/src/main/resources/META-INF/resources/spring-map-jsp/index.jsp
+++ b/servlet-map/src/main/resources/META-INF/resources/spring-map-jsp/index.jsp
@@ -120,7 +120,10 @@
         <c:choose>
             <%-- If logout url is present - so logout link --%>
             <c:when test="${!empty _logout_uri}">
-                <a href="${pageContext.request.contextPath}${_logout_uri}"><spring:message code="logout" text="Logout" /></a>
+                <form action="${pageContext.request.contextPath}${_logout_uri}" method="POST" id="logoutform">
+                    <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
+                    <a href="${pageContext.request.contextPath}${_logout_uri}" onClick="jQuery('#logoutform').submit();return false;"><spring:message code="logout" text="Logout" /></a>
+                </form>
                 <%-- oskari-profile-link id is used by the personaldata bundle - do not modify --%>
                 <a href="${pageContext.request.contextPath}${_registration_uri}" id="oskari-profile-link"><spring:message code="account" text="Account" /></a>
             </c:when>


### PR DESCRIPTION
Spring security needs logout to happen with HTTP POST when using CSRF. This fixes the issue with logout after CSRF was enabled in #240.

Oskari instances with customized JSP-pages need to update the logout-link to work with something similar to this:

    <form action="${pageContext.request.contextPath}${_logout_uri}" method="POST" id="logoutform">
        <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
        <a href="${pageContext.request.contextPath}${_logout_uri}" onClick="jQuery('#logoutform').submit();return false;"><spring:message code="logout" text="Logout" /></a>
    </form>