### PR TITLE
Throw more specialized exception so it can be handled separately

### DIFF
--- a/service-base/src/main/java/fi/nls/oskari/util/PropertyUtil.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/PropertyUtil.java
@@ -118,7 +118,7 @@ public class PropertyUtil {
             if(detailMessage != null) {
                 msg = msg + ". Message: " + detailMessage;
             }
-            throw new RuntimeException(msg);
+            throw new NoSuchElementException(msg);
         }
         return prop;
     }


### PR DESCRIPTION
PropertyUtil.getNecessary() already throws a RuntimeException if the requested property is not present. This makes the exception more specific so it can be caught and handled separately from other possible RuntimeExceptions.