### PR TITLE
Remove references to non-minified frontend

### DIFF
--- a/servlet-map/src/main/java/fi/nls/oskari/MapController.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/MapController.java
@@ -36,7 +36,6 @@ public class MapController {
 
     private final static Logger log = LogFactory.getLogger(MapController.class);
 
-    private final static String PROPERTY_DEVELOPMENT = "development";
     private final static String PROPERTY_VERSION = "oskari.client.version";
     private final static String KEY_PRELOADED = "preloaded";
     private final static String KEY_PATH = "path";
@@ -47,16 +46,13 @@ public class MapController {
     private final static String KEY_RESPONSE_HEADER_PREFIX = "oskari.page.header.";
 
     private final ViewService viewService = new ViewServiceIbatisImpl();
-    private boolean isDevelopmentMode = false;
     private String version = null;
-    private final Set<String> paramHandlers = new HashSet<String>();
+    private final Set<String> paramHandlers = new HashSet<>();
 
     @Autowired
     private SpringEnvHelper env;
 
     public MapController() {
-        // check if we have development flag -> serve non-minified js
-        isDevelopmentMode = ConversionHelper.getBoolean(PropertyUtil.get(PROPERTY_DEVELOPMENT), false);
         // Get version from properties
         version = PropertyUtil.get(PROPERTY_VERSION);
     }
@@ -69,20 +65,13 @@ public class MapController {
             paramHandlers.addAll(ParamControl.getHandlerKeys());
             log.debug("Checking for params", paramHandlers);
         }
-        // for debugging - Note! changes the setting for the whole instance!!! Use with care
-        if(params.getUser().isAdmin() && params.getHttpParam("reallyseriouslyyes", false)) {
-            isDevelopmentMode = params.getHttpParam("dev", isDevelopmentMode);
-        }
 
         writeCustomHeaders(params.getResponse());
-        model.addAttribute("preloaded", !isDevelopmentMode);
+        // compatibility for <1.49 JSPs -> there was an if statement to use minified or non-minified code
+        model.addAttribute("preloaded", true);
 
-        if (isDevelopmentMode) {
-            model.addAttribute("oskariApplication", PropertyUtil.get("oskari.development.prefix"));
-        } else {
-            model.addAttribute("oskariApplication", PropertyUtil.get("oskari.client.version") +
-                    PropertyUtil.get("oskari.application"));
-        }
+        model.addAttribute("oskariApplication",
+                PropertyUtil.get("oskari.client.version") + PropertyUtil.get("oskari.application"));
 
         // JSP
         final String viewJSP = setupRenderParameters(params, model);
@@ -209,12 +198,8 @@ public class MapController {
         JSONHelper.putValue(controlParams, GetAppSetupHandler.PARAM_NO_SAVED_STATE, request.getParameter(GetAppSetupHandler.PARAM_NO_SAVED_STATE));
         model.addAttribute(KEY_CONTROL_PARAMS, controlParams.toString());
 
-        model.addAttribute(KEY_PRELOADED, !isDevelopmentMode);
-        if (isDevelopmentMode) {
-            model.addAttribute(KEY_PATH, view.getDevelopmentPath() + "/" + view.getApplication());
-        } else {
-            model.addAttribute(KEY_PATH, "/" + version + "/" + view.getApplication());
-        }
+        model.addAttribute(KEY_PRELOADED, true);
+        model.addAttribute(KEY_PATH, "/" + version + "/" + view.getApplication());
         model.addAttribute("application", view.getApplication());
         model.addAttribute("viewName", view.getName());
         model.addAttribute("user", params.getUser());
@@ -223,19 +208,6 @@ public class MapController {
         model.addAttribute(KEY_AJAX_URL,
                 PropertyUtil.get(params.getLocale(), GetAppSetupHandler.PROPERTY_AJAXURL));
         model.addAttribute("urlPrefix", "");
-
-        // in dev-mode app/page can be overridden
-        if (isDevelopmentMode) {
-            // check if we want to override the page & app
-            final String app = params.getHttpParam("app");
-            final String page = params.getHttpParam("page");
-            if (page != null && app != null) {
-                log.debug("Using dev-override!!! \nUsing JSP:", page, "with application:", app);
-                model.addAttribute(KEY_PATH, app);
-                model.addAttribute("application", app);
-                viewJSP = page;
-            }
-        }
 
         // return jsp for the requested view
         return viewJSP;

--- a/servlet-map/src/main/resources/META-INF/resources/spring-map-jsp/index.jsp
+++ b/servlet-map/src/main/resources/META-INF/resources/spring-map-jsp/index.jsp
@@ -172,27 +172,14 @@
     var ajaxUrl = '${ajaxUrl}';
     var controlParams = ${controlParams};
 </script>
-
+<%-- Pre-compiled application JS, empty unless created by build job --%>
 <script type="text/javascript"
-        src="/Oskari/bundles/bundle.js">
+        src="/Oskari${path}/oskari.min.js">
 </script>
-
-<c:if test="${preloaded}">
-    <!-- Pre-compiled application JS, empty unless created by build job -->
-    <script type="text/javascript"
-            src="/Oskari${path}/oskari.min.js">
-    </script>
-    <!-- Minified CSS for preload -->
-    <link
-            rel="stylesheet"
-            type="text/css"
-            href="/Oskari${path}/oskari.min.css"
-            />
-    <%--language files --%>
-    <script type="text/javascript"
-            src="/Oskari${path}/oskari_lang_${language}.js">
-    </script>
-</c:if>
+<%--language files --%>
+<script type="text/javascript"
+        src="/Oskari${path}/oskari_lang_${language}.js">
+</script>
 
 <script type="text/javascript"
         src="/Oskari${path}/index.js">

--- a/servlet-map/src/main/resources/META-INF/resources/spring-map-jsp/published.jsp
+++ b/servlet-map/src/main/resources/META-INF/resources/spring-map-jsp/published.jsp
@@ -1,5 +1,4 @@
 <%@ page contentType="text/html; charset=UTF-8" isELIgnored="false" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <!DOCTYPE html>
 <html>
 <head>
@@ -65,28 +64,15 @@
     var ajaxUrl = '${ajaxUrl}';
     var controlParams = ${controlParams};
 </script>
-
+<%-- Pre-compiled application JS, empty unless created by build job --%>
 <script type="text/javascript"
-        src="/Oskari/bundles/bundle.js">
+        src="/Oskari${path}/oskari.min.js">
 </script>
 
-
-<c:if test="${preloaded}">
-    <!-- Pre-compiled application JS, empty unless created by build job -->
-    <script type="text/javascript"
-            src="/Oskari${path}/oskari.min.js">
-    </script>
-    <!-- Minified CSS for preload -->
-    <link
-            rel="stylesheet"
-            type="text/css"
-            href="/Oskari${path}/oskari.min.css"
-            />
-    <%--language files --%>
-    <script type="text/javascript"
-            src="/Oskari${path}/oskari_lang_${language}.js">
-    </script>
-</c:if>
+<%-- language files --%>
+<script type="text/javascript"
+        src="/Oskari${path}/oskari_lang_${language}.js">
+</script>
 
 <script type="text/javascript"
         src="/Oskari${path}/index.js">

--- a/servlet-map/src/main/resources/oskari.properties
+++ b/servlet-map/src/main/resources/oskari.properties
@@ -4,10 +4,9 @@
 ## with the same property key as used here
 ###############################################################################
 
-# set development to false or comment it out to load using minified javascript
-# (requires minified version of the javascript to be compiled and servlet init-param to set the version to load)
-development=true
-# Client version to use in links if development = false
+# development mode disables caching for server localizations
+development=false
+# Client version to use in links
 oskari.client.version=${project.version}
 # set to true to get database populated with initial demo content
 oskari.init.db=true


### PR DESCRIPTION
Removes references to old bundles/bundle.js and oskari.min.css (included in oskari.min.js) as they are not generated with the Webpack-based build and cause problems if old versions are used with the new compiled min.js.

The default value of property "development" has been changed to false and it now only affects if server-side localizations are cached or not. Switching development=true allows you to see changes in messages.properties under Jetty/resources without restarting the server. It no longer affects if minified frontend is being used.

The JSPs will now always have the model attribute "preloaded" as true for compatibility in customized JSPs. The if-statements can be removed from the customized JSPs. 