### PR TITLE
Set UTF-8 charset when reading features from wfs

### DIFF
--- a/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
@@ -33,6 +33,7 @@ public class IOHelper {
     public static final String HEADER_USERAGENT = "User-Agent";
     public static final String HEADER_REFERER = "Referer";
     public static final String HEADER_ACCEPT = "Accept";
+    public static final String HEADER_ACCEPT_CHARSET = "Accept-Charset";
 
     public static final String CHARSET_UTF8 = "UTF-8";
     public static final String DEFAULT_CHARSET = CHARSET_UTF8;
@@ -238,6 +239,7 @@ public class IOHelper {
         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
         conn.setConnectTimeout(CONNECTION_TIMEOUT_MS);
         conn.setReadTimeout(READ_TIMEOUT_MS);
+        conn.setRequestProperty(HEADER_ACCEPT_CHARSET, CHARSET_UTF8);
         if(trustAllCerts) trustAllCerts(conn);
         if(trustAllHosts) trustAllHosts(conn);
         return conn;

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS110Client.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS110Client.java
@@ -1,6 +1,11 @@
 package org.oskari.service.wfs.client;
 
-import java.io.*;
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.io.InputStreamReader;
+
 import java.net.HttpURLConnection;
 import java.util.LinkedHashMap;
 import java.util.Map;

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS110Client.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS110Client.java
@@ -1,8 +1,6 @@
 package org.oskari.service.wfs.client;
 
-import java.io.BufferedInputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.net.HttpURLConnection;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -64,7 +62,9 @@ public class OskariWFS110Client {
         }
 
         try (InputStream in = conn.getInputStream();
-                FeatureIterator<SimpleFeature> it = FJ.streamFeatureCollection(in)) {
+             Reader utf8Reader = new InputStreamReader(in, IOHelper.CHARSET_UTF8);
+             FeatureIterator<SimpleFeature> it = FJ.streamFeatureCollection(utf8Reader)) {
+
             DefaultFeatureCollection features = new DefaultFeatureCollection(null, null);
             while (it.hasNext()) {
                 features.add(it.next());


### PR DESCRIPTION
Fixes an issue where wfs features had broken property strings due to default encoding.