### PR TITLE
oskari.css -> oskari.min.css

### DIFF
--- a/servlet-map/src/main/resources/META-INF/resources/spring-map-jsp/index.jsp
+++ b/servlet-map/src/main/resources/META-INF/resources/spring-map-jsp/index.jsp
@@ -17,7 +17,7 @@
     <link
             rel="stylesheet"
             type="text/css"
-            href="/Oskari${path}/oskari.css"/>
+            href="/Oskari${path}/oskari.min.css"/>
 
     <link href="https://fonts.googleapis.com/css?family=Noto+Sans" rel="stylesheet">
     <style type="text/css">

--- a/servlet-map/src/main/resources/META-INF/resources/spring-map-jsp/published.jsp
+++ b/servlet-map/src/main/resources/META-INF/resources/spring-map-jsp/published.jsp
@@ -17,7 +17,7 @@
     <link
             rel="stylesheet"
             type="text/css"
-            href="/Oskari${path}/oskari.css"/>
+            href="/Oskari${path}/oskari.min.css"/>
 
     <link href="https://fonts.googleapis.com/css?family=Noto+Sans" rel="stylesheet">
     <style type="text/css">

--- a/webapp-map/src/main/webapp/WEB-INF/jsp/published.jsp
+++ b/webapp-map/src/main/webapp/WEB-INF/jsp/published.jsp
@@ -19,7 +19,7 @@
     <link
             rel="stylesheet"
             type="text/css"
-            href="/Oskari${path}/oskari.css"/>
+            href="/Oskari${path}/oskari.min.css"/>
 
     <style type="text/css">
         @media screen {


### PR DESCRIPTION
Rename new build artifact/css-file to match the old one so migration guide doesn't need to mention renaming.