### PR TITLE
URLEncode query parameters in WMTS requests sent by print module

### DIFF
--- a/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
@@ -892,7 +892,7 @@ public class IOHelper {
         for (Map.Entry<String, String> entry : kvps.entrySet()) {
             final String key = entry.getKey();
             final String value = entry.getValue();
-            if (key == null || key.isEmpty() || value == null || value.isEmpty()) {
+            if (key == null || key.isEmpty()) {
                 continue;
             }
             final String keyEnc = urlEncode(key);

--- a/service-print/src/main/java/org/oskari/print/wmts/GetTileRequestBuilderKVP.java
+++ b/service-print/src/main/java/org/oskari/print/wmts/GetTileRequestBuilderKVP.java
@@ -1,5 +1,10 @@
 package org.oskari.print.wmts;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import fi.nls.oskari.util.IOHelper;
+
 /**
  * WMTS GetTile Request Builder (KVP)
  */
@@ -61,9 +66,6 @@ public class GetTileRequestBuilderKVP implements GetTileRequestBuilder {
         if (layer == null || layer.length() == 0) {
             throw new IllegalArgumentException("Required parameter 'layer' missing");
         }
-        if (style == null || style.length() == 0) {
-            throw new IllegalArgumentException("Required parameter 'style' missing");
-        }
         if (format == null || format.length() == 0) {
             throw new IllegalArgumentException("Required parameter 'format' missing");
         }
@@ -80,19 +82,18 @@ public class GetTileRequestBuilderKVP implements GetTileRequestBuilder {
             throw new IllegalArgumentException("Required parameter 'tileCol' missing");
         }
 
-        StringBuilder sb = new StringBuilder();
-        sb.append(endPoint);
-        sb.append("?SERVICE=WMTS");
-        sb.append("&REQUEST=GetTile");
-        sb.append("&VERSION=1.0.0");
-        sb.append("&LAYER=").append(layer);
-        sb.append("&STYLE=").append(style);
-        sb.append("&FORMAT=").append(format);
-        sb.append("&TILEMATRIXSET=").append(tileMatrixSet);
-        sb.append("&TILEMATRIX=").append(tileMatrix);
-        sb.append("&TILEROW=").append(tileRow);
-        sb.append("&TILECOL=").append(tileCol);
-        return sb.toString();
+        Map<String, String> params = new LinkedHashMap<>();
+        params.put("SERVICE", "WMTS");
+        params.put("VERSION", "1.0.0");
+        params.put("REQUEST", "GetTile");
+        params.put("LAYER", layer);
+        params.put("STYLE", style == null ? "" : style);
+        params.put("FORMAT", format);
+        params.put("TILEMATRIXSET", tileMatrixSet);
+        params.put("TILEMATRIX", tileMatrix);
+        params.put("TILEROW", Integer.toString(tileRow));
+        params.put("TILECOL", Integer.toString(tileCol));
+        return IOHelper.constructUrl(endPoint, params);
     }
 
 }

--- a/service-print/src/test/java/org/oskari/print/wmts/GetTileRequestBuilderKVPTest.java
+++ b/service-print/src/test/java/org/oskari/print/wmts/GetTileRequestBuilderKVPTest.java
@@ -16,7 +16,6 @@ public class GetTileRequestBuilderKVPTest {
         final String[] strFields = new String[] {
                 "endPoint",
                 "layer",
-                "style",
                 "format",
                 "tileMatrixSet",
                 "tileMatrix"
@@ -62,10 +61,10 @@ public class GetTileRequestBuilderKVPTest {
         }
 
         String expected = "foo?SERVICE=WMTS"
-                + "&REQUEST=GetTile"
                 + "&VERSION=1.0.0"
+                + "&REQUEST=GetTile"
                 + "&LAYER=foo"
-                + "&STYLE=foo"
+                + "&STYLE="
                 + "&FORMAT=foo"
                 + "&TILEMATRIXSET=foo"
                 + "&TILEMATRIX=foo"
@@ -74,5 +73,29 @@ public class GetTileRequestBuilderKVPTest {
         String actual = builder.build();
         assertEquals(expected, actual);
     }
+
+    @Test
+    public void testParametersAreURLEncoded() {
+        String actual = new GetTileRequestBuilderKVP().endPoint("foo")
+                .layer("foo bar")
+                .format("image/png")
+                .tileMatrixSet("ETRS-TM35FIN")
+                .tileMatrix("ETRS_TM35-FIN:8")
+                .tileRow(114)
+                .tileCol(208)
+                .build();
+        String expected = "foo?SERVICE=WMTS"
+                + "&VERSION=1.0.0"
+                + "&REQUEST=GetTile"
+                + "&LAYER=foo+bar"
+                + "&STYLE="
+                + "&FORMAT=image%2Fpng"
+                + "&TILEMATRIXSET=ETRS-TM35FIN"
+                + "&TILEMATRIX=ETRS_TM35-FIN%3A8"
+                + "&TILEROW=114"
+                + "&TILECOL=208";
+        assertEquals(expected, actual);
+    }
+
 
 }


### PR DESCRIPTION
Fixes an issue where layer name that contains characters that need to be url encoded (space for example) didn't work properly.