### PR TITLE
Remove refs to Ibatis TermsOfUse.xml

### DIFF
--- a/content-resources/src/main/resources/META-INF/SqlMapConfig-content-resources.xml
+++ b/content-resources/src/main/resources/META-INF/SqlMapConfig-content-resources.xml
@@ -20,7 +20,6 @@ PUBLIC "-//ibatis.apache.org//DTD SQL Map Config 2.0//EN"
   <sqlMap resource="META-INF/MaplayerGroup.xml" />
   <sqlMap resource="META-INF/Permissions.xml" />
   <sqlMap resource="META-INF/PublishedMapUsage.xml" />
-  <sqlMap resource="META-INF/TermsOfUse.xml" />
   <sqlMap resource="META-INF/View.xml" />
   <sqlMap resource="META-INF/Bundle.xml" />
   <sqlMap resource="META-INF/BackendStatus.xml" />

--- a/servlet-map/src/main/resources/META-INF/SqlMapConfig.xml
+++ b/servlet-map/src/main/resources/META-INF/SqlMapConfig.xml
@@ -21,7 +21,6 @@ PUBLIC "-//ibatis.apache.org//DTD SQL Map Config 2.0//EN"
   <sqlMap resource="META-INF/MaplayerGroup.xml" />
   <sqlMap resource="META-INF/Permissions.xml" />
   <sqlMap resource="META-INF/PublishedMapUsage.xml" />
-  <sqlMap resource="META-INF/TermsOfUse.xml" />
   <sqlMap resource="META-INF/View.xml" />
   <sqlMap resource="META-INF/Bundle.xml" />
   <sqlMap resource="META-INF/PublishedMap.xml" />


### PR DESCRIPTION
The code for TermsOfUse Ibatis services was removed in #270, but a couple of references was left behind. These cause problems on server startup so removing the references