### PR TITLE
Use latest JDK releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,12 @@ jdk:
   - oraclejdk8
   - openjdk8
 
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
+      - openjdk-8-jdk
+
 notifications:
   slack: oskari:N5vZf0lzsIGpQ8nAPRfHgQ91
   webhooks:


### PR DESCRIPTION
Use the latest JDK release versions instead of the pre-installed ones.
Based on this: https://docs.travis-ci.com/user/languages/java/#updating-oracle-jdk-8-to-a-recent-release