### PR TITLE
HTML changes for CSS & JS

### DIFF
--- a/servlet-map/src/main/java/fi/nls/oskari/MapController.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/MapController.java
@@ -70,8 +70,9 @@ public class MapController {
         // compatibility for <1.49 JSPs -> there was an if statement to use minified or non-minified code
         model.addAttribute("preloaded", true);
 
-        model.addAttribute("oskariApplication",
-                PropertyUtil.get("oskari.client.version") + PropertyUtil.get("oskari.application"));
+        // for figuring out paths for frontend files
+        model.addAttribute("version", version);
+        model.addAttribute("oskariApplication",version + PropertyUtil.get("oskari.application"));
 
         // JSP
         final String viewJSP = setupRenderParameters(params, model);
@@ -167,7 +168,7 @@ public class MapController {
             final String referer = RequestHelper.getDomainFromReferer(params.getHttpHeader(IOHelper.HEADER_REFERER));
             final String pubDomain = view.getPubDomain();
             if (ViewHelper.isRefererDomain(referer, pubDomain)) {
-                log.info("Granted access to published view in domain:",pubDomain, "for referer", referer);
+                log.info("Granted access to published view in domain:", pubDomain, "for referer", referer);
             } else {
                 log.debug("Referer: ", params.getHttpHeader(IOHelper.HEADER_REFERER), " -> ", referer);
                 log.warn("Denied access to published view in domain:", pubDomain, "for referer", referer);

--- a/servlet-map/src/main/java/fi/nls/oskari/MapController.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/MapController.java
@@ -67,12 +67,6 @@ public class MapController {
         }
 
         writeCustomHeaders(params.getResponse());
-        // compatibility for <1.49 JSPs -> there was an if statement to use minified or non-minified code
-        model.addAttribute("preloaded", true);
-
-        // for figuring out paths for frontend files
-        model.addAttribute("version", version);
-        model.addAttribute("oskariApplication",version + PropertyUtil.get("oskari.application"));
 
         // JSP
         final String viewJSP = setupRenderParameters(params, model);
@@ -177,6 +171,7 @@ public class MapController {
             }
         }
 
+
         log.debug("Serving view with id:", view.getId());
         log.debug("View:", view.getDevelopmentPath(), "/", view.getApplication(), "/", view.getPage());
         model.addAttribute("viewId", view.getId());
@@ -188,9 +183,9 @@ public class MapController {
         // construct control params
         final JSONObject controlParams = getControlParams(params);
 
-        if(uuId != null){
+        if (uuId != null) {
             JSONHelper.putValue(controlParams, PARAM_UUID, view.getUuid());
-        }else{
+        } else {
             JSONHelper.putValue(controlParams, PARAM_VIEW_ID, view.getId());
         }
 
@@ -199,10 +194,17 @@ public class MapController {
         JSONHelper.putValue(controlParams, GetAppSetupHandler.PARAM_NO_SAVED_STATE, request.getParameter(GetAppSetupHandler.PARAM_NO_SAVED_STATE));
         model.addAttribute(KEY_CONTROL_PARAMS, controlParams.toString());
 
+        // compatibility for <1.49 JSPs -> there was an if statement to use minified or non-minified code
         model.addAttribute(KEY_PRELOADED, true);
+
+        // for figuring out paths for frontend files
+        model.addAttribute("version", version);
         model.addAttribute(KEY_PATH, "/" + version + "/" + view.getApplication());
         model.addAttribute("application", view.getApplication());
+
+        // title of the page
         model.addAttribute("viewName", view.getName());
+        
         model.addAttribute("user", params.getUser());
         model.addAttribute("language", params.getLocale().getLanguage());
 

--- a/servlet-map/src/main/resources/META-INF/resources/spring-map-jsp/index.jsp
+++ b/servlet-map/src/main/resources/META-INF/resources/spring-map-jsp/index.jsp
@@ -7,18 +7,18 @@
 <head>
     <title>Oskari - ${viewName}</title>
     <link rel="shortcut icon" href="/Oskari${path}/logo.png" type="image/png" />
-    <script type="text/javascript" src="/Oskari/libraries/jquery/jquery-3.3.1.min.js">
+    <script type="text/javascript" src="/Oskari/${version}/resources/js/jquery-3.3.1.min.js">
     </script>
 
     <!-- ############# css ################# -->
     <link
             rel="stylesheet"
             type="text/css"
-            href="/Oskari/resources/css/forms.css"/>
+            href="/Oskari/${version}/resources/css/forms.css"/>
     <link
             rel="stylesheet"
             type="text/css"
-            href="/Oskari/resources/css/portal.css"/>
+            href="/Oskari/${version}/resources/css/portal.css"/>
     <link
             rel="stylesheet"
             type="text/css"
@@ -59,7 +59,7 @@
             #login input[type="text"], #login input[type="password"] {
                 width: 90%;
                 margin-bottom: 5px;
-                background-image: url("/Oskari/resources/images/forms/input_shadow.png");
+                background-image: url("/Oskari/${version}/resources/images/forms/input_shadow.png");
                 background-repeat: no-repeat;
                 padding-left: 5px;
                 padding-right: 5px;

--- a/servlet-map/src/main/resources/META-INF/resources/spring-map-jsp/index.jsp
+++ b/servlet-map/src/main/resources/META-INF/resources/spring-map-jsp/index.jsp
@@ -7,18 +7,8 @@
 <head>
     <title>Oskari - ${viewName}</title>
     <link rel="shortcut icon" href="/Oskari${path}/logo.png" type="image/png" />
-    <script type="text/javascript" src="/Oskari/${version}/resources/js/jquery-3.3.1.min.js">
-    </script>
 
     <!-- ############# css ################# -->
-    <link
-            rel="stylesheet"
-            type="text/css"
-            href="/Oskari/${version}/resources/css/forms.css"/>
-    <link
-            rel="stylesheet"
-            type="text/css"
-            href="/Oskari/${version}/resources/css/portal.css"/>
     <link
             rel="stylesheet"
             type="text/css"

--- a/servlet-map/src/main/resources/META-INF/resources/spring-map-jsp/published.jsp
+++ b/servlet-map/src/main/resources/META-INF/resources/spring-map-jsp/published.jsp
@@ -5,7 +5,7 @@
     <title>${viewName}</title>
     <link rel="shortcut icon" href="/Oskari${path}/logo.png" type="image/png" />
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
-    <script type="text/javascript" src="/Oskari/libraries/jquery/jquery-3.3.1.min.js">
+    <script type="text/javascript" src="/Oskari/${version}/resources/js/jquery-3.3.1.min.js">
     </script>
     <!-- IE 9 polyfill for openlayers 3 - https://github.com/openlayers/ol3/issues/4865 -->
     <!--[if lte IE 9]> <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=fetch,requestAnimationFrame,Element.prototype.classList"></script> <![endif]-->
@@ -14,11 +14,11 @@
     <link
             rel="stylesheet"
             type="text/css"
-            href="/Oskari/resources/css/forms.css"/>
+            href="/Oskari/${version}/resources/css/forms.css"/>
     <link
             rel="stylesheet"
             type="text/css"
-            href="/Oskari/resources/css/portal.css"/>
+            href="/Oskari/${version}/resources/css/portal.css"/>
     <link
             rel="stylesheet"
             type="text/css"

--- a/servlet-map/src/main/resources/META-INF/resources/spring-map-jsp/published.jsp
+++ b/servlet-map/src/main/resources/META-INF/resources/spring-map-jsp/published.jsp
@@ -5,20 +5,10 @@
     <title>${viewName}</title>
     <link rel="shortcut icon" href="/Oskari${path}/logo.png" type="image/png" />
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
-    <script type="text/javascript" src="/Oskari/${version}/resources/js/jquery-3.3.1.min.js">
-    </script>
     <!-- IE 9 polyfill for openlayers 3 - https://github.com/openlayers/ol3/issues/4865 -->
     <!--[if lte IE 9]> <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=fetch,requestAnimationFrame,Element.prototype.classList"></script> <![endif]-->
 
     <!-- ############# css ################# -->
-    <link
-            rel="stylesheet"
-            type="text/css"
-            href="/Oskari/${version}/resources/css/forms.css"/>
-    <link
-            rel="stylesheet"
-            type="text/css"
-            href="/Oskari/${version}/resources/css/portal.css"/>
     <link
             rel="stylesheet"
             type="text/css"

--- a/webapp-map/src/main/webapp/WEB-INF/jsp/published.jsp
+++ b/webapp-map/src/main/webapp/WEB-INF/jsp/published.jsp
@@ -6,21 +6,11 @@
     <title>Standalone servlet - ${viewName} view</title>
     <link rel="shortcut icon" href="/Oskari${path}/logo.png" type="image/png" />
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
-    <script type="text/javascript" src="/Oskari/${version}/resources/js/jquery-3.3.1.min.js">
-    </script>
 
     <!-- IE 9 polyfill for openlayers 3 - https://github.com/openlayers/ol3/issues/4865 -->
     <!--[if lte IE 9]> <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=fetch,requestAnimationFrame,Element.prototype.classList"></script> <![endif]-->
 
     <!-- ############# css ################# -->
-    <link
-            rel="stylesheet"
-            type="text/css"
-            href="/Oskari/${version}/resources/css/forms.css"/>
-    <link
-            rel="stylesheet"
-            type="text/css"
-            href="/Oskari/${version}/resources/css/portal.css"/>
     <link
             rel="stylesheet"
             type="text/css"

--- a/webapp-map/src/main/webapp/WEB-INF/jsp/published.jsp
+++ b/webapp-map/src/main/webapp/WEB-INF/jsp/published.jsp
@@ -6,7 +6,7 @@
     <title>Standalone servlet - ${viewName} view</title>
     <link rel="shortcut icon" href="/Oskari${path}/logo.png" type="image/png" />
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
-    <script type="text/javascript" src="/Oskari/libraries/jquery/jquery-3.3.1.min.js">
+    <script type="text/javascript" src="/Oskari/${version}/resources/js/jquery-3.3.1.min.js">
     </script>
 
     <!-- IE 9 polyfill for openlayers 3 - https://github.com/openlayers/ol3/issues/4865 -->
@@ -16,11 +16,11 @@
     <link
             rel="stylesheet"
             type="text/css"
-            href="/Oskari/resources/css/forms.css"/>
+            href="/Oskari/${version}/resources/css/forms.css"/>
     <link
             rel="stylesheet"
             type="text/css"
-            href="/Oskari/resources/css/portal.css"/>
+            href="/Oskari/${version}/resources/css/portal.css"/>
     <link
             rel="stylesheet"
             type="text/css"


### PR DESCRIPTION
Add version model attribute that can be used for creating asset paths for the frontend. Removes references to jQuery and common CSS as they will be part of oskari.min.js

Note! This requires a frontend PR as well oskariorg/oskari-frontend#678 that needs to be merged at the same time.