### PR TITLE
Support for printing ArcGIS REST layers

### DIFF
--- a/service-print/src/main/java/org/oskari/print/loader/AsyncImageLoader.java
+++ b/service-print/src/main/java/org/oskari/print/loader/AsyncImageLoader.java
@@ -55,6 +55,10 @@ public class AsyncImageLoader {
                 images.add(new CommandLoadImageAnalysis(request.getUser(),
                         layer, width, height, bbox, srsName).queue());
                 break;
+            case OskariLayer.TYPE_ARCGIS93:
+                images.add(new CommandLoadImageArcGISREST(layer,
+                        width, height, bbox, srsName).queue());
+                break;
             default:
                 throw new IllegalArgumentException("Invalid layer type!");
             }

--- a/service-print/src/main/java/org/oskari/print/loader/CommandLoadImageArcGISREST.java
+++ b/service-print/src/main/java/org/oskari/print/loader/CommandLoadImageArcGISREST.java
@@ -1,0 +1,52 @@
+package org.oskari.print.loader;
+
+import java.awt.image.BufferedImage;
+
+import org.oskari.print.request.PrintLayer;
+import org.oskari.print.util.ArcGISMapExportBuilder;
+
+/**
+ * HystrixCommand that loads BufferedImage from ArcGIS REST API
+ */
+public class CommandLoadImageArcGISREST extends CommandLoadImageBase {
+
+    private final PrintLayer layer;
+    private final int width;
+    private final int height;
+    private final double[] bbox;
+    private final String srsName;
+
+    public CommandLoadImageArcGISREST(PrintLayer layer,
+            int width,
+            int height,
+            double[] bbox,
+            String srsName) {
+        super(Integer.toString(layer.getId()));
+        this.layer = layer;
+        this.width = width;
+        this.height = height;
+        this.bbox = bbox;
+        this.srsName = srsName;
+    }
+
+    @Override
+    public BufferedImage run() throws Exception {
+        final String request = new ArcGISMapExportBuilder()
+                .endPoint(layer.getUrl())
+                .layer(layer.getName())
+                .bbox(bbox)
+                .crs(srsName)
+                .width(width)
+                .height(height)
+                .transparent(true)
+                .build();
+
+        return CommandLoadImageFromURL.load(request, layer.getUsername(), layer.getPassword());
+    }
+
+    @Override
+    public BufferedImage getFallback() {
+        return null;
+    }
+
+}

--- a/service-print/src/main/java/org/oskari/print/util/ArcGISMapExportBuilder.java
+++ b/service-print/src/main/java/org/oskari/print/util/ArcGISMapExportBuilder.java
@@ -1,0 +1,85 @@
+package org.oskari.print.util;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import fi.nls.oskari.util.IOHelper;
+
+/**
+ * ArcGIS REST API Export Map Request (KVP) Builder
+ */
+public class ArcGISMapExportBuilder {
+
+    private String endPoint;
+    private String layer;
+    private double[] bbox;
+    private int bboxsr;
+    private int width;
+    private int height;
+    private boolean transparent;
+
+    public ArcGISMapExportBuilder endPoint(String endPoint) {
+        this.endPoint = endPoint;
+        return this;
+    }
+
+    public ArcGISMapExportBuilder layer(String layer) {
+        this.layer = layer;
+        return this;
+    }
+
+    public ArcGISMapExportBuilder bbox(double[] bbox) throws IllegalArgumentException {
+        if (bbox == null || bbox.length != 4) {
+            throw new IllegalArgumentException("bbox length must be 4");
+        }
+        this.bbox = bbox;
+        return this;
+    }
+
+    public ArcGISMapExportBuilder crs(String srs) {
+        int i = srs.lastIndexOf(':');
+        if (i < 0) {
+            throw new IllegalArgumentException("srs must contain :");
+        }
+        return srid(Integer.parseInt(srs.substring(i + 1)));
+    }
+
+    public ArcGISMapExportBuilder srid(int srid) {
+        this.bboxsr = srid;
+        return this;
+    }
+
+    public ArcGISMapExportBuilder width(int width) {
+        this.width = width;
+        return this;
+    }
+
+    public ArcGISMapExportBuilder height(int height) {
+        this.height = height;
+        return this;
+    }
+
+    public ArcGISMapExportBuilder transparent(boolean transparent) {
+        this.transparent = transparent;
+        return this;
+    }
+
+    public String build() throws IllegalArgumentException {
+        if (endPoint == null || endPoint.length() == 0) {
+            throw new IllegalArgumentException("Required parameter 'endPoint' missing");
+        }
+
+        Map<String, String> params = new LinkedHashMap<>();
+        params.put("F", "IMAGE");
+        params.put("FORMAT", "PNG32");
+        params.put("BBOX", String.format("%f,%f,%f,%f", bbox[0], bbox[1], bbox[2], bbox[3]));
+        params.put("BBOXSR", Integer.toString(bboxsr));
+        params.put("SIZE", String.format("%d,%d", width, height));
+        params.put("LAYER", String.format("show:%s", layer));
+        params.put("TRANSPARENT", transparent ? "TRUE" : "FALSE");
+        params.put("DPI", Integer.toString(90));
+
+        return IOHelper.constructUrl(endPoint, params);
+    }
+
+}


### PR DESCRIPTION
Currently `OskariLayer.TYPE_ARCGIS93` layers throw an exception when one tries to print one. This PR adds support for them.