### PR TITLE
Use the transformed geometry

### DIFF
--- a/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/RegionSetHelper.java
+++ b/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/RegionSetHelper.java
@@ -117,7 +117,8 @@ public class RegionSetHelper {
         if (transform != null) {
             Object geometry = f.getDefaultGeometry();
             if (geometry != null && geometry instanceof Geometry) {
-                JTS.transform((Geometry) geometry, transform);
+                Geometry geom = JTS.transform((Geometry) geometry, transform);
+                f.setDefaultGeometry(geom);
             }
         }
     }


### PR DESCRIPTION
Regionset resources already implemented transforms for different projections. The result just wasn't used. This fixes the issue.