### PR TITLE
Errorhandling for xalan in classpath

### DIFF
--- a/service-base/src/main/java/fi/nls/oskari/util/XmlHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/XmlHelper.java
@@ -237,8 +237,8 @@ public class XmlHelper {
             // Fox example Xalan is providing a custom TransformerFactory which doesn't support this so having it in the
             // classpath will give you this error and getting the actual impl class name is a huge win for debugging the reason.
             // You can check which dependency brings for example Xalan to classpath by running "mvn dependency:tree"
-            LOGGER.error(e, "Unable to disable external DTD and stylesheets for XML parsing. Transformer class impl is",
-                    transformerFactory.getClass().getCanonicalName());
+            LOGGER.warn("Unable to disable external DTD and stylesheets for XML parsing. Transformer class impl is",
+                    transformerFactory.getClass().getCanonicalName(), ". Error was:", e.getMessage());
         }
         // Disable resolving of any kind of URIs, not sure if this is actually necessary
         transformerFactory.setURIResolver((String href, String base) -> null);

--- a/service-base/src/main/java/fi/nls/oskari/util/XmlHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/XmlHelper.java
@@ -234,9 +234,9 @@ public class XmlHelper {
             // https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet#JAXP_DocumentBuilderFactory.2C_SAXParserFactory_and_DOM4J
             // https://stackoverflow.com/questions/27128578/set-feature-accessexternaldtd-in-transformerfactory#29021326
 
-            // xalan is providing a custom TransformerFactory which doesn't support this.
-            // so for example having xalan in the classpath will give you this error
-            // you can check what dependency brings for example xalan to classpath by running "mvn dependency:tree"
+            // Fox example Xalan is providing a custom TransformerFactory which doesn't support this so having it in the
+            // classpath will give you this error and getting the actual impl class name is a huge win for debugging the reason.
+            // You can check which dependency brings for example Xalan to classpath by running "mvn dependency:tree"
             LOGGER.error(e, "Unable to disable external DTD and stylesheets for XML parsing. Transformer class impl is",
                     transformerFactory.getClass().getCanonicalName());
         }

--- a/service-base/src/main/java/fi/nls/oskari/util/XmlHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/XmlHelper.java
@@ -26,7 +26,7 @@ import javax.xml.stream.XMLStreamException;
 
 public class XmlHelper {
 
-    private static final Logger log = LogFactory.getLogger(XmlHelper.class);
+    private static final Logger LOGGER = LogFactory.getLogger(XmlHelper.class);
 
 /*
     <wfs:Transaction xmlns:wfs="http://www.opengis.net/wfs" service="WFS" version="1.0.0" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-transaction.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -60,7 +60,7 @@ public class XmlHelper {
             // https://ws.apache.org/axiom/apidocs/org/apache/axiom/om/util/StAXParserConfiguration.html#STANDALONE
             return OMXMLBuilderFactory.createOMBuilder(OMAbstractFactory.getOMFactory(), StAXParserConfiguration.STANDALONE, new StringReader(xml)).getDocumentElement();
         } catch (Exception e) {
-            log.error("Couldnt't parse XML", log.getCauseMessages(e), xml);
+            LOGGER.error("Couldnt't parse XML", LOGGER.getCauseMessages(e), xml);
         }
         return null;
     }
@@ -71,7 +71,7 @@ public class XmlHelper {
             xml.serialize(writer);
             return writer.toString();
         } catch (Exception e) {
-            log.error("Couldnt't serialize XML to String", log.getCauseMessages(e), xml);
+            LOGGER.error("Couldnt't serialize XML to String", LOGGER.getCauseMessages(e), xml);
         }
         return null;
     }
@@ -160,7 +160,7 @@ public class XmlHelper {
             xpath.setNamespaceContext(ctx);
             return xpath;
         } catch (Exception ex) {
-            log.error(ex, "Error creating xpath:", str);
+            LOGGER.error(ex, "Error creating xpath:", str);
         }
         return null;
     }
@@ -204,7 +204,7 @@ public class XmlHelper {
             factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
             factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
         } catch (ParserConfigurationException ex) {
-            log.warn("Unable to enable security features for DocumentBuilderFactory", ex.getMessage());
+            LOGGER.warn("Unable to enable security features for DocumentBuilderFactory", ex.getMessage());
         }
         factory.setXIncludeAware(false);
         factory.setExpandEntityReferences(false);
@@ -224,11 +224,22 @@ public class XmlHelper {
         try {
             transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         } catch (TransformerConfigurationException ex) {
-            log.warn("Unable to enable feature for secure processing for TransformerFactory", ex.getMessage());
+            LOGGER.warn("Unable to enable feature for secure processing for TransformerFactory", ex.getMessage());
         }
         // Empty protocol String to disable access to external resources
-        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+        try {
+            transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+        } catch (Exception e) {
+            // https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet#JAXP_DocumentBuilderFactory.2C_SAXParserFactory_and_DOM4J
+            // https://stackoverflow.com/questions/27128578/set-feature-accessexternaldtd-in-transformerfactory#29021326
+
+            // xalan is providing a custom TransformerFactory which doesn't support this.
+            // so for example having xalan in the classpath will give you this error
+            // you can check what dependency brings for example xalan to classpath by running "mvn dependency:tree"
+            LOGGER.error(e, "Unable to disable external DTD and stylesheets for XML parsing. Transformer class impl is",
+                    transformerFactory.getClass().getCanonicalName());
+        }
         // Disable resolving of any kind of URIs, not sure if this is actually necessary
         transformerFactory.setURIResolver((String href, String base) -> null);
         return transformerFactory;


### PR DESCRIPTION
Fixes an issue where setting security features for XML-parsing are not supported by the implementation. 

TransformerFactory transformerFactory = TransformerFactory.newInstance(); returns implementation from the Xalan-library instead of the default one IF Xalan is part of the classpath. You can replace Xalan in the sentence with anything that provides a custom implementation for TransformerFactory. This happens for example if the SAML-support is enabled on Oskari.

From user perspective for example the analysis functionality didn't work when SAML was enabled and there was no clear error message on the log why this happened (the exception was not logged). Now when you get hit by this the logs shows:

`2018-10-30 17:54:04,369 WARN fi.nls.oskari.util.XmlHelper.newTransformerFactory(XmlHelper.java:240) - Unable to disable external DTD and stylesheets for XML parsing. Transformer class impl is org.apache.xalan.processor.TransformerFactoryImpl . Error was: Not supported: http://javax.xml.XMLConstants/property/accessExternalDTD`

And we settle for what ever this means for the implementation:

            transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);