### PR TITLE
Maplayer coverage data handling

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/view/modifier/bundle/MapfullHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/view/modifier/bundle/MapfullHandler.java
@@ -447,10 +447,8 @@ public class MapfullHandler extends BundleHandler {
                 continue;
             }
 
-            final JSONObject json = userLayerDataService.parseUserLayer2JSON(userLayer, baseLayer);
+            final JSONObject json = userLayerDataService.parseUserLayer2JSON(userLayer, baseLayer, mapSrs);
             if (json != null) {
-                // transform WKT (WGS84) to mapSrs
-                OskariLayerWorker.transformWKTGeom(json, mapSrs);
                 layerList.put(json);
             }
         }

--- a/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java
+++ b/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java
@@ -397,7 +397,8 @@ public class CreateUserLayerHandler extends RestActionHandler {
     }
 
     private void writeResponse(ActionParameters params, UserLayer ulayer) throws ActionException {
-        JSONObject userLayer = UserLayerDataService.parseUserLayer2JSON(ulayer);
+        String mapSrs = params.getHttpParam(ActionConstants.PARAM_SRS);
+        JSONObject userLayer = UserLayerDataService.parseUserLayer2JSON(ulayer, mapSrs);
         JSONHelper.putValue(userLayer, "featuresCount", ulayer.getFeatures_count());
         JSONObject permissions = OskariLayerWorker.getAllowedPermissions();
         JSONHelper.putValue(userLayer, "permissions", permissions);
@@ -407,8 +408,6 @@ public class CreateUserLayerHandler extends RestActionHandler {
             JSONHelper.putValue(featuresSkipped, "featuresSkipped", ulayer.getFeatures_skipped());
             JSONHelper.putValue(userLayer, "warning", featuresSkipped);
         }
-        // transform WKT for layers now that we know SRS
-        OskariLayerWorker.transformWKTGeom(userLayer, params.getHttpParam(ActionConstants.PARAM_SRS));
         ResponseHelper.writeResponse(params, userLayer);
     }
 

--- a/control-userlayer/src/main/java/org/oskari/control/userlayer/EditUserLayerHandler.java
+++ b/control-userlayer/src/main/java/org/oskari/control/userlayer/EditUserLayerHandler.java
@@ -34,6 +34,7 @@ public class EditUserLayerHandler extends RestActionHandler {
 
     @Override
     public void handlePost(ActionParameters params) throws ActionException {
+        String mapSrs = params.getHttpParam(ActionConstants.PARAM_SRS);
         final UserLayer userLayer = UserLayerHandlerHelper.getUserLayer(userLayerDbService, params);
         userLayer.setLayer_name(params.getRequiredParam(PARAM_NAME));
         userLayer.setLayer_desc(params.getHttpParam(PARAM_DESC, userLayer.getLayer_desc()));
@@ -46,7 +47,7 @@ public class EditUserLayerHandler extends RestActionHandler {
         userLayerDbService.updateUserLayerCols(userLayer);
         userLayerDbService.updateUserLayerStyleCols(style);
 
-        JSONObject ulayer = UserLayerDataService.parseUserLayer2JSON(userLayer);
+        JSONObject ulayer = UserLayerDataService.parseUserLayer2JSON(userLayer, mapSrs);
         JSONObject permissions = OskariLayerWorker.getAllowedPermissions();
         JSONHelper.putValue(ulayer, "permissions", permissions);
 

--- a/control-userlayer/src/main/java/org/oskari/control/userlayer/GetUserLayersHandler.java
+++ b/control-userlayer/src/main/java/org/oskari/control/userlayer/GetUserLayersHandler.java
@@ -35,22 +35,19 @@ public class GetUserLayersHandler extends ActionHandler {
 
     @Override
     public void handleAction(ActionParameters params) throws ActionException {
-
+        String mapSrs = params.getHttpParam(ActionConstants.PARAM_SRS);
         final JSONObject response = new JSONObject();
         final JSONArray layers = new JSONArray();
         JSONHelper.putValue(response, JSKEY_USERLAYERS, layers);
-
         final User user = params.getUser();
         if (!user.isGuest()) {
             final List<UserLayer> list = userLayerService.getUserLayerByUuid(user.getUuid());
             final OskariLayer baseLayer = UserLayerDataService.getBaseLayer();
             for (UserLayer ul : list) {
                 // Parse userlayer data to userlayer
-                final JSONObject userLayer = UserLayerDataService.parseUserLayer2JSON(ul, baseLayer);
+                final JSONObject userLayer = UserLayerDataService.parseUserLayer2JSON(ul, baseLayer, mapSrs);
                 JSONObject permissions = OskariLayerWorker.getAllowedPermissions();
                 JSONHelper.putValue(userLayer, "permissions", permissions);
-                // transform WKT for layers now that we know SRS
-                OskariLayerWorker.transformWKTGeom(userLayer, params.getHttpParam(ActionConstants.PARAM_SRS));
                 layers.put(userLayer);
             }
         }

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERLAYER.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERLAYER.java
@@ -35,7 +35,8 @@ public class LayerJSONFormatterUSERLAYER extends LayerJSONFormatter {
                                      final boolean isSecure,
                                      final String crs,
                                      UserLayer ulayer) {
-
+        // set geometry before parsing layerJson
+        layer.setGeometry(ulayer.getWkt());
         final JSONObject layerJson = getBaseJSON(layer, lang, isSecure, crs);
 
         JSONHelper.putValue(layerJson, "isQueryable", true);
@@ -51,7 +52,6 @@ public class LayerJSONFormatterUSERLAYER extends LayerJSONFormatter {
         // user layer rendering url - override DB url if property is defined
         JSONHelper.putValue(layerJson, "url", getUserLayerTileUrl());
         JSONHelper.putValue(layerJson, "renderingElement", userlayerRenderingElement);
-        JSONHelper.putValue(layerJson, "geom", ulayer.getWkt());
 
         return layerJson;
     }

--- a/service-map/src/test/java/fi/mml/map/mapwindow/service/wms/WebMapServiceV1_3_0ImplTest.java
+++ b/service-map/src/test/java/fi/mml/map/mapwindow/service/wms/WebMapServiceV1_3_0ImplTest.java
@@ -39,6 +39,8 @@ public class WebMapServiceV1_3_0ImplTest {
                 "text/xml; subtype=gml/3.1.1", "text/html", "application/json"
         }, wms.getFormats());
         assertEquals(0, wms.getTime().size());
+        String wkt = "POLYGON ((15.608220469655935 59.36205414098515, 15.608220469655935 70.09468368748001, 33.107629330539034 70.09468368748001, 33.107629330539034 59.36205414098515, 15.608220469655935 59.36205414098515))";
+        assertEquals(wkt, wms.getGeom());
     }
 
     @Test
@@ -76,6 +78,18 @@ public class WebMapServiceV1_3_0ImplTest {
         wms = new WebMapServiceV1_3_0_Impl("http://unit.test/ing",
                 readResource(CHLORO), "arctic_sdi:Chlorophyll", allowed);
         assertArrayEquals(new String[] { "EPSG:3408", "EPSG:3857" }, wms.getCRSs());
+    }
+
+    @Test
+    public void testBoundingBox()
+            throws IOException, WebMapServiceParseException, LayerNotFoundInCapabilitiesException {
+        WebMapServiceV1_3_0_Impl wms = new WebMapServiceV1_3_0_Impl("http://unit.test/ing", readResource(CHLORO),
+                "arctic_sdi:LandSurfaceTemperature");
+        // BBOX minx, minx, miny, maxx, maxy
+        // Abstract layer's bbox (-4462340.35076383, -4467019.64923622, 4467019.64923617, 4462340.35076378)
+        // Layer's bbox (-180.0, 30.669210068137946, 180.0, 90.0)
+        String wkt = "POLYGON ((-180.0 30.669210068137946, -180.0 90.0, 180.0 90.0, 180.0 30.669210068137946, -180.0 30.669210068137946))";
+        assertEquals(wkt, wms.getGeom());
     }
 
     private String readResource(String p) throws IOException {

--- a/service-map/src/test/resources/hake_wms_1_3_0.xml
+++ b/service-map/src/test/resources/hake_wms_1_3_0.xml
@@ -1,0 +1,795 @@
+<?xml version="1.0" encoding="UTF-8"?><WMS_Capabilities version="1.3.0" updateSequence="18228" xmlns="http://www.opengis.net/wms" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wms https://fake.address/inspire-wms/schemas/wms/1.3.0/capabilities_1_3_0.xsd">
+  <Service>
+    <Name>WMS</Name>
+    <Title>Digia WMS Service</Title>
+    <Abstract/>
+    <KeywordList/>
+    <OnlineResource xlink:type="simple" xlink:href="http://kampi.digia.com:80/geoserver/"/>
+    <ContactInformation>
+      <ContactPersonPrimary>
+        <ContactPerson/>
+        <ContactOrganization/>
+      </ContactPersonPrimary>
+      <ContactPosition/>
+      <ContactAddress>
+        <AddressType/>
+        <Address/>
+        <City/>
+        <StateOrProvince/>
+        <PostCode/>
+        <Country/>
+      </ContactAddress>
+      <ContactVoiceTelephone/>
+      <ContactFacsimileTelephone/>
+      <ContactElectronicMailAddress/>
+    </ContactInformation>
+    <Fees>none</Fees>
+    <AccessConstraints>none</AccessConstraints>
+  </Service>
+  <Capability>
+    <Request>
+      <GetCapabilities>
+        <Format>text/xml</Format>
+        <DCPType>
+          <HTTP>
+            <Get>
+              <OnlineResource xlink:type="simple" xlink:href="http://kampi.digia.com:80/geoserver/hake/ows?SERVICE=WMS&amp;"/>
+            </Get>
+            <Post>
+              <OnlineResource xlink:type="simple" xlink:href="http://kampi.digia.com:80/geoserver/hake/ows?SERVICE=WMS&amp;"/>
+            </Post>
+          </HTTP>
+        </DCPType>
+      </GetCapabilities>
+      <GetMap>
+        <Format>image/png</Format>
+        <Format>application/atom+xml</Format>
+        <Format>application/pdf</Format>
+        <Format>application/rss+xml</Format>
+        <Format>application/vnd.google-earth.kml+xml</Format>
+        <Format>application/vnd.google-earth.kml+xml;mode=networklink</Format>
+        <Format>application/vnd.google-earth.kmz</Format>
+        <Format>image/geotiff</Format>
+        <Format>image/geotiff8</Format>
+        <Format>image/gif</Format>
+        <Format>image/jpeg</Format>
+        <Format>image/png; mode=8bit</Format>
+        <Format>image/svg+xml</Format>
+        <Format>image/tiff</Format>
+        <Format>image/tiff8</Format>
+        <Format>text/html; subtype=openlayers</Format>
+        <DCPType>
+          <HTTP>
+            <Get>
+              <OnlineResource xlink:type="simple" xlink:href="http://kampi.digia.com:80/geoserver/hake/ows?SERVICE=WMS&amp;"/>
+            </Get>
+          </HTTP>
+        </DCPType>
+      </GetMap>
+      <GetFeatureInfo>
+        <Format>text/plain</Format>
+        <Format>application/vnd.ogc.gml</Format>
+        <Format>text/xml</Format>
+        <Format>application/vnd.ogc.gml/3.1.1</Format>
+        <Format>text/xml; subtype=gml/3.1.1</Format>
+        <Format>text/html</Format>
+        <Format>application/json</Format>
+        <DCPType>
+          <HTTP>
+            <Get>
+              <OnlineResource xlink:type="simple" xlink:href="http://kampi.digia.com:80/geoserver/hake/ows?SERVICE=WMS&amp;"/>
+            </Get>
+          </HTTP>
+        </DCPType>
+      </GetFeatureInfo>
+    </Request>
+    <Exception>
+      <Format>XML</Format>
+      <Format>INIMAGE</Format>
+      <Format>BLANK</Format>
+    </Exception>
+    <Layer>
+      <Title>Digia WMS Service</Title>
+      <Abstract/>
+      <!--Limited list of EPSG projections:-->
+      <CRS>EPSG:3067</CRS>
+      <CRS>CRS:84</CRS>
+      <EX_GeographicBoundingBox>
+        <westBoundLongitude>0.0</westBoundLongitude>
+        <eastBoundLongitude>-1.0</eastBoundLongitude>
+        <southBoundLatitude>0.0</southBoundLatitude>
+        <northBoundLatitude>-1.0</northBoundLatitude>
+      </EX_GeographicBoundingBox>
+      <BoundingBox CRS="CRS:84" minx="0.0" miny="0.0" maxx="-1.0" maxy="-1.0"/>
+      <Layer queryable="1">
+        <Name>layergroup_hake</Name>
+        <Title>layergroup_hake</Title>
+        <Abstract>Layer-Group type layer: layergroup_hake</Abstract>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-180.0</westBoundLongitude>
+          <eastBoundLongitude>180.0</eastBoundLongitude>
+          <southBoundLatitude>45.767459900657855</southBoundLatitude>
+          <northBoundLatitude>90.0</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="EPSG:3067" minx="-1834281.875" miny="5528623.5" maxx="1807281.875" maxy="8964040.0"/>
+        <Layer queryable="1">
+          <Name>hake:layergroup_ruotsi_fastighetskartan</Name>
+          <Title>hake:layergroup_ruotsi_fastighetskartan</Title>
+          <Abstract>Layer-Group type layer: hake:layergroup_ruotsi_fastighetskartan</Abstract>
+          <CRS>EPSG:3067</CRS>
+          <EX_GeographicBoundingBox>
+            <westBoundLongitude>18.084476934257992</westBoundLongitude>
+            <eastBoundLongitude>24.221885380045894</eastBoundLongitude>
+            <southBoundLatitude>65.32213019106449</southBoundLatitude>
+            <northBoundLatitude>69.17396959370204</northBoundLatitude>
+          </EX_GeographicBoundingBox>
+          <BoundingBox CRS="EPSG:3067" minx="144049.484375" miny="7266007.0" maxx="371435.65625" maxy="7677161.0"/>
+        </Layer>
+        <Layer queryable="1">
+          <Name>hake:layergroup_ruotsi_oversiktskartan</Name>
+          <Title>hake:layergroup_ruotsi_oversiktskartan</Title>
+          <Abstract>Layer-Group type layer: hake:layergroup_ruotsi_oversiktskartan</Abstract>
+          <CRS>EPSG:3067</CRS>
+          <EX_GeographicBoundingBox>
+            <westBoundLongitude>18.084476934257992</westBoundLongitude>
+            <eastBoundLongitude>24.221885380045894</eastBoundLongitude>
+            <southBoundLatitude>65.32213019106449</southBoundLatitude>
+            <northBoundLatitude>69.17396959370204</northBoundLatitude>
+          </EX_GeographicBoundingBox>
+          <BoundingBox CRS="EPSG:3067" minx="144049.484375" miny="7266007.0" maxx="371435.65625" maxy="7677161.0"/>
+        </Layer>
+        <Layer queryable="1">
+          <Name>hake:layergroup_ruotsi_sverigekartan</Name>
+          <Title>hake:layergroup_ruotsi_sverigekartan</Title>
+          <Abstract>Layer-Group type layer: hake:layergroup_ruotsi_sverigekartan</Abstract>
+          <CRS>EPSG:3067</CRS>
+          <EX_GeographicBoundingBox>
+            <westBoundLongitude>18.084473321882765</westBoundLongitude>
+            <eastBoundLongitude>24.22190695784743</eastBoundLongitude>
+            <southBoundLatitude>65.32213019106449</southBoundLatitude>
+            <northBoundLatitude>69.17397902137789</northBoundLatitude>
+          </EX_GeographicBoundingBox>
+          <BoundingBox CRS="EPSG:3067" minx="144049.484375" miny="7266007.0" maxx="371436.65625" maxy="7677162.0"/>
+        </Layer>
+        <Layer queryable="1">
+          <Name>hake:layergroup_ruotsi_terrangkartan</Name>
+          <Title>hake:layergroup_ruotsi_terrangkartan</Title>
+          <Abstract>Layer-Group type layer: hake:layergroup_ruotsi_terrangkartan</Abstract>
+          <CRS>EPSG:3067</CRS>
+          <EX_GeographicBoundingBox>
+            <westBoundLongitude>18.89911378163271</westBoundLongitude>
+            <eastBoundLongitude>24.220595862642707</eastBoundLongitude>
+            <southBoundLatitude>65.3332749350297</southBoundLatitude>
+            <northBoundLatitude>66.93963897799684</northBoundLatitude>
+          </EX_GeographicBoundingBox>
+          <BoundingBox CRS="EPSG:3067" minx="144109.15625" miny="7267253.0" maxx="371430.9375" maxy="7427689.5"/>
+        </Layer>
+        <Layer queryable="1">
+          <Name>hake:layergroup_ruotsi_vagkartan</Name>
+          <Title>hake:layergroup_ruotsi_vagkartan</Title>
+          <Abstract>Layer-Group type layer: hake:layergroup_ruotsi_vagkartan</Abstract>
+          <CRS>EPSG:3067</CRS>
+          <EX_GeographicBoundingBox>
+            <westBoundLongitude>18.08586307740464</westBoundLongitude>
+            <eastBoundLongitude>24.219675437290654</eastBoundLongitude>
+            <southBoundLatitude>65.32222995362747</southBoundLatitude>
+            <northBoundLatitude>69.17384949706967</northBoundLatitude>
+          </EX_GeographicBoundingBox>
+          <BoundingBox CRS="EPSG:3067" minx="144104.5" miny="7266011.5" maxx="371333.4375" maxy="7677153.0"/>
+        </Layer>
+        <Layer queryable="1">
+          <Name>hake:layergroup_suomi_10k</Name>
+          <Title>hake:layergroup_suomi_10k</Title>
+          <Abstract>Layer-Group type layer: hake:layergroup_suomi_10k</Abstract>
+          <CRS>EPSG:3067</CRS>
+          <EX_GeographicBoundingBox>
+            <westBoundLongitude>15.494365888391311</westBoundLongitude>
+            <eastBoundLongitude>33.245095850674566</eastBoundLongitude>
+            <southBoundLatitude>59.30647576354951</southBoundLatitude>
+            <northBoundLatitude>70.1479881138766</northBoundLatitude>
+          </EX_GeographicBoundingBox>
+          <BoundingBox CRS="EPSG:3067" minx="58329.4296875" miny="6599985.5" maxx="737576.5" maxy="7782403.5"/>
+        </Layer>
+        <Layer queryable="1">
+          <Name>hake:layergroup_suomi_160k</Name>
+          <Title>hake:layergroup_suomi_160k</Title>
+          <Abstract>Layer-Group type layer: hake:layergroup_suomi_160k</Abstract>
+          <CRS>EPSG:3067</CRS>
+          <EX_GeographicBoundingBox>
+            <westBoundLongitude>15.494049613848684</westBoundLongitude>
+            <eastBoundLongitude>33.211028202487746</eastBoundLongitude>
+            <southBoundLatitude>59.296919882526744</southBoundLatitude>
+            <northBoundLatitude>70.14862533843454</northBoundLatitude>
+          </EX_GeographicBoundingBox>
+          <BoundingBox CRS="EPSG:3067" minx="58329.7734375" miny="6598911.5" maxx="736264.0" maxy="7782470.5"/>
+        </Layer>
+        <Layer queryable="1">
+          <Name>hake:layergroup_suomi_2000k</Name>
+          <Title>hake:layergroup_suomi_2000k</Title>
+          <Abstract>Layer-Group type layer: hake:layergroup_suomi_2000k</Abstract>
+          <CRS>EPSG:3067</CRS>
+          <EX_GeographicBoundingBox>
+            <westBoundLongitude>-180.0</westBoundLongitude>
+            <eastBoundLongitude>180.0</eastBoundLongitude>
+            <southBoundLatitude>45.767459900657855</southBoundLatitude>
+            <northBoundLatitude>90.0</northBoundLatitude>
+          </EX_GeographicBoundingBox>
+          <BoundingBox CRS="EPSG:3067" minx="-1834281.875" miny="5528623.5" maxx="1807281.875" maxy="8964040.0"/>
+        </Layer>
+        <Layer queryable="1">
+          <Name>hake:layergroup_suomi_20k</Name>
+          <Title>hake:layergroup_suomi_20k</Title>
+          <Abstract>Layer-Group type layer: hake:layergroup_suomi_20k</Abstract>
+          <CRS>EPSG:3067</CRS>
+          <EX_GeographicBoundingBox>
+            <westBoundLongitude>15.494365888391311</westBoundLongitude>
+            <eastBoundLongitude>33.210849363360865</eastBoundLongitude>
+            <southBoundLatitude>59.30647576354951</southBoundLatitude>
+            <northBoundLatitude>70.14802455671852</northBoundLatitude>
+          </EX_GeographicBoundingBox>
+          <BoundingBox CRS="EPSG:3067" minx="58329.4296875" miny="6599985.5" maxx="736264.0" maxy="7782403.5"/>
+        </Layer>
+        <Layer queryable="1">
+          <Name>hake:layergroup_suomi_320k</Name>
+          <Title>hake:layergroup_suomi_320k</Title>
+          <Abstract>Layer-Group type layer: hake:layergroup_suomi_320k</Abstract>
+          <CRS>EPSG:3067</CRS>
+          <EX_GeographicBoundingBox>
+            <westBoundLongitude>15.446752539139055</westBoundLongitude>
+            <eastBoundLongitude>33.21058245963129</eastBoundLongitude>
+            <southBoundLatitude>59.285881577237774</southBoundLatitude>
+            <northBoundLatitude>70.14715231123607</northBoundLatitude>
+          </EX_GeographicBoundingBox>
+          <BoundingBox CRS="EPSG:3067" minx="56435.09765625" miny="6597893.5" maxx="736264.0" maxy="7782303.5"/>
+        </Layer>
+        <Layer queryable="1">
+          <Name>hake:layergroup_suomi_4000k</Name>
+          <Title>hake:layergroup_suomi_4000k</Title>
+          <Abstract>Layer-Group type layer: hake:layergroup_suomi_4000k</Abstract>
+          <CRS>EPSG:3067</CRS>
+          <EX_GeographicBoundingBox>
+            <westBoundLongitude>-180.0</westBoundLongitude>
+            <eastBoundLongitude>180.0</eastBoundLongitude>
+            <southBoundLatitude>45.767459900657855</southBoundLatitude>
+            <northBoundLatitude>90.0</northBoundLatitude>
+          </EX_GeographicBoundingBox>
+          <BoundingBox CRS="EPSG:3067" minx="-1834281.875" miny="5528623.5" maxx="1807281.875" maxy="8964040.0"/>
+        </Layer>
+        <Layer queryable="1">
+          <Name>hake:layergroup_suomi_40k</Name>
+          <Title>hake:layergroup_suomi_40k</Title>
+          <Abstract>Layer-Group type layer: hake:layergroup_suomi_40k</Abstract>
+          <CRS>EPSG:3067</CRS>
+          <EX_GeographicBoundingBox>
+            <westBoundLongitude>15.494061741223906</westBoundLongitude>
+            <eastBoundLongitude>33.21102152918958</eastBoundLongitude>
+            <southBoundLatitude>59.30175584614387</southBoundLatitude>
+            <northBoundLatitude>70.14860292103626</northBoundLatitude>
+          </EX_GeographicBoundingBox>
+          <BoundingBox CRS="EPSG:3067" minx="58329.7734375" miny="6599455.0" maxx="736264.0" maxy="7782468.0"/>
+        </Layer>
+        <Layer queryable="1">
+          <Name>hake:layergroup_suomi_5k</Name>
+          <Title>hake:layergroup_suomi_5k</Title>
+          <Abstract>Layer-Group type layer: hake:layergroup_suomi_5k</Abstract>
+          <CRS>EPSG:3067</CRS>
+          <EX_GeographicBoundingBox>
+            <westBoundLongitude>15.494365888391311</westBoundLongitude>
+            <eastBoundLongitude>33.245095850674566</eastBoundLongitude>
+            <southBoundLatitude>59.30647576354951</southBoundLatitude>
+            <northBoundLatitude>70.1479881138766</northBoundLatitude>
+          </EX_GeographicBoundingBox>
+          <BoundingBox CRS="EPSG:3067" minx="58329.4296875" miny="6599985.5" maxx="737576.5" maxy="7782403.5"/>
+        </Layer>
+        <Layer queryable="1">
+          <Name>hake:layergroup_suomi_8000k</Name>
+          <Title>hake:layergroup_suomi_8000k</Title>
+          <Abstract>Layer-Group type layer: hake:layergroup_suomi_8000k</Abstract>
+          <CRS>EPSG:3067</CRS>
+          <EX_GeographicBoundingBox>
+            <westBoundLongitude>-180.0</westBoundLongitude>
+            <eastBoundLongitude>180.0</eastBoundLongitude>
+            <southBoundLatitude>45.767459900657855</southBoundLatitude>
+            <northBoundLatitude>90.0</northBoundLatitude>
+          </EX_GeographicBoundingBox>
+          <BoundingBox CRS="EPSG:3067" minx="-1834281.875" miny="5528623.5" maxx="1807281.875" maxy="8964040.0"/>
+        </Layer>
+        <Layer queryable="1">
+          <Name>hake:layergroup_suomi_800k</Name>
+          <Title>hake:layergroup_suomi_800k</Title>
+          <Abstract>Layer-Group type layer: hake:layergroup_suomi_800k</Abstract>
+          <CRS>EPSG:3067</CRS>
+          <EX_GeographicBoundingBox>
+            <westBoundLongitude>-180.0</westBoundLongitude>
+            <eastBoundLongitude>180.0</eastBoundLongitude>
+            <southBoundLatitude>45.767459900657855</southBoundLatitude>
+            <northBoundLatitude>90.0</northBoundLatitude>
+          </EX_GeographicBoundingBox>
+          <BoundingBox CRS="EPSG:3067" minx="-1834281.875" miny="5528623.5" maxx="1807281.875" maxy="8964040.0"/>
+        </Layer>
+        <Layer queryable="1">
+          <Name>hake:layergroup_suomi_80k</Name>
+          <Title>hake:layergroup_suomi_80k</Title>
+          <Abstract>Layer-Group type layer: hake:layergroup_suomi_80k</Abstract>
+          <CRS>EPSG:3067</CRS>
+          <EX_GeographicBoundingBox>
+            <westBoundLongitude>15.494049613848684</westBoundLongitude>
+            <eastBoundLongitude>33.211028202487746</eastBoundLongitude>
+            <southBoundLatitude>59.296919882526744</southBoundLatitude>
+            <northBoundLatitude>70.14862533843454</northBoundLatitude>
+          </EX_GeographicBoundingBox>
+          <BoundingBox CRS="EPSG:3067" minx="58329.7734375" miny="6598911.5" maxx="736264.0" maxy="7782470.5"/>
+        </Layer>
+        <Layer queryable="1">
+          <Name>hake:layergroup_venaja</Name>
+          <Title>hake:layergroup_venaja</Title>
+          <Abstract>Layer-Group type layer: hake:layergroup_venaja</Abstract>
+          <CRS>EPSG:3067</CRS>
+          <EX_GeographicBoundingBox>
+            <westBoundLongitude>26.96289494354828</westBoundLongitude>
+            <eastBoundLongitude>34.418871535544575</eastBoundLongitude>
+            <southBoundLatitude>59.654249896867526</southBoundLatitude>
+            <northBoundLatitude>70.0267523825119</northBoundLatitude>
+          </EX_GeographicBoundingBox>
+          <BoundingBox CRS="EPSG:3067" minx="498585.46875" miny="6623726.53597135" maxx="784322.3125" maxy="7768856.92658639"/>
+        </Layer>
+      </Layer>
+      <Layer queryable="1">
+        <Name>layergroup_ruotsi_fastighetskartan</Name>
+        <Title>layergroup_ruotsi_fastighetskartan</Title>
+        <Abstract>Layer-Group type layer: layergroup_ruotsi_fastighetskartan</Abstract>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>18.084476934257992</westBoundLongitude>
+          <eastBoundLongitude>24.221885380045894</eastBoundLongitude>
+          <southBoundLatitude>65.32213019106449</southBoundLatitude>
+          <northBoundLatitude>69.17396959370204</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="EPSG:3067" minx="144049.484375" miny="7266007.0" maxx="371435.65625" maxy="7677161.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>layergroup_ruotsi_oversiktskartan</Name>
+        <Title>layergroup_ruotsi_oversiktskartan</Title>
+        <Abstract>Layer-Group type layer: layergroup_ruotsi_oversiktskartan</Abstract>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>18.084476934257992</westBoundLongitude>
+          <eastBoundLongitude>24.221885380045894</eastBoundLongitude>
+          <southBoundLatitude>65.32213019106449</southBoundLatitude>
+          <northBoundLatitude>69.17396959370204</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="EPSG:3067" minx="144049.484375" miny="7266007.0" maxx="371435.65625" maxy="7677161.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>layergroup_ruotsi_sverigekartan</Name>
+        <Title>layergroup_ruotsi_sverigekartan</Title>
+        <Abstract>Layer-Group type layer: layergroup_ruotsi_sverigekartan</Abstract>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>18.084473321882765</westBoundLongitude>
+          <eastBoundLongitude>24.22190695784743</eastBoundLongitude>
+          <southBoundLatitude>65.32213019106449</southBoundLatitude>
+          <northBoundLatitude>69.17397902137789</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="EPSG:3067" minx="144049.484375" miny="7266007.0" maxx="371436.65625" maxy="7677162.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>layergroup_ruotsi_terrangkartan</Name>
+        <Title>layergroup_ruotsi_terrangkartan</Title>
+        <Abstract>Layer-Group type layer: layergroup_ruotsi_terrangkartan</Abstract>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>18.89911378163271</westBoundLongitude>
+          <eastBoundLongitude>24.220595862642707</eastBoundLongitude>
+          <southBoundLatitude>65.3332749350297</southBoundLatitude>
+          <northBoundLatitude>66.93963897799684</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="EPSG:3067" minx="144109.15625" miny="7267253.0" maxx="371430.9375" maxy="7427689.5"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>layergroup_ruotsi_vagkartan</Name>
+        <Title>layergroup_ruotsi_vagkartan</Title>
+        <Abstract>Layer-Group type layer: layergroup_ruotsi_vagkartan</Abstract>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>18.08586307740464</westBoundLongitude>
+          <eastBoundLongitude>24.219675437290654</eastBoundLongitude>
+          <southBoundLatitude>65.32222995362747</southBoundLatitude>
+          <northBoundLatitude>69.17384949706967</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="EPSG:3067" minx="144104.5" miny="7266011.5" maxx="371333.4375" maxy="7677153.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>layergroup_suomi</Name>
+        <Title>layergroup_suomi</Title>
+        <Abstract>Layer-Group type layer: layergroup_suomi</Abstract>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-180.0</westBoundLongitude>
+          <eastBoundLongitude>180.0</eastBoundLongitude>
+          <southBoundLatitude>45.767459900657855</southBoundLatitude>
+          <northBoundLatitude>90.0</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="EPSG:3067" minx="-1834281.875" miny="5528623.5" maxx="1807281.875" maxy="8964040.0"/>
+        <Layer queryable="1">
+          <Name>hake:layergroup_ruotsi_fastighetskartan</Name>
+          <Title>hake:layergroup_ruotsi_fastighetskartan</Title>
+          <Abstract>Layer-Group type layer: hake:layergroup_ruotsi_fastighetskartan</Abstract>
+          <CRS>EPSG:3067</CRS>
+          <EX_GeographicBoundingBox>
+            <westBoundLongitude>18.084476934257992</westBoundLongitude>
+            <eastBoundLongitude>24.221885380045894</eastBoundLongitude>
+            <southBoundLatitude>65.32213019106449</southBoundLatitude>
+            <northBoundLatitude>69.17396959370204</northBoundLatitude>
+          </EX_GeographicBoundingBox>
+          <BoundingBox CRS="EPSG:3067" minx="144049.484375" miny="7266007.0" maxx="371435.65625" maxy="7677161.0"/>
+        </Layer>
+        <Layer queryable="1">
+          <Name>hake:layergroup_ruotsi_oversiktskartan</Name>
+          <Title>hake:layergroup_ruotsi_oversiktskartan</Title>
+          <Abstract>Layer-Group type layer: hake:layergroup_ruotsi_oversiktskartan</Abstract>
+          <CRS>EPSG:3067</CRS>
+          <EX_GeographicBoundingBox>
+            <westBoundLongitude>18.084476934257992</westBoundLongitude>
+            <eastBoundLongitude>24.221885380045894</eastBoundLongitude>
+            <southBoundLatitude>65.32213019106449</southBoundLatitude>
+            <northBoundLatitude>69.17396959370204</northBoundLatitude>
+          </EX_GeographicBoundingBox>
+          <BoundingBox CRS="EPSG:3067" minx="144049.484375" miny="7266007.0" maxx="371435.65625" maxy="7677161.0"/>
+        </Layer>
+        <Layer queryable="1">
+          <Name>hake:layergroup_ruotsi_sverigekartan</Name>
+          <Title>hake:layergroup_ruotsi_sverigekartan</Title>
+          <Abstract>Layer-Group type layer: hake:layergroup_ruotsi_sverigekartan</Abstract>
+          <CRS>EPSG:3067</CRS>
+          <EX_GeographicBoundingBox>
+            <westBoundLongitude>18.084473321882765</westBoundLongitude>
+            <eastBoundLongitude>24.22190695784743</eastBoundLongitude>
+            <southBoundLatitude>65.32213019106449</southBoundLatitude>
+            <northBoundLatitude>69.17397902137789</northBoundLatitude>
+          </EX_GeographicBoundingBox>
+          <BoundingBox CRS="EPSG:3067" minx="144049.484375" miny="7266007.0" maxx="371436.65625" maxy="7677162.0"/>
+        </Layer>
+        <Layer queryable="1">
+          <Name>hake:layergroup_ruotsi_terrangkartan</Name>
+          <Title>hake:layergroup_ruotsi_terrangkartan</Title>
+          <Abstract>Layer-Group type layer: hake:layergroup_ruotsi_terrangkartan</Abstract>
+          <CRS>EPSG:3067</CRS>
+          <EX_GeographicBoundingBox>
+            <westBoundLongitude>18.89911378163271</westBoundLongitude>
+            <eastBoundLongitude>24.220595862642707</eastBoundLongitude>
+            <southBoundLatitude>65.3332749350297</southBoundLatitude>
+            <northBoundLatitude>66.93963897799684</northBoundLatitude>
+          </EX_GeographicBoundingBox>
+          <BoundingBox CRS="EPSG:3067" minx="144109.15625" miny="7267253.0" maxx="371430.9375" maxy="7427689.5"/>
+        </Layer>
+        <Layer queryable="1">
+          <Name>hake:layergroup_ruotsi_vagkartan</Name>
+          <Title>hake:layergroup_ruotsi_vagkartan</Title>
+          <Abstract>Layer-Group type layer: hake:layergroup_ruotsi_vagkartan</Abstract>
+          <CRS>EPSG:3067</CRS>
+          <EX_GeographicBoundingBox>
+            <westBoundLongitude>18.08586307740464</westBoundLongitude>
+            <eastBoundLongitude>24.219675437290654</eastBoundLongitude>
+            <southBoundLatitude>65.32222995362747</southBoundLatitude>
+            <northBoundLatitude>69.17384949706967</northBoundLatitude>
+          </EX_GeographicBoundingBox>
+          <BoundingBox CRS="EPSG:3067" minx="144104.5" miny="7266011.5" maxx="371333.4375" maxy="7677153.0"/>
+        </Layer>
+        <Layer queryable="1">
+          <Name>hake:layergroup_suomi_10k</Name>
+          <Title>hake:layergroup_suomi_10k</Title>
+          <Abstract>Layer-Group type layer: hake:layergroup_suomi_10k</Abstract>
+          <CRS>EPSG:3067</CRS>
+          <EX_GeographicBoundingBox>
+            <westBoundLongitude>15.494365888391311</westBoundLongitude>
+            <eastBoundLongitude>33.245095850674566</eastBoundLongitude>
+            <southBoundLatitude>59.30647576354951</southBoundLatitude>
+            <northBoundLatitude>70.1479881138766</northBoundLatitude>
+          </EX_GeographicBoundingBox>
+          <BoundingBox CRS="EPSG:3067" minx="58329.4296875" miny="6599985.5" maxx="737576.5" maxy="7782403.5"/>
+        </Layer>
+        <Layer queryable="1">
+          <Name>hake:layergroup_suomi_160k</Name>
+          <Title>hake:layergroup_suomi_160k</Title>
+          <Abstract>Layer-Group type layer: hake:layergroup_suomi_160k</Abstract>
+          <CRS>EPSG:3067</CRS>
+          <EX_GeographicBoundingBox>
+            <westBoundLongitude>15.494049613848684</westBoundLongitude>
+            <eastBoundLongitude>33.211028202487746</eastBoundLongitude>
+            <southBoundLatitude>59.296919882526744</southBoundLatitude>
+            <northBoundLatitude>70.14862533843454</northBoundLatitude>
+          </EX_GeographicBoundingBox>
+          <BoundingBox CRS="EPSG:3067" minx="58329.7734375" miny="6598911.5" maxx="736264.0" maxy="7782470.5"/>
+        </Layer>
+        <Layer queryable="1">
+          <Name>hake:layergroup_suomi_2000k</Name>
+          <Title>hake:layergroup_suomi_2000k</Title>
+          <Abstract>Layer-Group type layer: hake:layergroup_suomi_2000k</Abstract>
+          <CRS>EPSG:3067</CRS>
+          <EX_GeographicBoundingBox>
+            <westBoundLongitude>-180.0</westBoundLongitude>
+            <eastBoundLongitude>180.0</eastBoundLongitude>
+            <southBoundLatitude>45.767459900657855</southBoundLatitude>
+            <northBoundLatitude>90.0</northBoundLatitude>
+          </EX_GeographicBoundingBox>
+          <BoundingBox CRS="EPSG:3067" minx="-1834281.875" miny="5528623.5" maxx="1807281.875" maxy="8964040.0"/>
+        </Layer>
+        <Layer queryable="1">
+          <Name>hake:layergroup_suomi_20k</Name>
+          <Title>hake:layergroup_suomi_20k</Title>
+          <Abstract>Layer-Group type layer: hake:layergroup_suomi_20k</Abstract>
+          <CRS>EPSG:3067</CRS>
+          <EX_GeographicBoundingBox>
+            <westBoundLongitude>15.494365888391311</westBoundLongitude>
+            <eastBoundLongitude>33.210849363360865</eastBoundLongitude>
+            <southBoundLatitude>59.30647576354951</southBoundLatitude>
+            <northBoundLatitude>70.14802455671852</northBoundLatitude>
+          </EX_GeographicBoundingBox>
+          <BoundingBox CRS="EPSG:3067" minx="58329.4296875" miny="6599985.5" maxx="736264.0" maxy="7782403.5"/>
+        </Layer>
+        <Layer queryable="1">
+          <Name>hake:layergroup_suomi_320k</Name>
+          <Title>hake:layergroup_suomi_320k</Title>
+          <Abstract>Layer-Group type layer: hake:layergroup_suomi_320k</Abstract>
+          <CRS>EPSG:3067</CRS>
+          <EX_GeographicBoundingBox>
+            <westBoundLongitude>15.446752539139055</westBoundLongitude>
+            <eastBoundLongitude>33.21058245963129</eastBoundLongitude>
+            <southBoundLatitude>59.285881577237774</southBoundLatitude>
+            <northBoundLatitude>70.14715231123607</northBoundLatitude>
+          </EX_GeographicBoundingBox>
+          <BoundingBox CRS="EPSG:3067" minx="56435.09765625" miny="6597893.5" maxx="736264.0" maxy="7782303.5"/>
+        </Layer>
+        <Layer queryable="1">
+          <Name>hake:layergroup_suomi_4000k</Name>
+          <Title>hake:layergroup_suomi_4000k</Title>
+          <Abstract>Layer-Group type layer: hake:layergroup_suomi_4000k</Abstract>
+          <CRS>EPSG:3067</CRS>
+          <EX_GeographicBoundingBox>
+            <westBoundLongitude>-180.0</westBoundLongitude>
+            <eastBoundLongitude>180.0</eastBoundLongitude>
+            <southBoundLatitude>45.767459900657855</southBoundLatitude>
+            <northBoundLatitude>90.0</northBoundLatitude>
+          </EX_GeographicBoundingBox>
+          <BoundingBox CRS="EPSG:3067" minx="-1834281.875" miny="5528623.5" maxx="1807281.875" maxy="8964040.0"/>
+        </Layer>
+        <Layer queryable="1">
+          <Name>hake:layergroup_suomi_40k</Name>
+          <Title>hake:layergroup_suomi_40k</Title>
+          <Abstract>Layer-Group type layer: hake:layergroup_suomi_40k</Abstract>
+          <CRS>EPSG:3067</CRS>
+          <EX_GeographicBoundingBox>
+            <westBoundLongitude>15.494061741223906</westBoundLongitude>
+            <eastBoundLongitude>33.21102152918958</eastBoundLongitude>
+            <southBoundLatitude>59.30175584614387</southBoundLatitude>
+            <northBoundLatitude>70.14860292103626</northBoundLatitude>
+          </EX_GeographicBoundingBox>
+          <BoundingBox CRS="EPSG:3067" minx="58329.7734375" miny="6599455.0" maxx="736264.0" maxy="7782468.0"/>
+        </Layer>
+        <Layer queryable="1">
+          <Name>hake:layergroup_suomi_5k</Name>
+          <Title>hake:layergroup_suomi_5k</Title>
+          <Abstract>Layer-Group type layer: hake:layergroup_suomi_5k</Abstract>
+          <CRS>EPSG:3067</CRS>
+          <EX_GeographicBoundingBox>
+            <westBoundLongitude>15.494365888391311</westBoundLongitude>
+            <eastBoundLongitude>33.245095850674566</eastBoundLongitude>
+            <southBoundLatitude>59.30647576354951</southBoundLatitude>
+            <northBoundLatitude>70.1479881138766</northBoundLatitude>
+          </EX_GeographicBoundingBox>
+          <BoundingBox CRS="EPSG:3067" minx="58329.4296875" miny="6599985.5" maxx="737576.5" maxy="7782403.5"/>
+        </Layer>
+        <Layer queryable="1">
+          <Name>hake:layergroup_suomi_8000k</Name>
+          <Title>hake:layergroup_suomi_8000k</Title>
+          <Abstract>Layer-Group type layer: hake:layergroup_suomi_8000k</Abstract>
+          <CRS>EPSG:3067</CRS>
+          <EX_GeographicBoundingBox>
+            <westBoundLongitude>-180.0</westBoundLongitude>
+            <eastBoundLongitude>180.0</eastBoundLongitude>
+            <southBoundLatitude>45.767459900657855</southBoundLatitude>
+            <northBoundLatitude>90.0</northBoundLatitude>
+          </EX_GeographicBoundingBox>
+          <BoundingBox CRS="EPSG:3067" minx="-1834281.875" miny="5528623.5" maxx="1807281.875" maxy="8964040.0"/>
+        </Layer>
+        <Layer queryable="1">
+          <Name>hake:layergroup_suomi_800k</Name>
+          <Title>hake:layergroup_suomi_800k</Title>
+          <Abstract>Layer-Group type layer: hake:layergroup_suomi_800k</Abstract>
+          <CRS>EPSG:3067</CRS>
+          <EX_GeographicBoundingBox>
+            <westBoundLongitude>-180.0</westBoundLongitude>
+            <eastBoundLongitude>180.0</eastBoundLongitude>
+            <southBoundLatitude>45.767459900657855</southBoundLatitude>
+            <northBoundLatitude>90.0</northBoundLatitude>
+          </EX_GeographicBoundingBox>
+          <BoundingBox CRS="EPSG:3067" minx="-1834281.875" miny="5528623.5" maxx="1807281.875" maxy="8964040.0"/>
+        </Layer>
+        <Layer queryable="1">
+          <Name>hake:layergroup_suomi_80k</Name>
+          <Title>hake:layergroup_suomi_80k</Title>
+          <Abstract>Layer-Group type layer: hake:layergroup_suomi_80k</Abstract>
+          <CRS>EPSG:3067</CRS>
+          <EX_GeographicBoundingBox>
+            <westBoundLongitude>15.494049613848684</westBoundLongitude>
+            <eastBoundLongitude>33.211028202487746</eastBoundLongitude>
+            <southBoundLatitude>59.296919882526744</southBoundLatitude>
+            <northBoundLatitude>70.14862533843454</northBoundLatitude>
+          </EX_GeographicBoundingBox>
+          <BoundingBox CRS="EPSG:3067" minx="58329.7734375" miny="6598911.5" maxx="736264.0" maxy="7782470.5"/>
+        </Layer>
+        <Layer queryable="1">
+          <Name>hake:layergroup_venaja</Name>
+          <Title>hake:layergroup_venaja</Title>
+          <Abstract>Layer-Group type layer: hake:layergroup_venaja</Abstract>
+          <CRS>EPSG:3067</CRS>
+          <EX_GeographicBoundingBox>
+            <westBoundLongitude>26.96289494354828</westBoundLongitude>
+            <eastBoundLongitude>34.418871535544575</eastBoundLongitude>
+            <southBoundLatitude>59.654249896867526</southBoundLatitude>
+            <northBoundLatitude>70.0267523825119</northBoundLatitude>
+          </EX_GeographicBoundingBox>
+          <BoundingBox CRS="EPSG:3067" minx="498585.46875" miny="6623726.53597135" maxx="784322.3125" maxy="7768856.92658639"/>
+        </Layer>
+      </Layer>
+      <Layer queryable="1">
+        <Name>layergroup_suomi_10k</Name>
+        <Title>layergroup_suomi_10k</Title>
+        <Abstract>Layer-Group type layer: layergroup_suomi_10k</Abstract>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>15.494365888391311</westBoundLongitude>
+          <eastBoundLongitude>33.245095850674566</eastBoundLongitude>
+          <southBoundLatitude>59.30647576354951</southBoundLatitude>
+          <northBoundLatitude>70.1479881138766</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="EPSG:3067" minx="58329.4296875" miny="6599985.5" maxx="737576.5" maxy="7782403.5"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>layergroup_suomi_160k</Name>
+        <Title>layergroup_suomi_160k</Title>
+        <Abstract>Layer-Group type layer: layergroup_suomi_160k</Abstract>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>15.494049613848684</westBoundLongitude>
+          <eastBoundLongitude>33.211028202487746</eastBoundLongitude>
+          <southBoundLatitude>59.296919882526744</southBoundLatitude>
+          <northBoundLatitude>70.14862533843454</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="EPSG:3067" minx="58329.7734375" miny="6598911.5" maxx="736264.0" maxy="7782470.5"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>layergroup_suomi_2000k</Name>
+        <Title>layergroup_suomi_2000k</Title>
+        <Abstract>Layer-Group type layer: layergroup_suomi_2000k</Abstract>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-180.0</westBoundLongitude>
+          <eastBoundLongitude>180.0</eastBoundLongitude>
+          <southBoundLatitude>45.767459900657855</southBoundLatitude>
+          <northBoundLatitude>90.0</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="EPSG:3067" minx="-1834281.875" miny="5528623.5" maxx="1807281.875" maxy="8964040.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>layergroup_suomi_20k</Name>
+        <Title>layergroup_suomi_20k</Title>
+        <Abstract>Layer-Group type layer: layergroup_suomi_20k</Abstract>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>15.494365888391311</westBoundLongitude>
+          <eastBoundLongitude>33.210849363360865</eastBoundLongitude>
+          <southBoundLatitude>59.30647576354951</southBoundLatitude>
+          <northBoundLatitude>70.14802455671852</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="EPSG:3067" minx="58329.4296875" miny="6599985.5" maxx="736264.0" maxy="7782403.5"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>layergroup_suomi_320k</Name>
+        <Title>layergroup_suomi_320k</Title>
+        <Abstract>Layer-Group type layer: layergroup_suomi_320k</Abstract>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>15.446752539139055</westBoundLongitude>
+          <eastBoundLongitude>33.21058245963129</eastBoundLongitude>
+          <southBoundLatitude>59.285881577237774</southBoundLatitude>
+          <northBoundLatitude>70.14715231123607</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="EPSG:3067" minx="56435.09765625" miny="6597893.5" maxx="736264.0" maxy="7782303.5"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>layergroup_suomi_4000k</Name>
+        <Title>layergroup_suomi_4000k</Title>
+        <Abstract>Layer-Group type layer: layergroup_suomi_4000k</Abstract>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-180.0</westBoundLongitude>
+          <eastBoundLongitude>180.0</eastBoundLongitude>
+          <southBoundLatitude>45.767459900657855</southBoundLatitude>
+          <northBoundLatitude>90.0</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="EPSG:3067" minx="-1834281.875" miny="5528623.5" maxx="1807281.875" maxy="8964040.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>layergroup_suomi_40k</Name>
+        <Title>layergroup_suomi_40k</Title>
+        <Abstract>Layer-Group type layer: layergroup_suomi_40k</Abstract>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>15.494061741223906</westBoundLongitude>
+          <eastBoundLongitude>33.21102152918958</eastBoundLongitude>
+          <southBoundLatitude>59.30175584614387</southBoundLatitude>
+          <northBoundLatitude>70.14860292103626</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="EPSG:3067" minx="58329.7734375" miny="6599455.0" maxx="736264.0" maxy="7782468.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>layergroup_suomi_5k</Name>
+        <Title>layergroup_suomi_5k</Title>
+        <Abstract>Layer-Group type layer: layergroup_suomi_5k</Abstract>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>15.494365888391311</westBoundLongitude>
+          <eastBoundLongitude>33.245095850674566</eastBoundLongitude>
+          <southBoundLatitude>59.30647576354951</southBoundLatitude>
+          <northBoundLatitude>70.1479881138766</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="EPSG:3067" minx="58329.4296875" miny="6599985.5" maxx="737576.5" maxy="7782403.5"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>layergroup_suomi_8000k</Name>
+        <Title>layergroup_suomi_8000k</Title>
+        <Abstract>Layer-Group type layer: layergroup_suomi_8000k</Abstract>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-180.0</westBoundLongitude>
+          <eastBoundLongitude>180.0</eastBoundLongitude>
+          <southBoundLatitude>45.767459900657855</southBoundLatitude>
+          <northBoundLatitude>90.0</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="EPSG:3067" minx="-1834281.875" miny="5528623.5" maxx="1807281.875" maxy="8964040.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>layergroup_suomi_800k</Name>
+        <Title>layergroup_suomi_800k</Title>
+        <Abstract>Layer-Group type layer: layergroup_suomi_800k</Abstract>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-180.0</westBoundLongitude>
+          <eastBoundLongitude>180.0</eastBoundLongitude>
+          <southBoundLatitude>45.767459900657855</southBoundLatitude>
+          <northBoundLatitude>90.0</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="EPSG:3067" minx="-1834281.875" miny="5528623.5" maxx="1807281.875" maxy="8964040.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>layergroup_suomi_80k</Name>
+        <Title>layergroup_suomi_80k</Title>
+        <Abstract>Layer-Group type layer: layergroup_suomi_80k</Abstract>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>15.494049613848684</westBoundLongitude>
+          <eastBoundLongitude>33.211028202487746</eastBoundLongitude>
+          <southBoundLatitude>59.296919882526744</southBoundLatitude>
+          <northBoundLatitude>70.14862533843454</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="EPSG:3067" minx="58329.7734375" miny="6598911.5" maxx="736264.0" maxy="7782470.5"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>layergroup_venaja</Name>
+        <Title>layergroup_venaja</Title>
+        <Abstract>Layer-Group type layer: layergroup_venaja</Abstract>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>26.96289494354828</westBoundLongitude>
+          <eastBoundLongitude>34.418871535544575</eastBoundLongitude>
+          <southBoundLatitude>59.654249896867526</southBoundLatitude>
+          <northBoundLatitude>70.0267523825119</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="EPSG:3067" minx="498585.46875" miny="6623726.53597135" maxx="784322.3125" maxy="7768856.92658639"/>
+      </Layer>
+    </Layer>
+  </Capability>
+</WMS_Capabilities>

--- a/service-userlayer/src/main/java/org/oskari/map/userlayer/service/UserLayerDataService.java
+++ b/service-userlayer/src/main/java/org/oskari/map/userlayer/service/UserLayerDataService.java
@@ -158,8 +158,8 @@ public class UserLayerDataService {
      * @param ulayer
      * @return
      */
-    public static JSONObject parseUserLayer2JSON(UserLayer ulayer) {
-        return parseUserLayer2JSON(ulayer, getBaseLayer());
+    public static JSONObject parseUserLayer2JSON(UserLayer ulayer, String mapSrs) {
+        return parseUserLayer2JSON(ulayer, getBaseLayer(), mapSrs);
     }
     /**
      * @param ulayer data in user_layer table
@@ -167,7 +167,7 @@ public class UserLayerDataService {
      * @return
      * @throws ServiceException
      */
-    public static JSONObject parseUserLayer2JSON(final UserLayer ulayer, final OskariLayer baseLayer) {
+    public static JSONObject parseUserLayer2JSON(final UserLayer ulayer, final OskariLayer baseLayer, final String mapSrs) {
 
         try {
             final String name = baseLayer.getName();
@@ -177,7 +177,7 @@ public class UserLayerDataService {
             baseLayer.setName(ulayer.getLayer_name());
             baseLayer.setType(OskariLayer.TYPE_USERLAYER);
             // create the JSON
-            final JSONObject json = FORMATTER.getJSON(baseLayer, PropertyUtil.getDefaultLanguage(), false, null, ulayer);
+            final JSONObject json = FORMATTER.getJSON(baseLayer, PropertyUtil.getDefaultLanguage(), false, mapSrs, ulayer);
             JSONHelper.putValue(json, "id", USERLAYER_LAYER_PREFIX + ulayer.getId());
 
             // restore the previous values for baseLayer


### PR DESCRIPTION
Parse layer's coverage/bbox from actual layer (WMS 1.3.0 + capabilities). Use WKTHelper to create wkt.

Move wkt/geom transform to layerjsonformatter. Remove wkt/geom handling from userlayer. Userlayer formatter adds wkt to layer before getbasejson parsing so no need for own wkt handling.

Add possibility to ignore adding coverage to layerjson.
layer attributes: {"ignoreCoverage": true}