### PR TITLE
Fix initial labels for myplaces

### DIFF
--- a/content-resources/src/main/java/fi/nls/oskari/geoserver/GeoserverPopulator.java
+++ b/content-resources/src/main/java/fi/nls/oskari/geoserver/GeoserverPopulator.java
@@ -123,7 +123,8 @@ public class GeoserverPopulator {
         // setup WFS conf with defaults
         WFSLayerConfiguration conf = LayerHelper.getConfig(baseLayer, NAMESPACE);
         conf.setFeatureElement("my_places");
-        conf.setFeatureParamsLocales("{\"default\": [\"name\", \"place_desc\",\"link\", \"image_url\"],\"fi\": [\"name\", \"place_desc\",\"link\", \"image_url\"]}");
+        conf.setSelectedFeatureParams("{\"default\": [\"name\", \"place_desc\",\"link\", \"image_url\"],\"fi\": [\"name\", \"place_desc\",\"link\", \"image_url\"]}");
+        conf.setFeatureParamsLocales("{\"default\": [\"name\", \"description\",\"link\", \"image\"],\"fi\": [\"nimi\", \"kuvaus\",\"linkki\", \"kuva-linkki\"]}");
         WFS_SERVICE.insert(conf);
         return baseLayer.getId();
     }


### PR DESCRIPTION
This fixes the database creation for empty database. Previously the labels for myplaces features attribute data were off when initializing the baselayer. This modifies an existing migration script which is something that shouldn't be done. But the people hosting Oskari instances must have either disabled myplaces functionality or fixed the labels manually as they were way off and I don't want to overwrite the manually updated labels with a new script. For example the attribute name had the value of the users uuid on the featuredata table and so on. Here's an example of the ws-traffic where you can see that the indexes of labels ("locales") are not in sync with selected fields and the feature attribute data:

Labels (locales) and attribute selection (fields):
`
[{
	"data": {
		"locales": ["ID", "name", "place_desc", "link", "image_url", "x", "y"],
		"layerId": "myplaces_1",
		"fields": ["__fid", "uuid", "category_id", "attention_text", "created", "updated", "place_desc", "link", "image_url", "__centerX", "__centerY"],
		"reqId": -1
	},
	"channel": "/wfs/properties"
}]
`
Data for a single feature:
`
[{
	"data": {
		"layerId": "myplaces_1",
		"feature": ["my_places.1", "fdsa-fdsa-fdsa-fdsa-fdsa", "1", "", "2018-10-29 16:02:24.806", null, "", "", "", 25.75195, 62.05075],
		"reqId": -1
	},
	"channel": "/wfs/feature"
}]
`

After this change:
`
[{"data":{"locales":["ID","name","description","link","image","x","y"],"layerId":"myplaces_1","fields":["__fid","name","place_desc","link","image_url","__centerX","__centerY"],"reqId":-1},"channel":"/wfs/properties"}]
`

`
[{"data":{"layerId":"myplaces_1","feature":["my_places.1","jee","","","",25.370150000000002,62.81980000000001],"reqId":-1},"channel":"/wfs/feature"}]
`

I'm not sure why the configuration is not done with a simple mapping { "place_desc": "description", ... }, but with two arrays that assume the values are listed in the same order. Perhaps the labels have been added as an afterthought and fields was an existing array to select attribute order. We really should simplify the WFS-configuration in database.