### PR TITLE
Update JTS to match GeoTools dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <xmlbeans.version>2.6.0</xmlbeans.version>
         <geotools.version>19.2</geotools.version>
         <geotools.major>19</geotools.major>
-        <jts.version>1.13</jts.version>
+        <jts.version>1.14</jts.version>
         <mvt.version>2.0.0</mvt.version>
         <!-- gt-xsd-kml.version>9.3</gt-xsd-kml.version -->
         <flexjson.version>2.0</flexjson.version>


### PR DESCRIPTION
Fixes an error reported by Jetty 9 (oskari-server/service-base used 1.13 and GeoTools 19.2 uses 1.14): 

com.vividsolutions.jts.geom.MultiPoint scanned from multiple locations: jar:file:///var/web/work/oskari-server/jetty-0.0.0.0-8080-oskari-map.war-_-any-8472495850454460616.dir/webapp/WEB-INF/lib/jts-core-1.14.0.jar!/com/vividsolutions/jts/geom/MultiPoint.class, jar:file:///var/web/work/oskari-server/jetty-0.0.0.0-8080-oskari-map.war-_-any-8472495850454460616.dir/webapp/WEB-INF/lib/jts-1.13.jar!/com/vividsolutions/jts/geom/MultiPoint.class