### PR TITLE
Fix TileGrid calculations in WFS-MVT

### DIFF
--- a/service-mvt-wfs/src/main/java/org/oskari/service/mvt/wfs/WFSTileGrid.java
+++ b/service-mvt-wfs/src/main/java/org/oskari/service/mvt/wfs/WFSTileGrid.java
@@ -2,7 +2,7 @@ package org.oskari.service.mvt.wfs;
 
 public class WFSTileGrid {
 
-    public static final int TILE_SIZE = 512;
+    public static final int TILE_SIZE = 256;
 
     private final double originX;
     private final double originY;
@@ -16,7 +16,7 @@ public class WFSTileGrid {
         }
 
         this.originX = extent[0];
-        this.originY = extent[1];
+        this.originY = extent[3];
 
         this.resolutions = new double[maxZoom + 1];
 
@@ -33,8 +33,8 @@ public class WFSTileGrid {
     public double[] getTileExtent(TileCoord tile) {
         double tileSizeInNature = TILE_SIZE * resolutions[tile.getZ()];
         double x1 = originX + tile.getX() * tileSizeInNature;
-        double y1 = originY + tile.getY() * tileSizeInNature;
-        return new double[] { x1, y1, x1 + tileSizeInNature, y1 + tileSizeInNature };
+        double y1 = originY - tile.getY() * tileSizeInNature;
+        return new double[] { x1, y1 - tileSizeInNature, x1 + tileSizeInNature, y1 };
     }
 
     public static int getMatrixSize(int z) {

--- a/service-mvt-wfs/src/test/java/org/oskari/service/mvt/wfs/WFSTileGridTest.java
+++ b/service-mvt-wfs/src/test/java/org/oskari/service/mvt/wfs/WFSTileGridTest.java
@@ -1,0 +1,26 @@
+package org.oskari.service.mvt.wfs;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import org.junit.Test;
+
+public class WFSTileGridTest {
+
+    @Test
+    public void testETRSTM35FIN() {
+        WFSTileGrid etrsTM35fin = new WFSTileGrid(new double[] { -548576, 6291456, 1548576, 8388608 }, 15);
+
+        double[] actuals = etrsTM35fin.getTileExtent(new TileCoord(0, 0, 0));
+        double[] expecteds = { -548576, 6291456, 1548576, 8388608 };
+        assertArrayEquals(expecteds, actuals, 0);
+
+        double[] actuals2 = etrsTM35fin.getTileExtent(new TileCoord(1, 0, 1));
+        double[] expecteds2 = { -548576, 6291456, -548576 + 4096*256, 8388608 - 4096*256 };
+        assertArrayEquals(expecteds2, actuals2, 0);
+
+        double[] actuals3 = etrsTM35fin.getTileExtent(new TileCoord(1, 1, 1));
+        double[] expecteds3 = { -548576 + 4096*256, 6291456, 1548576, 8388608 - 4096*256 };
+        assertArrayEquals(expecteds3, actuals3, 0);
+    }
+
+}


### PR DESCRIPTION
Use 256 tilesize instead of 512
Use WMTS way of tileRows growing downwards, e.g. tileRow 1 is down/south of tileRow 0