### PR TITLE
Support for printing Analysis layers

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/data/GetPrintHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/data/GetPrintHandler.java
@@ -381,13 +381,16 @@ public class GetPrintHandler extends ActionHandler {
         int opacity = requestedLayer.getOpacity() != null ? requestedLayer.getOpacity() : 100;
         if (opacity <= 0) {
             // Ignore fully transparent layers
+            LOG.info("Ignoring zero opacity layer:", requestedLayer.getId());
             return null;
         }
 
-        String layerIdWithoutPrefix = requestedLayer.getId().substring(p.prefix.length());
-        int id = ConversionHelper.getInt(layerIdWithoutPrefix, -1);
+        int lastUnderscore = requestedLayer.getId().lastIndexOf('_');
+        String layerId = requestedLayer.getId().substring(lastUnderscore + 1);
+        int id = ConversionHelper.getInt(layerId, -1);
         if (id < 0) {
             // Ignore layers with negative id
+            LOG.info("Failed to parse integer id from:", requestedLayer.getId());
             return null;
         }
 

--- a/control-base/src/main/java/fi/nls/oskari/control/data/GetPrintHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/data/GetPrintHandler.java
@@ -76,6 +76,7 @@ public class GetPrintHandler extends ActionHandler {
 
     private static final String PREFIX_MY_PLACES = "myplaces_";
     private static final String PREFIX_USER_LAYER = "userlayer_";
+    private static final String PREFIX_ANALYSIS = "analysis_";
 
     private final PermissionHelper permissionHelper;
     private final PrintService printService;
@@ -242,6 +243,9 @@ public class GetPrintHandler extends ActionHandler {
             } else if (layerId.startsWith(PREFIX_USER_LAYER)) {
                 int userLayerId = ConversionHelper.getInt(layerId.substring(PREFIX_USER_LAYER.length()), -1);
                 printLayer = createUserLayerPrintLayer(userLayerId, requestedLayer);
+            } else if (layerId.startsWith(PREFIX_ANALYSIS)) {
+                int analysisId = ConversionHelper.getInt(layerId.substring(PREFIX_ANALYSIS.length()), -1);
+                printLayer = createUserLayerPrintLayer(analysisId, requestedLayer);
             }
             if (printLayer != null) {
                 printLayers.add(printLayer);
@@ -407,6 +411,22 @@ public class GetPrintHandler extends ActionHandler {
         layer.setType(OskariLayer.TYPE_USERLAYER);
         layer.setVersion("1.3.0");
         layer.setName("oskari:user_layer_data_style");
+        layer.setOpacity(opacity);
+        return layer;
+    }
+
+    private PrintLayer createAnalysisPrintLayer(int analysisId, LayerProperties requestedLayer) {
+        int opacity = requestedLayer.getOpacity() != null ? requestedLayer.getOpacity() : 100;
+        if (opacity <= 0) {
+            // Ignore fully transparent layers
+            return null;
+        }
+
+        PrintLayer layer = new PrintLayer();
+        layer.setId(analysisId);
+        layer.setType(OskariLayer.TYPE_ANALYSIS);
+        layer.setVersion("1.3.0");
+        layer.setName("oskari:analysis_data_style");
         layer.setOpacity(opacity);
         return layer;
     }

--- a/control-base/src/main/java/fi/nls/oskari/control/data/GetPrintHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/data/GetPrintHandler.java
@@ -74,10 +74,6 @@ public class GetPrintHandler extends ActionHandler {
     private static final int MARGIN_WIDTH = 10 * 2;
     private static final int MARGIN_HEIGHT = 15 * 2;
 
-    private static final String PREFIX_MY_PLACES = "myplaces_";
-    private static final String PREFIX_USER_LAYER = "userlayer_";
-    private static final String PREFIX_ANALYSIS = "analysis_";
-
     private final PermissionHelper permissionHelper;
     private final PrintService printService;
 
@@ -237,15 +233,13 @@ public class GetPrintHandler extends ActionHandler {
             if (id != -1) {
                 OskariLayer oskariLayer = permissionHelper.getLayer(id, user);
                 printLayer = createPrintLayer(oskariLayer, requestedLayer);
-            } else if (layerId.startsWith(PREFIX_MY_PLACES)) {
-                int categoryId = ConversionHelper.getInt(layerId.substring(PREFIX_MY_PLACES.length()), -1);
-                printLayer = createMyPlacesPrintLayer(categoryId, requestedLayer);
-            } else if (layerId.startsWith(PREFIX_USER_LAYER)) {
-                int userLayerId = ConversionHelper.getInt(layerId.substring(PREFIX_USER_LAYER.length()), -1);
-                printLayer = createUserLayerPrintLayer(userLayerId, requestedLayer);
-            } else if (layerId.startsWith(PREFIX_ANALYSIS)) {
-                int analysisId = ConversionHelper.getInt(layerId.substring(PREFIX_ANALYSIS.length()), -1);
-                printLayer = createUserLayerPrintLayer(analysisId, requestedLayer);
+            } else {
+                for (ProxyPrintLayer p : ProxyPrintLayer.values()) {
+                    if (layerId.startsWith(p.prefix)) {
+                        printLayer = createProxyLayer(p, requestedLayer);
+                        break;
+                    }
+                }
             }
             if (printLayer != null) {
                 printLayers.add(printLayer);
@@ -383,50 +377,25 @@ public class GetPrintHandler extends ActionHandler {
         return arr;
     }
 
-    private PrintLayer createMyPlacesPrintLayer(int categoryId, LayerProperties requestedLayer) {
+    private PrintLayer createProxyLayer(ProxyPrintLayer p, LayerProperties requestedLayer) {
         int opacity = requestedLayer.getOpacity() != null ? requestedLayer.getOpacity() : 100;
         if (opacity <= 0) {
             // Ignore fully transparent layers
             return null;
         }
 
-        PrintLayer layer = new PrintLayer();
-        layer.setId(categoryId);
-        layer.setType("myplaces");
-        layer.setVersion("1.3.0");
-        layer.setName("oskari:my_places_categories");
-        layer.setOpacity(opacity);
-        return layer;
-    }
-
-    private PrintLayer createUserLayerPrintLayer(int userLayerId, LayerProperties requestedLayer) {
-        int opacity = requestedLayer.getOpacity() != null ? requestedLayer.getOpacity() : 100;
-        if (opacity <= 0) {
-            // Ignore fully transparent layers
+        String layerIdWithoutPrefix = requestedLayer.getId().substring(p.prefix.length());
+        int id = ConversionHelper.getInt(layerIdWithoutPrefix, -1);
+        if (id < 0) {
+            // Ignore layers with negative id
             return null;
         }
 
         PrintLayer layer = new PrintLayer();
-        layer.setId(userLayerId);
-        layer.setType(OskariLayer.TYPE_USERLAYER);
+        layer.setId(id);
+        layer.setType(p.type);
         layer.setVersion("1.3.0");
-        layer.setName("oskari:user_layer_data_style");
-        layer.setOpacity(opacity);
-        return layer;
-    }
-
-    private PrintLayer createAnalysisPrintLayer(int analysisId, LayerProperties requestedLayer) {
-        int opacity = requestedLayer.getOpacity() != null ? requestedLayer.getOpacity() : 100;
-        if (opacity <= 0) {
-            // Ignore fully transparent layers
-            return null;
-        }
-
-        PrintLayer layer = new PrintLayer();
-        layer.setId(analysisId);
-        layer.setType(OskariLayer.TYPE_ANALYSIS);
-        layer.setVersion("1.3.0");
-        layer.setName("oskari:analysis_data_style");
+        layer.setName(p.layerName);
         layer.setOpacity(opacity);
         return layer;
     }
@@ -475,6 +444,24 @@ public class GetPrintHandler extends ActionHandler {
 
         public String getStyle() {
             return style;
+        }
+
+    }
+    
+    private enum ProxyPrintLayer {
+        
+        MyPlaces("myplaces_", "myplaces", "oskari:my_places_categories"),
+        UserLayer("userlayer_", OskariLayer.TYPE_USERLAYER, "oskari:user_layer_data_style"),
+        Analysis("analysis_", OskariLayer.TYPE_ANALYSIS, "oskari:analysis_data_style");
+        
+        private final String prefix;
+        private final String type;
+        private final String layerName;
+        
+        private ProxyPrintLayer(String prefix, String type, String layerName) {
+            this.prefix = prefix;
+            this.type = type;
+            this.layerName = layerName;
         }
 
     }

--- a/service-print/src/main/java/org/oskari/print/loader/AsyncImageLoader.java
+++ b/service-print/src/main/java/org/oskari/print/loader/AsyncImageLoader.java
@@ -51,6 +51,10 @@ public class AsyncImageLoader {
                 images.add(new CommandLoadImageUserLayer(request.getUser(),
                         layer, width, height, bbox, srsName).queue());
                 break;
+            case OskariLayer.TYPE_ANALYSIS:
+                images.add(new CommandLoadImageAnalysis(request.getUser(),
+                        layer, width, height, bbox, srsName).queue());
+                break;
             default:
                 throw new IllegalArgumentException("Invalid layer type!");
             }

--- a/service-print/src/main/java/org/oskari/print/loader/CommandLoadImageAnalysis.java
+++ b/service-print/src/main/java/org/oskari/print/loader/CommandLoadImageAnalysis.java
@@ -19,7 +19,7 @@ import fi.nls.oskari.service.ProxyService;
 /**
  * HystrixCommand that loads BufferedImage from UserLayer via ProxyService
  */
-public class CommandLoadImageUserLayer extends CommandLoadImageBase {
+public class CommandLoadImageAnalysis extends CommandLoadImageBase {
 
     private static final String FORMAT = "image/png";
 
@@ -30,13 +30,13 @@ public class CommandLoadImageUserLayer extends CommandLoadImageBase {
     private final double[] bbox;
     private final String srsName;
 
-    public CommandLoadImageUserLayer(User user,
+    public CommandLoadImageAnalysis(User user,
             PrintLayer layer,
             int width,
             int height,
             double[] bbox,
             String srsName) {
-        super("userlayer_" + layer.getId());
+        super("analysis_" + layer.getId());
         this.user = user;
         this.layer = layer;
         this.width = width;
@@ -57,14 +57,14 @@ public class CommandLoadImageUserLayer extends CommandLoadImageBase {
                 .format(FORMAT)
                 .transparent(true)
                 .toParamMap();
-        queryParams.put("id", Integer.toString(layer.getId()));
+        queryParams.put("wpsLayerId", Integer.toString(layer.getId()));
 
         HttpServletRequest request = new ModifiedHttpServletRequest(queryParams);
         ActionParameters params = new ActionParameters();
         params.setUser(user);
         params.setRequest(request);
 
-        byte[] resp = ProxyService.proxyBinary("userlayertile", params);
+        byte[] resp = ProxyService.proxyBinary("analysistile", params);
         InputStream input = new ByteArrayInputStream(resp);
         return ImageIO.read(input);
     }

--- a/service-print/src/main/java/org/oskari/print/loader/CommandLoadImageAnalysis.java
+++ b/service-print/src/main/java/org/oskari/print/loader/CommandLoadImageAnalysis.java
@@ -1,34 +1,13 @@
 package org.oskari.print.loader;
 
-import java.awt.image.BufferedImage;
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.util.Map;
-
-import javax.imageio.ImageIO;
-import javax.servlet.http.HttpServletRequest;
-
 import org.oskari.print.request.PrintLayer;
-import org.oskari.print.util.GetMapBuilder;
-import org.oskari.print.util.ModifiedHttpServletRequest;
 
-import fi.nls.oskari.control.ActionParameters;
 import fi.nls.oskari.domain.User;
-import fi.nls.oskari.service.ProxyService;
 
 /**
- * HystrixCommand that loads BufferedImage from UserLayer via ProxyService
+ * HystrixCommand that loads BufferedImage from Analysis Layer via ProxyService
  */
-public class CommandLoadImageAnalysis extends CommandLoadImageBase {
-
-    private static final String FORMAT = "image/png";
-
-    private final User user;
-    private final PrintLayer layer;
-    private final int width;
-    private final int height;
-    private final double[] bbox;
-    private final String srsName;
+public class CommandLoadImageAnalysis extends CommandLoadImageProxyService {
 
     public CommandLoadImageAnalysis(User user,
             PrintLayer layer,
@@ -36,42 +15,17 @@ public class CommandLoadImageAnalysis extends CommandLoadImageBase {
             int height,
             double[] bbox,
             String srsName) {
-        super("analysis_" + layer.getId());
-        this.user = user;
-        this.layer = layer;
-        this.width = width;
-        this.height = height;
-        this.bbox = bbox;
-        this.srsName = srsName;
+        super(user, layer, width, height, bbox, srsName);
+    }
+    
+    @Override
+    public String getIdParamName() {
+        return "wpsLayerId";
     }
 
     @Override
-    public BufferedImage run() throws Exception {
-        Map<String, String> queryParams = new GetMapBuilder()
-                .version(layer.getVersion())
-                .layer(layer.getName())
-                .bbox(bbox)
-                .crs(srsName)
-                .width(width)
-                .height(height)
-                .format(FORMAT)
-                .transparent(true)
-                .toParamMap();
-        queryParams.put("wpsLayerId", Integer.toString(layer.getId()));
-
-        HttpServletRequest request = new ModifiedHttpServletRequest(queryParams);
-        ActionParameters params = new ActionParameters();
-        params.setUser(user);
-        params.setRequest(request);
-
-        byte[] resp = ProxyService.proxyBinary("analysistile", params);
-        InputStream input = new ByteArrayInputStream(resp);
-        return ImageIO.read(input);
-    }
-
-    @Override
-    public BufferedImage getFallback() {
-        return null;
+    public String getProxyServiceKey() {
+        return "analysistile";
     }
 
 }

--- a/service-print/src/main/java/org/oskari/print/loader/CommandLoadImageMyPlaces.java
+++ b/service-print/src/main/java/org/oskari/print/loader/CommandLoadImageMyPlaces.java
@@ -1,34 +1,13 @@
 package org.oskari.print.loader;
 
-import java.awt.image.BufferedImage;
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.util.Map;
-
-import javax.imageio.ImageIO;
-import javax.servlet.http.HttpServletRequest;
-
 import org.oskari.print.request.PrintLayer;
-import org.oskari.print.util.GetMapBuilder;
-import org.oskari.print.util.ModifiedHttpServletRequest;
 
-import fi.nls.oskari.control.ActionParameters;
 import fi.nls.oskari.domain.User;
-import fi.nls.oskari.service.ProxyService;
 
 /**
- * HystrixCommand that loads BufferedImage from MyPlaces WMS
+ * HystrixCommand that loads BufferedImage from MyPlaces via ProxyService
  */
-public class CommandLoadImageMyPlaces extends CommandLoadImageBase {
-
-    private static final String FORMAT = "image/png";
-
-    private final User user;
-    private final PrintLayer layer;
-    private final int width;
-    private final int height;
-    private final double[] bbox;
-    private final String srsName;
+public class CommandLoadImageMyPlaces extends CommandLoadImageProxyService {
 
     public CommandLoadImageMyPlaces(User user,
             PrintLayer layer,
@@ -36,42 +15,17 @@ public class CommandLoadImageMyPlaces extends CommandLoadImageBase {
             int height,
             double[] bbox,
             String srsName) {
-        super("myplaces_" + layer.getId());
-        this.user = user;
-        this.layer = layer;
-        this.width = width;
-        this.height = height;
-        this.bbox = bbox;
-        this.srsName = srsName;
+        super(user, layer, width, height, bbox, srsName);
     }
 
     @Override
-    public BufferedImage run() throws Exception {
-        Map<String, String> queryParams = new GetMapBuilder()
-                .version(layer.getVersion())
-                .layer(layer.getName())
-                .bbox(bbox)
-                .crs(srsName)
-                .width(width)
-                .height(height)
-                .format(FORMAT)
-                .transparent(true)
-                .toParamMap();
-        queryParams.put("myCat", Integer.toString(layer.getId()));
-
-        HttpServletRequest request = new ModifiedHttpServletRequest(queryParams);
-        ActionParameters params = new ActionParameters();
-        params.setUser(user);
-        params.setRequest(request);
-
-        byte[] resp = ProxyService.proxyBinary("myplacestile", params);
-        InputStream input = new ByteArrayInputStream(resp);
-        return ImageIO.read(input);
+    public String getIdParamName() {
+        return "myCat";
     }
 
     @Override
-    public BufferedImage getFallback() {
-        return null;
+    public String getProxyServiceKey() {
+        return "myplacestile";
     }
 
 }

--- a/service-print/src/main/java/org/oskari/print/loader/CommandLoadImageProxyService.java
+++ b/service-print/src/main/java/org/oskari/print/loader/CommandLoadImageProxyService.java
@@ -1,0 +1,80 @@
+package org.oskari.print.loader;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Map;
+
+import javax.imageio.ImageIO;
+import javax.servlet.http.HttpServletRequest;
+
+import org.oskari.print.request.PrintLayer;
+import org.oskari.print.util.GetMapBuilder;
+import org.oskari.print.util.ModifiedHttpServletRequest;
+
+import fi.nls.oskari.control.ActionParameters;
+import fi.nls.oskari.domain.User;
+import fi.nls.oskari.service.ProxyService;
+
+/**
+ * HystrixCommand that loads BufferedImage from GeoServer via ProxyService
+ */
+public abstract class CommandLoadImageProxyService extends CommandLoadImageBase {
+
+    protected static final String FORMAT = "image/png";
+
+    protected final User user;
+    protected final PrintLayer layer;
+    protected final int width;
+    protected final int height;
+    protected final double[] bbox;
+    protected final String srsName;
+
+    public CommandLoadImageProxyService(User user,
+            PrintLayer layer,
+            int width,
+            int height,
+            double[] bbox,
+            String srsName) {
+        super("geoserver");
+        this.user = user;
+        this.layer = layer;
+        this.width = width;
+        this.height = height;
+        this.bbox = bbox;
+        this.srsName = srsName;
+    }
+
+    @Override
+    public BufferedImage run() throws Exception {
+        Map<String, String> queryParams = new GetMapBuilder()
+                .version(layer.getVersion())
+                .layer(layer.getName())
+                .bbox(bbox)
+                .crs(srsName)
+                .width(width)
+                .height(height)
+                .format(FORMAT)
+                .transparent(true)
+                .toParamMap();
+        queryParams.put(getIdParamName(), Integer.toString(layer.getId()));
+
+        HttpServletRequest request = new ModifiedHttpServletRequest(queryParams);
+        ActionParameters params = new ActionParameters();
+        params.setUser(user);
+        params.setRequest(request);
+
+        byte[] resp = ProxyService.proxyBinary(getProxyServiceKey(), params);
+        InputStream input = new ByteArrayInputStream(resp);
+        return ImageIO.read(input);
+    }
+
+    @Override
+    public BufferedImage getFallback() {
+        return null;
+    }
+
+    public abstract String getIdParamName();
+    public abstract String getProxyServiceKey();
+
+}

--- a/service-print/src/main/java/org/oskari/print/loader/CommandLoadImageUserLayer.java
+++ b/service-print/src/main/java/org/oskari/print/loader/CommandLoadImageUserLayer.java
@@ -1,34 +1,13 @@
 package org.oskari.print.loader;
 
-import java.awt.image.BufferedImage;
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.util.Map;
-
-import javax.imageio.ImageIO;
-import javax.servlet.http.HttpServletRequest;
-
 import org.oskari.print.request.PrintLayer;
-import org.oskari.print.util.GetMapBuilder;
-import org.oskari.print.util.ModifiedHttpServletRequest;
 
-import fi.nls.oskari.control.ActionParameters;
 import fi.nls.oskari.domain.User;
-import fi.nls.oskari.service.ProxyService;
 
 /**
  * HystrixCommand that loads BufferedImage from UserLayer via ProxyService
  */
-public class CommandLoadImageUserLayer extends CommandLoadImageBase {
-
-    private static final String FORMAT = "image/png";
-
-    private final User user;
-    private final PrintLayer layer;
-    private final int width;
-    private final int height;
-    private final double[] bbox;
-    private final String srsName;
+public class CommandLoadImageUserLayer extends CommandLoadImageProxyService {
 
     public CommandLoadImageUserLayer(User user,
             PrintLayer layer,
@@ -36,42 +15,17 @@ public class CommandLoadImageUserLayer extends CommandLoadImageBase {
             int height,
             double[] bbox,
             String srsName) {
-        super("userlayer_" + layer.getId());
-        this.user = user;
-        this.layer = layer;
-        this.width = width;
-        this.height = height;
-        this.bbox = bbox;
-        this.srsName = srsName;
+        super(user, layer, width, height, bbox, srsName);
     }
 
     @Override
-    public BufferedImage run() throws Exception {
-        Map<String, String> queryParams = new GetMapBuilder()
-                .version(layer.getVersion())
-                .layer(layer.getName())
-                .bbox(bbox)
-                .crs(srsName)
-                .width(width)
-                .height(height)
-                .format(FORMAT)
-                .transparent(true)
-                .toParamMap();
-        queryParams.put("id", Integer.toString(layer.getId()));
-
-        HttpServletRequest request = new ModifiedHttpServletRequest(queryParams);
-        ActionParameters params = new ActionParameters();
-        params.setUser(user);
-        params.setRequest(request);
-
-        byte[] resp = ProxyService.proxyBinary("userlayertile", params);
-        InputStream input = new ByteArrayInputStream(resp);
-        return ImageIO.read(input);
+    public String getIdParamName() {
+        return "id";
     }
 
     @Override
-    public BufferedImage getFallback() {
-        return null;
+    public String getProxyServiceKey() {
+        return "userlayertile";
     }
 
 }


### PR DESCRIPTION
Currently `analysis_` layers are ignored in the GetPrint ActionRoute and the underlying service. This PR adds support for them. The images for the layers are created the same way AnalysisTile creates them (via ProxyService).

`CommandLoadImageAnalysis` uses two magic keys ("wpsLayerId" and "analysistile") without referring to the original static final fields. We could use the original Strings, but that would require adding dependencies to the modules where they live to the print-service module.

Also refactored changes made in #243 and #242.