### PR TITLE
Language handling for statistical indicators

### DIFF
--- a/control-statistics/src/main/java/fi/nls/oskari/control/statistics/user/SaveIndicatorHandler.java
+++ b/control-statistics/src/main/java/fi/nls/oskari/control/statistics/user/SaveIndicatorHandler.java
@@ -12,6 +12,8 @@ import fi.nls.oskari.annotation.OskariActionRoute;
 import fi.nls.oskari.util.JSONHelper;
 import fi.nls.oskari.util.ResponseHelper;
 
+import java.util.NoSuchElementException;
+
 @OskariActionRoute("SaveIndicator")
 public class SaveIndicatorHandler extends RestActionHandler {
 
@@ -75,10 +77,18 @@ public class SaveIndicatorHandler extends RestActionHandler {
         ind.setPublic(true);
 
         String language = params.getLocale().getLanguage();
-        ind.addName(language, params.getHttpParam(PARAM_NAME, ind.getName(language)));
+        ind.addName(language, params.getHttpParam(PARAM_NAME, getExistingName(ind, language)));
         ind.addDescription(language, params.getHttpParam(PARAM_DESCRIPTION, ind.getDescription(language)));
         ind.addSource(language, params.getHttpParam(PARAM_SOURCE, ind.getSource(language)));
         return ind;
     }
 
+    private String getExistingName(StatisticalIndicator ind, String language) {
+        try {
+            return ind.getName(language);
+        } catch (NoSuchElementException e) {
+            // handle exception from getting existing name since new indicators don't have an existing one
+            return null;
+        }
+    }
 }

--- a/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/data/StatisticalIndicator.java
+++ b/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/data/StatisticalIndicator.java
@@ -62,7 +62,12 @@ public class StatisticalIndicator {
         return null;
     }
     public String getName(String lang) {
-        return getLocalizedValue(getName(), lang);
+        String name = getLocalizedValue(getName(), lang);
+
+        if(name == null || name.trim().isEmpty()) {
+            throw new NoSuchElementException("Value not found for " + lang + " or " + PropertyUtil.getDefaultLanguage());
+        }
+        return name;
     }
     public String getSource(String lang) {
         return getLocalizedValue(getSource(), lang);
@@ -80,7 +85,7 @@ public class StatisticalIndicator {
             lang = PropertyUtil.getDefaultLanguage();
         }
         String value = map.get(lang);
-        if(value == null) {
+        if(value == null || value.trim().isEmpty()) {
             // try with default language
             return map.get(PropertyUtil.getDefaultLanguage());
         }


### PR DESCRIPTION
Indicator.getName() now throws an exception if there was no name for the requested OR default language.