### PR TITLE
Ignore CSRF for logout

### DIFF
--- a/servlet-map/src/main/java/fi/nls/oskari/spring/security/OskariCommonSecurityConfig.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/spring/security/OskariCommonSecurityConfig.java
@@ -28,6 +28,8 @@ public class OskariCommonSecurityConfig extends WebSecurityConfigurerAdapter {
 
         final String logoutUrl = env.getLogoutUrl();
 
+        // CSRF config is needed in this particular config even if it's not otherwise configured here...
+        http.csrf().ignoringAntMatchers(logoutUrl);
         http
             .headers().frameOptions().disable()
             .and()
@@ -38,8 +40,8 @@ public class OskariCommonSecurityConfig extends WebSecurityConfigurerAdapter {
                 // NOTE! With CSRF enabled logout needs to happen with POST request
                 .logout()
                 .logoutUrl(logoutUrl)
-                .invalidateHttpSession(true)
                 .deleteCookies("oskaristate","JSESSIONID", "CSRF-TOKEN")
+                .invalidateHttpSession(true)
                 .logoutSuccessUrl("/");
     }
 }

--- a/servlet-saml-config/src/main/java/fi/nls/oskari/spring/security/saml/OskariSAMLSecurityConfig.java
+++ b/servlet-saml-config/src/main/java/fi/nls/oskari/spring/security/saml/OskariSAMLSecurityConfig.java
@@ -31,8 +31,8 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-import org.springframework.security.config.annotation.web.servlet.configuration.EnableWebMvcSecurity;
 import org.springframework.security.saml.*;
 import org.springframework.security.saml.context.SAMLContextProviderImpl;
 import org.springframework.security.saml.context.SAMLContextProviderLB;
@@ -78,7 +78,7 @@ import java.util.*;
  */
 @Profile(SpringEnvHelper.PROFILE_LOGIN_SAML)
 @Configuration
-@EnableWebMvcSecurity
+@EnableWebSecurity
 @EnableGlobalMethodSecurity(securedEnabled = true)
 @ImportResource("classpath:/saml/samlBindings.xml")
 public class OskariSAMLSecurityConfig extends WebSecurityConfigurerAdapter {


### PR DESCRIPTION
Added http.csrf().ignoringAntMatchers(logoutUrl); to the common logout config to make it compatible with PTI preauth login.