### PR TITLE
Publisher / appsetup saving fix

### DIFF
--- a/content-resources/src/main/java/fi/nls/oskari/util/FlywayHelper.java
+++ b/content-resources/src/main/java/fi/nls/oskari/util/FlywayHelper.java
@@ -96,7 +96,6 @@ public class FlywayHelper {
     public static Bundle updateBundleInView(Connection connection, Bundle bundle, Long viewId)
             throws SQLException {
         final String sql = "UPDATE portti_view_bundle_seq SET " +
-                "startup=?, " +
                 "config=?, " +
                 "state=?, " +
                 "seqno=?, " +
@@ -106,13 +105,12 @@ public class FlywayHelper {
 
         try (final PreparedStatement statement =
                      connection.prepareStatement(sql)) {
-            statement.setString(1, bundle.getStartup());
-            statement.setString(2, bundle.getConfig());
-            statement.setString(3, bundle.getState());
-            statement.setInt(4, bundle.getSeqNo());
-            statement.setString(5, bundle.getBundleinstance());
-            statement.setLong(6, bundle.getBundleId());
-            statement.setLong(7, viewId);
+            statement.setString(1, bundle.getConfig());
+            statement.setString(2, bundle.getState());
+            statement.setInt(3, bundle.getSeqNo());
+            statement.setString(4, bundle.getBundleinstance());
+            statement.setLong(5, bundle.getBundleId());
+            statement.setLong(6, viewId);
             statement.execute();
         }
         return null;

--- a/service-map/src/main/resources/META-INF/View.xml
+++ b/service-map/src/main/resources/META-INF/View.xml
@@ -209,8 +209,8 @@
 
     <statement id="add-bundle"
             parameterClass="Bundle">
-      INSERT INTO portti_view_bundle_seq (view_id, bundle_id, seqno, state, config, startup, bundleinstance)
-           VALUES ( #viewId#, #bundleId#, #seqNo#, #state#, #config#, #startup#, #bundleinstance#)
+      INSERT INTO portti_view_bundle_seq (view_id, bundle_id, seqno, state, config, bundleinstance)
+           VALUES ( #viewId#, #bundleId#, #seqNo#, #state#, #config#, #bundleinstance#)
         RETURNING view_id
     </statement>
 
@@ -222,7 +222,6 @@
     <update id="update-bundle-settings-in-view"
             parameterClass="java.util.Map">
         UPDATE portti_view_bundle_seq SET
-            startup = #startup#,
             config = #config#,
             state = #state#,
             bundleinstance = #bundleinstance#


### PR DESCRIPTION
The startup information for bundles is no longer stored on the database with 1.49.0/Webpack changes. The database now has null-value constraint for the field in portti_view_bundle_seq and portti_bundle tables. Publisher and view saving functionalities still try to insert startup json which makes them fail the server operations. This fixes the issue by removing any startup references from insert/update SQLs.