### PR TITLE
Add SpotBugs plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1024,6 +1024,31 @@
                     <verbose>false</verbose>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>3.1.8</version>
+                <configuration>
+                    <excludeFilterFile>spotbugs__ignore_filter.xml</excludeFilterFile>
+                </configuration>
+                <dependencies>
+                    <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
+                    <dependency>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs</artifactId>
+                        <version>3.1.9</version>
+                    </dependency>
+                </dependencies>
+                <!-- executions>
+                    <execution>
+                        <id>execution1</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions -->
+            </plugin>
         </plugins>
     </build>
     <repositories>

--- a/spotbugs__ignore_filter.xml
+++ b/spotbugs__ignore_filter.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>>
+    <Match>
+        <Package name="~org\.json.*"/>
+    </Match>
+</FindBugsFilter>


### PR DESCRIPTION
This plugin can be used to analyze the code for bugs while compiling the code: https://spotbugs.github.io/spotbugs-maven-plugin/index.html

Currently this needs to be run manually with for example "mvn spotbugs:check" (there's other goals besides check), but it's something that we should enable for Travis CI builds once we get the check to go through so PRs will be checked automagically.