### PR TITLE
Support for printing UserLayers

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/data/GetPrintHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/data/GetPrintHandler.java
@@ -75,6 +75,7 @@ public class GetPrintHandler extends ActionHandler {
     private static final int MARGIN_HEIGHT = 15 * 2;
 
     private static final String PREFIX_MY_PLACES = "myplaces_";
+    private static final String PREFIX_USER_LAYER = "userlayer_";
 
     private final PermissionHelper permissionHelper;
     private final PrintService printService;
@@ -238,6 +239,9 @@ public class GetPrintHandler extends ActionHandler {
             } else if (layerId.startsWith(PREFIX_MY_PLACES)) {
                 int categoryId = ConversionHelper.getInt(layerId.substring(PREFIX_MY_PLACES.length()), -1);
                 printLayer = createMyPlacesPrintLayer(categoryId, requestedLayer);
+            } else if (layerId.startsWith(PREFIX_USER_LAYER)) {
+                int userLayerId = ConversionHelper.getInt(layerId.substring(PREFIX_USER_LAYER.length()), -1);
+                printLayer = createUserLayerPrintLayer(userLayerId, requestedLayer);
             }
             if (printLayer != null) {
                 printLayers.add(printLayer);
@@ -387,6 +391,22 @@ public class GetPrintHandler extends ActionHandler {
         layer.setType("myplaces");
         layer.setVersion("1.3.0");
         layer.setName("oskari:my_places_categories");
+        layer.setOpacity(opacity);
+        return layer;
+    }
+
+    private PrintLayer createUserLayerPrintLayer(int userLayerId, LayerProperties requestedLayer) {
+        int opacity = requestedLayer.getOpacity() != null ? requestedLayer.getOpacity() : 100;
+        if (opacity <= 0) {
+            // Ignore fully transparent layers
+            return null;
+        }
+
+        PrintLayer layer = new PrintLayer();
+        layer.setId(userLayerId);
+        layer.setType(OskariLayer.TYPE_USERLAYER);
+        layer.setVersion("1.3.0");
+        layer.setName("oskari:user_layer_data_style");
         layer.setOpacity(opacity);
         return layer;
     }

--- a/service-print/src/main/java/org/oskari/print/loader/AsyncImageLoader.java
+++ b/service-print/src/main/java/org/oskari/print/loader/AsyncImageLoader.java
@@ -47,6 +47,10 @@ public class AsyncImageLoader {
                 images.add(new CommandLoadImageMyPlaces(request.getUser(),
                         layer, width, height, bbox, srsName).queue());
                 break;
+            case OskariLayer.TYPE_USERLAYER:
+                images.add(new CommandLoadImageUserLayer(request.getUser(),
+                        layer, width, height, bbox, srsName).queue());
+                break;
             default:
                 throw new IllegalArgumentException("Invalid layer type!");
             }

--- a/service-print/src/main/java/org/oskari/print/loader/CommandLoadImageUserLayer.java
+++ b/service-print/src/main/java/org/oskari/print/loader/CommandLoadImageUserLayer.java
@@ -1,0 +1,77 @@
+package org.oskari.print.loader;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Map;
+
+import javax.imageio.ImageIO;
+import javax.servlet.http.HttpServletRequest;
+
+import org.oskari.print.request.PrintLayer;
+import org.oskari.print.util.GetMapBuilder;
+import org.oskari.print.util.ModifiedHttpServletRequest;
+
+import fi.nls.oskari.control.ActionParameters;
+import fi.nls.oskari.domain.User;
+import fi.nls.oskari.service.ProxyService;
+
+/**
+ * HystrixCommand that loads BufferedImage from UserLayer via ProxyService
+ */
+public class CommandLoadImageUserLayer extends CommandLoadImageBase {
+
+    private static final String FORMAT = "image/png";
+
+    private final User user;
+    private final PrintLayer layer;
+    private final int width;
+    private final int height;
+    private final double[] bbox;
+    private final String srsName;
+
+    public CommandLoadImageUserLayer(User user,
+            PrintLayer layer,
+            int width,
+            int height,
+            double[] bbox,
+            String srsName) {
+        super("myplaces_" + layer.getId());
+        this.user = user;
+        this.layer = layer;
+        this.width = width;
+        this.height = height;
+        this.bbox = bbox;
+        this.srsName = srsName;
+    }
+
+    @Override
+    public BufferedImage run() throws Exception {
+        Map<String, String> queryParams = new GetMapBuilder()
+                .version(layer.getVersion())
+                .layer(layer.getName())
+                .bbox(bbox)
+                .crs(srsName)
+                .width(width)
+                .height(height)
+                .format(FORMAT)
+                .transparent(true)
+                .toParamMap();
+        queryParams.put("id", Integer.toString(layer.getId()));
+
+        HttpServletRequest request = new ModifiedHttpServletRequest(queryParams);
+        ActionParameters params = new ActionParameters();
+        params.setUser(user);
+        params.setRequest(request);
+
+        byte[] resp = ProxyService.proxyBinary("userlayertile", params);
+        InputStream input = new ByteArrayInputStream(resp);
+        return ImageIO.read(input);
+    }
+
+    @Override
+    public BufferedImage getFallback() {
+        return null;
+    }
+
+}


### PR DESCRIPTION
Currently userlayer_ layers are ignored in the GetPrint ActionRoute and the underlying service. This adds support for them. The images for the layers are created the same way UserLayerTile creates them (via ProxyService).

`CommandLoadImageUserLayer` uses two magic keys ("id" and "userlayertile") without referring to the original static final fields. We could use the original Strings, but that would require adding dependencies to the modules where they live to the print-service module.
