### PR TITLE
Halt app startup on db migration failure

### DIFF
--- a/service-webapp/src/main/java/fi/nls/oskari/servlet/WebappHelper.java
+++ b/service-webapp/src/main/java/fi/nls/oskari/servlet/WebappHelper.java
@@ -108,7 +108,7 @@ public class WebappHelper {
             log.warn("Skipping flyway migration! Remove 'db.flyway' property or set it to 'true' to enable migration");
             return;
         }
-        boolean ingoreMigrationFailures = PropertyUtil.getOptional("db.ingoreMigrationFailures", false);
+        boolean ignoreMigrationFailures = PropertyUtil.getOptional("db.ignoreMigrationFailures", false);
 
         // upgrade database structure with http://flywaydb.org/
         log.info("Oskari-map checking DB status");
@@ -117,7 +117,7 @@ public class WebappHelper {
             log.info("Oskari core DB migrated successfully");
         } catch (Exception e) {
             log.error("DB migration for Oskari core failed!");
-            if(!ingoreMigrationFailures) {
+            if(!ignoreMigrationFailures) {
                 throw e;
             }
         }
@@ -129,7 +129,7 @@ public class WebappHelper {
                 log.info(module + " DB migrated successfully");
             } catch (Exception e) {
                 log.error("DB migration for module " + module + " failed!", e);
-                if(!ingoreMigrationFailures) {
+                if(!ignoreMigrationFailures) {
                     throw e;
                 }
             }

--- a/servlet-map/src/main/java/fi/nls/oskari/spring/SpringConfig.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/spring/SpringConfig.java
@@ -49,7 +49,7 @@ public class SpringConfig extends WebMvcConfigurerAdapter implements Application
     private static final Logger LOG = LogFactory.getLogger(SpringConfig.class);
 
     @PostConstruct
-    public void oskariInit() throws Exception {
+    public void oskariInit() {
         // check DB connections/content
         WebappHelper.init();
     }


### PR DESCRIPTION
If an unchecked exception is thrown while running migrations, it will bubble up the stack all the way to oskariInit(). It is invoked with @PostConstruct annotation with which any unhandled exception will stop the app initialization.

Added ext.properties configuration `db.ignoreMigrationFailures` option to override behaviour.