### PR TITLE
Improvements to MVT-WFS module

### DIFF
--- a/service-mvt/src/main/java/org/oskari/service/mvt/SimpleFeatureConverter.java
+++ b/service-mvt/src/main/java/org/oskari/service/mvt/SimpleFeatureConverter.java
@@ -56,7 +56,8 @@ public class SimpleFeatureConverter implements IUserDataConverter {
                 continue;
             }
 
-            featureBuilder.addTags(layerProps.addKey(prop));
+            int keyIndex = layerProps.addKey(prop);
+            featureBuilder.addTags(keyIndex);
             featureBuilder.addTags(valueIndex);
         }
     }
@@ -65,14 +66,9 @@ public class SimpleFeatureConverter implements IUserDataConverter {
         if (id == null || id.isEmpty()) {
             return;
         }
-        int valueIndex = layerProps.addKey(id);
-        if (valueIndex < 0) {
-            // This shouldn't happen as id is non-empty String
-            LOG.warn("Could not add id: " + id);
-            return;
-        }
-        layerProps.addValue(id);
-        featureBuilder.addTags(layerProps.addKey(KEY_ID));
+        int valueIndex = layerProps.addValue(id);
+        int keyIndex = layerProps.addKey(KEY_ID);
+        featureBuilder.addTags(keyIndex);
         featureBuilder.addTags(valueIndex);
     }
 

--- a/service-mvt/src/main/java/org/oskari/service/mvt/SimpleFeatureConverter.java
+++ b/service-mvt/src/main/java/org/oskari/service/mvt/SimpleFeatureConverter.java
@@ -17,16 +17,20 @@ public class SimpleFeatureConverter implements IUserDataConverter {
 
     private static final Logger LOG = LogFactory.getLogger(SimpleFeatureConverter.class);
 
+    private static final String KEY_ID = "_oid";
+
     @Override
     public void addTags(Object userData, MvtLayerProps layerProps, Builder featureBuilder) {
         if (!(userData instanceof SimpleFeature)) {
             LOG.debug("userData not a SimpleFeature!");
             return;
         }
-
         SimpleFeature f = (SimpleFeature) userData;
-        Name geomPropertyName = f.getDefaultGeometryProperty().getName();
+
         String id = f.getID();
+        addId(layerProps, featureBuilder, id);
+
+        Name geomPropertyName = f.getDefaultGeometryProperty().getName();
         for (Property p : f.getProperties()) {
             Name name = p.getName();
             if (geomPropertyName.equals(name)) {
@@ -55,6 +59,21 @@ public class SimpleFeatureConverter implements IUserDataConverter {
             featureBuilder.addTags(layerProps.addKey(prop));
             featureBuilder.addTags(valueIndex);
         }
+    }
+
+    private void addId(MvtLayerProps layerProps, Builder featureBuilder, String id) {
+        if (id == null || id.isEmpty()) {
+            return;
+        }
+        int valueIndex = layerProps.addKey(id);
+        if (valueIndex < 0) {
+            // This shouldn't happen as id is non-empty String
+            LOG.warn("Could not add id: " + id);
+            return;
+        }
+        layerProps.addValue(id);
+        featureBuilder.addTags(layerProps.addKey(KEY_ID));
+        featureBuilder.addTags(valueIndex);
     }
 
 }

--- a/service-mvt/src/main/java/org/oskari/service/mvt/SimpleFeaturesMVTEncoder.java
+++ b/service-mvt/src/main/java/org/oskari/service/mvt/SimpleFeaturesMVTEncoder.java
@@ -34,6 +34,7 @@ import com.wdtinc.mapbox_vector_tile.build.MvtLayerProps;
 public class SimpleFeaturesMVTEncoder {
 
     private static final GeometryFactory GF = new GeometryFactory();
+    private static final int TILE_SIZE = 256;
 
     public static byte[] encodeToByteArray(SimpleFeatureCollection sfc,
             String layer, double[] bbox, int extent, int buffer) {
@@ -88,7 +89,7 @@ public class SimpleFeaturesMVTEncoder {
         }
 
         return JtsAdapter.createTileGeom(geoms, tileEnvelope, clipEnvelope, GF,
-                new MvtLayerParams(512, extent), new GeomMinSizeFilter(6, 6)).mvtGeoms;
+                new MvtLayerParams(TILE_SIZE, extent), new GeomMinSizeFilter(6, 6)).mvtGeoms;
     }
 
     public static List<Geometry> asMVTGeoms(SimpleFeatureCollection sfc, double[] bbox, int extent, int buffer) {
@@ -191,7 +192,9 @@ public class SimpleFeaturesMVTEncoder {
             Polygon polygon = (Polygon) geom;
             LinearRing exterior = (LinearRing) polygon.getExteriorRing();
             if (!rectIntersects.intersects(exterior)) {
-                return null;
+                if (!polygon.covers(GF.toGeometry(rect))) {
+                    return null;
+                }
             }
             int numInteriorRing = polygon.getNumInteriorRing();
             if (numInteriorRing == 0) {

--- a/service-mvt/src/test/java/org/oskari/service/mvt/SimpleFeaturesMVTEncoderTest.java
+++ b/service-mvt/src/test/java/org/oskari/service/mvt/SimpleFeaturesMVTEncoderTest.java
@@ -1,0 +1,89 @@
+package org.oskari.service.mvt;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.geotools.feature.DefaultFeatureCollection;
+import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.junit.Test;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.LinearRing;
+import com.vividsolutions.jts.geom.Polygon;
+
+public class SimpleFeaturesMVTEncoderTest {
+
+    @Test
+    public void whenFeaturePolygonFullyContainsTileExtentThenFeatureIsAccepted() {
+        Coordinate[] ca = new Coordinate[5];
+        ca[0] = new Coordinate(-50, -50);
+        ca[1] = new Coordinate(150, -50);
+        ca[2] = new Coordinate(150, 150);
+        ca[3] = new Coordinate(-50, 150);
+        ca[4] = new Coordinate(-50, -50);
+        GeometryFactory gf = new GeometryFactory();
+        LinearRing exterior = gf.createLinearRing(ca);
+        Polygon p = gf.createPolygon(exterior);
+
+        double[] bbox = { 0, 0, 100, 100 };
+        SimpleFeatureTypeBuilder tBuilder = new SimpleFeatureTypeBuilder();
+        tBuilder.setName("test");
+        tBuilder.add("geom", Polygon.class);
+        SimpleFeatureType featureType = tBuilder.buildFeatureType();
+
+        SimpleFeatureBuilder fBuilder = new SimpleFeatureBuilder(featureType);
+        fBuilder.set("geom", p);
+        SimpleFeature f = fBuilder.buildFeature(null);
+
+        DefaultFeatureCollection fc = new DefaultFeatureCollection("test");
+        fc.add(f);
+
+        List<Geometry> geom = SimpleFeaturesMVTEncoder.asMVTGeoms(fc, bbox, 4096, 256);
+        assertEquals(1, geom.size());
+    }
+
+    @Test
+    public void whenPolygonInteriorRingFullyContainsTileExtentThenFeatureIsIgnored() {
+        GeometryFactory gf = new GeometryFactory();
+
+        Coordinate[] ca = new Coordinate[5];
+        ca[0] = new Coordinate(-50, -50);
+        ca[1] = new Coordinate(150, -50);
+        ca[2] = new Coordinate(150, 150);
+        ca[3] = new Coordinate(-50, 150);
+        ca[4] = new Coordinate(-50, -50);
+        LinearRing exterior = gf.createLinearRing(ca);
+
+        ca[0] = new Coordinate(-10, -10);
+        ca[1] = new Coordinate(-10, 110);
+        ca[2] = new Coordinate(110, 110);
+        ca[3] = new Coordinate(110, -10);
+        ca[4] = new Coordinate(-10, -10);
+        LinearRing interior = gf.createLinearRing(ca);
+
+        Polygon p = gf.createPolygon(exterior, new LinearRing[] { interior });
+
+        double[] bbox = { 0, 0, 100, 100 };
+        SimpleFeatureTypeBuilder tBuilder = new SimpleFeatureTypeBuilder();
+        tBuilder.setName("test");
+        tBuilder.add("geom", Polygon.class);
+        SimpleFeatureType featureType = tBuilder.buildFeatureType();
+
+        SimpleFeatureBuilder fBuilder = new SimpleFeatureBuilder(featureType);
+        fBuilder.set("geom", p);
+        SimpleFeature f = fBuilder.buildFeature(null);
+
+        DefaultFeatureCollection fc = new DefaultFeatureCollection("test");
+        fc.add(f);
+
+        List<Geometry> geom = SimpleFeaturesMVTEncoder.asMVTGeoms(fc, bbox, 4096, 256);
+        assertEquals(0, geom.size());
+    }
+
+}


### PR DESCRIPTION
Currently Polygons that fully contain the tile extent get ignored. This fixes that.
Also add the id as a property to the MVT tiles. We don't use the actual 'id' field of the mvt.Feature because that only allows integer values and in many cases the id is a string prefixed integer or an uuid presented as a string.