### PR TITLE
Remove mapstats

### DIFF
--- a/content-resources/src/main/java/flyway/oskari/V1_48_1__remove_statslayerplugin.java
+++ b/content-resources/src/main/java/flyway/oskari/V1_48_1__remove_statslayerplugin.java
@@ -53,6 +53,9 @@ public class V1_48_1__remove_statslayerplugin implements JdbcMigration {
 
     private boolean removeStatslayerPlugin(JSONObject mapfullConfig) {
         JSONArray plugins = mapfullConfig.optJSONArray("plugins");
+        if(plugins == null) {
+            return false;
+        }
         JSONArray newPlugins = new JSONArray();
         for(int i = 0; i < plugins.length(); ++i) {
             JSONObject plugin = plugins.optJSONObject(i);

--- a/content-resources/src/main/resources/json/views/default-full-view.json
+++ b/content-resources/src/main/resources/json/views/default-full-view.json
@@ -47,7 +47,6 @@
                     { "id" : "Oskari.mapframework.bundle.mapmodule.plugin.Portti2Zoombar" },
                     { "id" : "Oskari.mapframework.bundle.mapmodule.plugin.PanButtons" },
                     { "id" : "Oskari.mapframework.bundle.mapmodule.plugin.FullScreenPlugin" },
-                    { "id" : "Oskari.mapframework.bundle.mapstats.plugin.StatsLayerPlugin" },
                     { "id" : "Oskari.mapframework.bundle.myplacesimport.plugin.UserLayersLayerPlugin" },
                     { "id" : "Oskari.mapframework.bundle.mapmyplaces.plugin.MyPlacesLayerPlugin" },
                     { "id" : "Oskari.mapframework.bundle.mapanalysis.plugin.AnalysisLayerPlugin" },

--- a/content-resources/src/main/resources/json/views/default-transport-view.json
+++ b/content-resources/src/main/resources/json/views/default-transport-view.json
@@ -47,7 +47,6 @@
                     { "id" : "Oskari.mapframework.bundle.mapmodule.plugin.Portti2Zoombar" },
                     { "id" : "Oskari.mapframework.bundle.mapmodule.plugin.PanButtons" },
                     { "id" : "Oskari.mapframework.bundle.mapmodule.plugin.FullScreenPlugin" },
-                    { "id" : "Oskari.mapframework.bundle.mapstats.plugin.StatsLayerPlugin" },
                     { "id" : "Oskari.mapframework.mapmodule.VectorLayerPlugin" }
                 ],
                 "layers": []

--- a/content-resources/src/main/resources/json/views/default-view.json
+++ b/content-resources/src/main/resources/json/views/default-view.json
@@ -43,7 +43,6 @@
                     { "id" : "Oskari.mapframework.bundle.mapmodule.plugin.Portti2Zoombar" },
                     { "id" : "Oskari.mapframework.bundle.mapmodule.plugin.PanButtons" },
                     { "id" : "Oskari.mapframework.bundle.mapmodule.plugin.FullScreenPlugin" },
-                    { "id" : "Oskari.mapframework.bundle.mapstats.plugin.StatsLayerPlugin" },
                     { "id" : "Oskari.mapframework.mapmodule.VectorLayerPlugin" }
                 ],
                 "layers": []

--- a/content-resources/src/main/resources/json/views/ol3-publisher-template-view-4326.json
+++ b/content-resources/src/main/resources/json/views/ol3-publisher-template-view-4326.json
@@ -33,8 +33,6 @@
                     }, {
                         "id": "Oskari.mapframework.wmts.mapmodule.plugin.WmtsLayerPlugin"
                     }, {
-                        "id": "Oskari.mapframework.bundle.mapstats.plugin.StatsLayerPlugin"
-                    }, {
                         "id": "Oskari.mapframework.bundle.mapmodule.plugin.RealtimePlugin"
                     }, {
                         "id": "Oskari.mapframework.bundle.mapmodule.plugin.LogoPlugin"

--- a/content-resources/src/main/resources/json/views/ol3-publisher-template-view.json
+++ b/content-resources/src/main/resources/json/views/ol3-publisher-template-view.json
@@ -31,9 +31,6 @@
                         "maparcgis": {
                             "bundlePath": "/Oskari/packages/mapping/ol3/"
                         },
-                        "mapstats": {
-                            "bundlePath": "/Oskari/packages/mapping/ol3/"
-                        },
                         "mapmodule": {
                             "bundlePath": "/Oskari/packages/mapping/ol3/"
                         },
@@ -69,8 +66,6 @@
                         "id": "Oskari.mapframework.bundle.mapwfs2.plugin.WfsLayerPlugin"
                     }, {
                         "id": "Oskari.mapframework.wmts.mapmodule.plugin.WmtsLayerPlugin"
-                    }, {
-                        "id": "Oskari.mapframework.bundle.mapstats.plugin.StatsLayerPlugin"
                     }, {
                         "id": "Oskari.mapframework.bundle.mapmodule.plugin.RealtimePlugin"
                     }, {


### PR DESCRIPTION
Remove references to mapstats-bundle in the sample applications setup-files as it has been removed in oskariorg/oskari-frontend#479 and fix migration to work on an empty database.