### PR TITLE
Manage Hystrix dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -851,11 +851,6 @@
                 <artifactId>hystrix-core</artifactId>
                 <version>${hystrix.version}</version>
             </dependency>
-            <dependency>
-                <groupId>com.netflix.hystrix</groupId>
-                <artifactId>hystrix-metrics-event-stream</artifactId>
-                <version>${hystrix.version}</version>
-            </dependency>
 
             <!-- Managed test dependencies -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,7 @@
 
         <mybatis.version>3.4.6</mybatis.version>
         <pdfbox.version>2.0.12</pdfbox.version>
+        <hystrix.version>1.5.18</hystrix.version>
         <!-- Test deps versions -->
         <powermock.version>1.5</powermock.version>
         <junit.version>4.11</junit.version>
@@ -844,6 +845,16 @@
                 <groupId>org.apache.pdfbox</groupId>
                 <artifactId>pdfbox</artifactId>
                 <version>${pdfbox.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.netflix.hystrix</groupId>
+                <artifactId>hystrix-core</artifactId>
+                <version>${hystrix.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.netflix.hystrix</groupId>
+                <artifactId>hystrix-metrics-event-stream</artifactId>
+                <version>${hystrix.version}</version>
             </dependency>
 
             <!-- Managed test dependencies -->

--- a/service-print/pom.xml
+++ b/service-print/pom.xml
@@ -11,7 +11,6 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <hystrix.version>1.5.12</hystrix.version>
     </properties>
 
     <dependencies>
@@ -34,7 +33,6 @@
         <dependency>
             <groupId>com.netflix.hystrix</groupId>
             <artifactId>hystrix-core</artifactId>
-            <version>${hystrix.version}</version>
         </dependency>
         <dependency>
             <groupId>fi.nls.oskari</groupId>

--- a/servlet-transport/pom.xml
+++ b/servlet-transport/pom.xml
@@ -76,7 +76,6 @@
         <dependency>
             <groupId>com.netflix.hystrix</groupId>
             <artifactId>hystrix-core</artifactId>
-            <version>1.4.0</version>
         </dependency>
         <dependency>
             <groupId>com.netflix.rxjava</groupId>

--- a/webapp-transport/pom.xml
+++ b/webapp-transport/pom.xml
@@ -50,9 +50,5 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.netflix.hystrix</groupId>
-            <artifactId>hystrix-metrics-event-stream</artifactId>
-        </dependency>
     </dependencies>
 </project>

--- a/webapp-transport/pom.xml
+++ b/webapp-transport/pom.xml
@@ -53,7 +53,6 @@
         <dependency>
             <groupId>com.netflix.hystrix</groupId>
             <artifactId>hystrix-metrics-event-stream</artifactId>
-            <version>1.1.2</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Currently multiple different versions are in use and none of them is managed by the parent pom.