### PR TITLE
Use default db for layer fetching instead of module-specific db

### DIFF
--- a/content-resources/src/main/java/flyway/userlayer/V1_0_11__populate_userlayer_wkt.java
+++ b/content-resources/src/main/java/flyway/userlayer/V1_0_11__populate_userlayer_wkt.java
@@ -5,6 +5,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
+import fi.nls.oskari.db.DBHandler;
 import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
 
 import fi.nls.oskari.log.LogFactory;
@@ -17,7 +18,7 @@ public class V1_0_11__populate_userlayer_wkt implements JdbcMigration {
     private static final int WGS84_SRID = 4326;
 
     public void migrate(Connection connection) throws Exception {
-        String srsName = getSrsName(connection);
+        String srsName = getSrsName(DBHandler.getConnection());
         if (srsName == null){
             LOG.error("Cannot get srs name for userlayer data");
             throw new IllegalArgumentException("Cannot get srs name for userlayer data");


### PR DESCRIPTION
Fixes an issue with userlayer migration where userlayers are in another database than the default oskaridb. 