### PR TITLE
Fix for user generated content SLDs

### DIFF
--- a/content-resources/src/main/resources/sld/analysis/AnalysisDefaultStyle.sld
+++ b/content-resources/src/main/resources/sld/analysis/AnalysisDefaultStyle.sld
@@ -503,10 +503,8 @@
                                 <ogc:Literal>true</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>stroke_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                         </ogc:And>
                     </ogc:Filter>
@@ -518,42 +516,6 @@
                             <CssParameter name="stroke-linecap"><ogc:PropertyName>stroke_linecap</ogc:PropertyName></CssParameter>
                         </Stroke>
                     </LineSymbolizer>
-                    <!--PointSymbolizer>
-                      <Geometry><ogc:Function name="vertices"><ogc:PropertyName>geometry</ogc:PropertyName></ogc:Function></Geometry>
-                      <Graphic>
-                        <Mark>
-                          <WellKnownName>square</WellKnownName>
-                          <Fill>
-                            <CssParameter name="fill"><ogc:PropertyName>stroke_color</ogc:PropertyName></CssParameter>
-                          </Fill>
-                        </Mark>
-                        <Size>6</Size>
-                      </Graphic>
-                    </PointSymbolizer-->
-                    <!--TextSymbolizer>
-                      <Label>
-                        <ogc:PropertyName>name</ogc:PropertyName>
-                      </Label>
-                      <Font>
-                        <CssParameter name="font-family">Arial</CssParameter>
-                        <CssParameter name="font-size">11</CssParameter>
-                        <CssParameter name="font-style">normal</CssParameter>
-                        <CssParameter name="font-weight">bold</CssParameter>
-                      </Font>
-                      <LabelPlacement>
-                        <PointPlacement>
-                          <AnchorPoint>
-                            <AnchorPointX>0.5</AnchorPointX>
-                            <AnchorPointY>0.5</AnchorPointY>
-                          </AnchorPoint>
-                        </PointPlacement>
-                      </LabelPlacement>
-                      <Fill>
-                        <CssParameter name="fill"><ogc:PropertyName>stroke_color</ogc:PropertyName></CssParameter>
-                      </Fill>
-                      <VendorOption name="autoWrap">60</VendorOption>
-                      <VendorOption name="maxDisplacement">150</VendorOption>
-                    </TextSymbolizer -->
                 </Rule>
 
                 <Rule>
@@ -570,10 +532,8 @@
                                 <ogc:Literal>true</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsNotEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>stroke_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsNotEqualTo>
                         </ogc:And>
                     </ogc:Filter>
@@ -585,42 +545,6 @@
                             <CssParameter name="stroke-linejoin"><ogc:PropertyName>stroke_linejoin</ogc:PropertyName></CssParameter>
                         </Stroke>
                     </LineSymbolizer>
-                    <!--PointSymbolizer>
-                      <Geometry><ogc:Function name="vertices"><ogc:PropertyName>geometry</ogc:PropertyName></ogc:Function></Geometry>
-                      <Graphic>
-                        <Mark>
-                          <WellKnownName>square</WellKnownName>
-                          <Fill>
-                            <CssParameter name="fill"><ogc:PropertyName>stroke_color</ogc:PropertyName></CssParameter>
-                          </Fill>
-                        </Mark>
-                        <Size>6</Size>
-                      </Graphic>
-                    </PointSymbolizer-->
-                    <!--TextSymbolizer>
-                      <Label>
-                        <ogc:PropertyName>name</ogc:PropertyName>
-                      </Label>
-                      <Font>
-                        <CssParameter name="font-family">Arial</CssParameter>
-                        <CssParameter name="font-size">11</CssParameter>
-                        <CssParameter name="font-style">normal</CssParameter>
-                        <CssParameter name="font-weight">bold</CssParameter>
-                      </Font>
-                      <LabelPlacement>
-                        <PointPlacement>
-                          <AnchorPoint>
-                            <AnchorPointX>0.5</AnchorPointX>
-                            <AnchorPointY>0.5</AnchorPointY>
-                          </AnchorPoint>
-                        </PointPlacement>
-                      </LabelPlacement>
-                      <Fill>
-                        <CssParameter name="fill"><ogc:PropertyName>stroke_color</ogc:PropertyName></CssParameter>
-                      </Fill>
-                      <VendorOption name="autoWrap">60</VendorOption>
-                      <VendorOption name="maxDisplacement">150</VendorOption>
-                    </TextSymbolizer -->
                 </Rule>
 
                 <Rule>
@@ -641,17 +565,14 @@
                                 <ogc:Literal>-1</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -664,28 +585,6 @@
                             <CssParameter name="stroke-linejoin"><ogc:PropertyName>border_linejoin</ogc:PropertyName></CssParameter>
                         </Stroke>
                     </PolygonSymbolizer>
-                    <!--TextSymbolizer>
-                      <Label><ogc:PropertyName>name</ogc:PropertyName></Label>
-                      <Font>
-                        <CssParameter name="font-family">Arial</CssParameter>
-                        <CssParameter name="font-size">20</CssParameter>
-                        <CssParameter name="font-style">normal</CssParameter>
-                        <CssParameter name="font-weight">bold</CssParameter>
-                      </Font>
-                      <LabelPlacement>
-                        <PointPlacement>
-                          <AnchorPoint>
-                            <AnchorPointX>0.5</AnchorPointX>
-                            <AnchorPointY>0.5</AnchorPointY>
-                          </AnchorPoint>
-                        </PointPlacement>
-                      </LabelPlacement>
-                      <Fill>
-                        <CssParameter name="fill"><ogc:PropertyName>stroke_color</ogc:PropertyName></CssParameter>
-                      </Fill>
-                      <VendorOption name="autoWrap">60</VendorOption>
-                      <VendorOption name="maxDisplacement">150</VendorOption>
-                    </TextSymbolizer -->
                 </Rule>
 
                 <Rule>
@@ -706,17 +605,14 @@
                                 <ogc:Literal>-1</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsNotEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsNotEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -730,28 +626,6 @@
                             <CssParameter name="stroke-linejoin"><ogc:PropertyName>border_linejoin</ogc:PropertyName></CssParameter>
                         </Stroke>
                     </PolygonSymbolizer>
-                    <!--TextSymbolizer>
-                      <Label><ogc:PropertyName>name</ogc:PropertyName></Label>
-                      <Font>
-                        <CssParameter name="font-family">Arial</CssParameter>
-                        <CssParameter name="font-size">20</CssParameter>
-                        <CssParameter name="font-style">normal</CssParameter>
-                        <CssParameter name="font-weight">bold</CssParameter>
-                      </Font>
-                      <LabelPlacement>
-                        <PointPlacement>
-                          <AnchorPoint>
-                            <AnchorPointX>0.5</AnchorPointX>
-                            <AnchorPointY>0.5</AnchorPointY>
-                          </AnchorPoint>
-                        </PointPlacement>
-                      </LabelPlacement>
-                      <Fill>
-                        <CssParameter name="fill"><ogc:PropertyName>stroke_color</ogc:PropertyName></CssParameter>
-                      </Fill>
-                      <VendorOption name="autoWrap">60</VendorOption>
-                      <VendorOption name="maxDisplacement">150</VendorOption>
-                    </TextSymbolizer -->
                 </Rule>
 
                 <Rule>
@@ -772,17 +646,14 @@
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -826,17 +697,14 @@
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsNotEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsNotEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -881,17 +749,14 @@
                                 <ogc:Literal>1</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -935,17 +800,14 @@
                                 <ogc:Literal>1</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsNotEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsNotEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -990,17 +852,14 @@
                                 <ogc:Literal>2</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -1044,17 +903,14 @@
                                 <ogc:Literal>2</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsNotEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsNotEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -1099,17 +955,14 @@
                                 <ogc:Literal>3</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -1153,17 +1006,14 @@
                                 <ogc:Literal>3</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsNotEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsNotEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -1379,85 +1229,6 @@
                     </PolygonSymbolizer>
                 </Rule>
             </FeatureTypeStyle>
-            <!--FeatureTypeStyle>
-              <Transformation>
-                <ogc:Function name="gs:PointStacker">
-                  <ogc:Function name="parameter">
-                    <ogc:Literal>data</ogc:Literal>
-                  </ogc:Function>
-                  <ogc:Function name="parameter">
-                    <ogc:Literal>cellSize</ogc:Literal>
-                    <ogc:Literal>100</ogc:Literal>
-                  </ogc:Function>
-                  <ogc:Function name="parameter">
-                    <ogc:Literal>outputBBOX</ogc:Literal>
-                    <ogc:Function name="env">
-                    <ogc:Literal>wms_bbox</ogc:Literal>
-                  </ogc:Function>
-                </ogc:Function>
-                <ogc:Function name="parameter">
-                  <ogc:Literal>outputWidth</ogc:Literal>
-                    <ogc:Function name="env">
-                      <ogc:Literal>wms_width</ogc:Literal>
-                    </ogc:Function>
-                  </ogc:Function>
-                  <ogc:Function name="parameter">
-                    <ogc:Literal>outputHeight</ogc:Literal>
-                    <ogc:Function name="env">
-                      <ogc:Literal>wms_height</ogc:Literal>
-                    </ogc:Function>
-                  </ogc:Function>
-                </ogc:Function>
-              </Transformation>
-              <Rule>
-                <ogc:Filter>
-                  <ogc:PropertyIsGreaterThan>
-                    <ogc:PropertyName>count</ogc:PropertyName>
-                    <ogc:Literal>1</ogc:Literal>
-                  </ogc:PropertyIsGreaterThan>
-                </ogc:Filter>
-                <PointSymbolizer>
-                  <Graphic>
-                    <Mark>
-                      <WellKnownName>circle</WellKnownName>
-                      <Fill>
-                        <CssParameter name="fill">#AA0000</CssParameter>
-                      </Fill>
-                    </Mark>
-                    <Size>14</Size>
-                  </Graphic>
-                </PointSymbolizer>
-                <TextSymbolizer>
-                  <Label>
-                    <ogc:PropertyName>count</ogc:PropertyName>
-                  </Label>
-                  <Font>
-                    <CssParameter name="font-family">Arial</CssParameter>
-                    <CssParameter name="font-size">12</CssParameter>
-                    <CssParameter name="font-weight">bold</CssParameter>
-                  </Font>
-                  <LabelPlacement>
-                    <PointPlacement>
-                      <AnchorPoint>
-                        <AnchorPointX>0.6</AnchorPointX>
-                        <AnchorPointY>0.8</AnchorPointY>
-                      </AnchorPoint>
-                    </PointPlacement>
-                  </LabelPlacement>
-                  <Halo>
-                    <Radius>2</Radius>
-                    <Fill>
-                      <CssParameter name="fill">#AA0000</CssParameter>
-                      <CssParameter name="fill-opacity">0.9</CssParameter>
-                    </Fill>
-                  </Halo>
-                  <Fill>
-                    <CssParameter name="fill">#FFFFFF</CssParameter>
-                    <CssParameter name="fill-opacity">1.0</CssParameter>
-                  </Fill>
-                </TextSymbolizer>
-              </Rule>
-            </FeatureTypeStyle-->
         </UserStyle>
     </NamedLayer>
 </StyledLayerDescriptor>

--- a/content-resources/src/main/resources/sld/myplaces/MyPlacesDefaultStyle.sld
+++ b/content-resources/src/main/resources/sld/myplaces/MyPlacesDefaultStyle.sld
@@ -40,12 +40,11 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -123,12 +122,11 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsGreaterThan>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -206,12 +204,11 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -290,12 +287,11 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsGreaterThan>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -374,12 +370,11 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -468,12 +463,11 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsGreaterThan>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -562,12 +556,11 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -657,12 +650,11 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsGreaterThan>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -752,12 +744,11 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -846,12 +837,11 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsGreaterThan>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -940,12 +930,11 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -1035,12 +1024,11 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsGreaterThan>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -1130,12 +1118,11 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -1224,12 +1211,11 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsGreaterThan>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -1318,12 +1304,11 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -1413,12 +1398,11 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsGreaterThan>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -1508,12 +1492,11 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -1602,12 +1585,11 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsGreaterThan>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -1696,12 +1678,11 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -1791,12 +1772,11 @@
                                 </ogc:Function>
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsGreaterThan>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>

--- a/content-resources/src/main/resources/sld/myplaces/MyPlacesDefaultStyle.sld
+++ b/content-resources/src/main/resources/sld/myplaces/MyPlacesDefaultStyle.sld
@@ -29,10 +29,8 @@
                                 <ogc:Literal>-1</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsEqualTo>
                                 <ogc:Function name="strLength">
@@ -111,10 +109,8 @@
                                 <ogc:Literal>-1</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsGreaterThan>
                                 <ogc:Function name="strLength">
@@ -193,10 +189,8 @@
                                 <ogc:Literal>-1</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsNotEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsNotEqualTo>
                             <ogc:PropertyIsEqualTo>
                                 <ogc:Function name="strLength">
@@ -276,10 +270,8 @@
                                 <ogc:Literal>-1</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsNotEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsNotEqualTo>
                             <ogc:PropertyIsGreaterThan>
                                 <ogc:Function name="strLength">
@@ -359,10 +351,8 @@
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsEqualTo>
                                 <ogc:Function name="strLength">
@@ -452,10 +442,8 @@
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsGreaterThan>
                                 <ogc:Function name="strLength">
@@ -545,10 +533,8 @@
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsNotEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsNotEqualTo>
                             <ogc:PropertyIsEqualTo>
                                 <ogc:Function name="strLength">
@@ -639,10 +625,8 @@
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsNotEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsNotEqualTo>
                             <ogc:PropertyIsGreaterThan>
                                 <ogc:Function name="strLength">
@@ -733,10 +717,8 @@
                                 <ogc:Literal>1</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsEqualTo>
                                 <ogc:Function name="strLength">
@@ -826,10 +808,8 @@
                                 <ogc:Literal>1</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsGreaterThan>
                                 <ogc:Function name="strLength">
@@ -919,10 +899,8 @@
                                 <ogc:Literal>1</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsNotEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsNotEqualTo>
                             <ogc:PropertyIsEqualTo>
                                 <ogc:Function name="strLength">
@@ -1013,10 +991,8 @@
                                 <ogc:Literal>1</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsNotEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsNotEqualTo>
                             <ogc:PropertyIsGreaterThan>
                                 <ogc:Function name="strLength">
@@ -1107,10 +1083,8 @@
                                 <ogc:Literal>2</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsEqualTo>
                                 <ogc:Function name="strLength">
@@ -1200,10 +1174,8 @@
                                 <ogc:Literal>2</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsGreaterThan>
                                 <ogc:Function name="strLength">
@@ -1293,10 +1265,8 @@
                                 <ogc:Literal>2</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsNotEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsNotEqualTo>
                             <ogc:PropertyIsEqualTo>
                                 <ogc:Function name="strLength">
@@ -1387,10 +1357,8 @@
                                 <ogc:Literal>2</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsNotEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsNotEqualTo>
                             <ogc:PropertyIsGreaterThan>
                                 <ogc:Function name="strLength">
@@ -1481,10 +1449,8 @@
                                 <ogc:Literal>3</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsEqualTo>
                                 <ogc:Function name="strLength">
@@ -1574,10 +1540,8 @@
                                 <ogc:Literal>3</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsGreaterThan>
                                 <ogc:Function name="strLength">
@@ -1667,10 +1631,8 @@
                                 <ogc:Literal>3</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsNotEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsNotEqualTo>
                             <ogc:PropertyIsEqualTo>
                                 <ogc:Function name="strLength">
@@ -1761,10 +1723,8 @@
                                 <ogc:Literal>3</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsNotEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>border_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsNotEqualTo>
                             <ogc:PropertyIsGreaterThan>
                                 <ogc:Function name="strLength">

--- a/content-resources/src/main/resources/sld/userlayer/UserLayerDefaultStyle.sld
+++ b/content-resources/src/main/resources/sld/userlayer/UserLayerDefaultStyle.sld
@@ -490,6 +490,7 @@
                 </Rule>
 
                 <Rule>
+                    <Name>LineStrokeNoDash</Name>
                     <ogc:Filter>
                         <ogc:And>
                             <ogc:PropertyIsEqualTo>
@@ -503,10 +504,8 @@
                                 <ogc:Literal>true</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>stroke_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>stroke_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                         </ogc:And>
                     </ogc:Filter>
@@ -518,45 +517,10 @@
                             <CssParameter name="stroke-linecap"><ogc:PropertyName>stroke_linecap</ogc:PropertyName></CssParameter>
                         </Stroke>
                     </LineSymbolizer>
-                    <!--PointSymbolizer>
-                      <Geometry><ogc:Function name="vertices"><ogc:PropertyName>geometry</ogc:PropertyName></ogc:Function></Geometry>
-                      <Graphic>
-                        <Mark>
-                          <WellKnownName>square</WellKnownName>
-                          <Fill>
-                            <CssParameter name="fill"><ogc:PropertyName>stroke_color</ogc:PropertyName></CssParameter>
-                          </Fill>
-                        </Mark>
-                        <Size>6</Size>
-                      </Graphic>
-                    </PointSymbolizer-->
-                    <!--TextSymbolizer>
-                      <Label>
-                        <ogc:PropertyName>name</ogc:PropertyName>
-                      </Label>
-                      <Font>
-                        <CssParameter name="font-family">Arial</CssParameter>
-                        <CssParameter name="font-size">11</CssParameter>
-                        <CssParameter name="font-style">normal</CssParameter>
-                        <CssParameter name="font-weight">bold</CssParameter>
-                      </Font>
-                      <LabelPlacement>
-                        <PointPlacement>
-                          <AnchorPoint>
-                            <AnchorPointX>0.5</AnchorPointX>
-                            <AnchorPointY>0.5</AnchorPointY>
-                          </AnchorPoint>
-                        </PointPlacement>
-                      </LabelPlacement>
-                      <Fill>
-                        <CssParameter name="fill"><ogc:PropertyName>stroke_color</ogc:PropertyName></CssParameter>
-                      </Fill>
-                      <VendorOption name="autoWrap">60</VendorOption>
-                      <VendorOption name="maxDisplacement">150</VendorOption>
-                    </TextSymbolizer -->
                 </Rule>
 
                 <Rule>
+                    <Name>LineStrokeWithDash</Name>
                     <ogc:Filter>
                         <ogc:And>
                             <ogc:PropertyIsEqualTo>
@@ -570,10 +534,8 @@
                                 <ogc:Literal>true</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsNotEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>stroke_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>stroke_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsNotEqualTo>
                         </ogc:And>
                     </ogc:Filter>
@@ -585,45 +547,10 @@
                             <CssParameter name="stroke-linejoin"><ogc:PropertyName>stroke_linejoin</ogc:PropertyName></CssParameter>
                         </Stroke>
                     </LineSymbolizer>
-                    <!--PointSymbolizer>
-                      <Geometry><ogc:Function name="vertices"><ogc:PropertyName>geometry</ogc:PropertyName></ogc:Function></Geometry>
-                      <Graphic>
-                        <Mark>
-                          <WellKnownName>square</WellKnownName>
-                          <Fill>
-                            <CssParameter name="fill"><ogc:PropertyName>stroke_color</ogc:PropertyName></CssParameter>
-                          </Fill>
-                        </Mark>
-                        <Size>6</Size>
-                      </Graphic>
-                    </PointSymbolizer-->
-                    <!--TextSymbolizer>
-                      <Label>
-                        <ogc:PropertyName>name</ogc:PropertyName>
-                      </Label>
-                      <Font>
-                        <CssParameter name="font-family">Arial</CssParameter>
-                        <CssParameter name="font-size">11</CssParameter>
-                        <CssParameter name="font-style">normal</CssParameter>
-                        <CssParameter name="font-weight">bold</CssParameter>
-                      </Font>
-                      <LabelPlacement>
-                        <PointPlacement>
-                          <AnchorPoint>
-                            <AnchorPointX>0.5</AnchorPointX>
-                            <AnchorPointY>0.5</AnchorPointY>
-                          </AnchorPoint>
-                        </PointPlacement>
-                      </LabelPlacement>
-                      <Fill>
-                        <CssParameter name="fill"><ogc:PropertyName>stroke_color</ogc:PropertyName></CssParameter>
-                      </Fill>
-                      <VendorOption name="autoWrap">60</VendorOption>
-                      <VendorOption name="maxDisplacement">150</VendorOption>
-                    </TextSymbolizer -->
                 </Rule>
 
                 <Rule>
+                    <Name>PolygonBorderNoDash</Name>
                     <ogc:Filter>
                         <ogc:And>
                             <ogc:PropertyIsEqualTo>
@@ -641,17 +568,14 @@
                                 <ogc:Literal>-1</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>stroke_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -664,31 +588,10 @@
                             <CssParameter name="stroke-linejoin"><ogc:PropertyName>border_linejoin</ogc:PropertyName></CssParameter>
                         </Stroke>
                     </PolygonSymbolizer>
-                    <!--TextSymbolizer>
-                      <Label><ogc:PropertyName>name</ogc:PropertyName></Label>
-                      <Font>
-                        <CssParameter name="font-family">Arial</CssParameter>
-                        <CssParameter name="font-size">20</CssParameter>
-                        <CssParameter name="font-style">normal</CssParameter>
-                        <CssParameter name="font-weight">bold</CssParameter>
-                      </Font>
-                      <LabelPlacement>
-                        <PointPlacement>
-                          <AnchorPoint>
-                            <AnchorPointX>0.5</AnchorPointX>
-                            <AnchorPointY>0.5</AnchorPointY>
-                          </AnchorPoint>
-                        </PointPlacement>
-                      </LabelPlacement>
-                      <Fill>
-                        <CssParameter name="fill"><ogc:PropertyName>stroke_color</ogc:PropertyName></CssParameter>
-                      </Fill>
-                      <VendorOption name="autoWrap">60</VendorOption>
-                      <VendorOption name="maxDisplacement">150</VendorOption>
-                    </TextSymbolizer -->
                 </Rule>
 
                 <Rule>
+                    <Name>PolygonBorderWithDash</Name>
                     <ogc:Filter>
                         <ogc:And>
                             <ogc:PropertyIsEqualTo>
@@ -706,17 +609,14 @@
                                 <ogc:Literal>-1</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsNotEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>stroke_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsNotEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -730,31 +630,10 @@
                             <CssParameter name="stroke-linejoin"><ogc:PropertyName>border_linejoin</ogc:PropertyName></CssParameter>
                         </Stroke>
                     </PolygonSymbolizer>
-                    <!--TextSymbolizer>
-                      <Label><ogc:PropertyName>name</ogc:PropertyName></Label>
-                      <Font>
-                        <CssParameter name="font-family">Arial</CssParameter>
-                        <CssParameter name="font-size">20</CssParameter>
-                        <CssParameter name="font-style">normal</CssParameter>
-                        <CssParameter name="font-weight">bold</CssParameter>
-                      </Font>
-                      <LabelPlacement>
-                        <PointPlacement>
-                          <AnchorPoint>
-                            <AnchorPointX>0.5</AnchorPointX>
-                            <AnchorPointY>0.5</AnchorPointY>
-                          </AnchorPoint>
-                        </PointPlacement>
-                      </LabelPlacement>
-                      <Fill>
-                        <CssParameter name="fill"><ogc:PropertyName>stroke_color</ogc:PropertyName></CssParameter>
-                      </Fill>
-                      <VendorOption name="autoWrap">60</VendorOption>
-                      <VendorOption name="maxDisplacement">150</VendorOption>
-                    </TextSymbolizer -->
                 </Rule>
 
                 <Rule>
+                    <Name>PolygonBorderNoDashWithFillPattern</Name>
                     <ogc:Filter>
                         <ogc:And>
                             <ogc:PropertyIsEqualTo>
@@ -772,17 +651,14 @@
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>stroke_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -809,6 +685,7 @@
                 </Rule>
 
                 <Rule>
+                    <Name>PolygonBorderWithDashWithFillPattern0</Name>
                     <ogc:Filter>
                         <ogc:And>
                             <ogc:PropertyIsEqualTo>
@@ -826,17 +703,14 @@
                                 <ogc:Literal>0</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsNotEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>stroke_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsNotEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -864,6 +738,7 @@
                 </Rule>
 
                 <Rule>
+                    <Name>PolygonBorderNoDashWithFillPattern1</Name>
                     <ogc:Filter>
                         <ogc:And>
                             <ogc:PropertyIsEqualTo>
@@ -881,17 +756,14 @@
                                 <ogc:Literal>1</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>stroke_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -918,6 +790,7 @@
                 </Rule>
 
                 <Rule>
+                    <Name>PolygonBorderWithDashWithFillPattern1</Name>
                     <ogc:Filter>
                         <ogc:And>
                             <ogc:PropertyIsEqualTo>
@@ -935,17 +808,14 @@
                                 <ogc:Literal>1</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsNotEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>stroke_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsNotEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -973,6 +843,7 @@
                 </Rule>
 
                 <Rule>
+                    <Name>PolygonBorderNoDashWithFillPattern2</Name>
                     <ogc:Filter>
                         <ogc:And>
                             <ogc:PropertyIsEqualTo>
@@ -990,17 +861,14 @@
                                 <ogc:Literal>2</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>stroke_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -1027,6 +895,7 @@
                 </Rule>
 
                 <Rule>
+                    <Name>PolygonBorderWithDashWithFillPattern2</Name>
                     <ogc:Filter>
                         <ogc:And>
                             <ogc:PropertyIsEqualTo>
@@ -1044,17 +913,14 @@
                                 <ogc:Literal>2</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsNotEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>stroke_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsNotEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -1082,6 +948,7 @@
                 </Rule>
 
                 <Rule>
+                    <Name>PolygonBorderNoDashWithFillPattern3</Name>
                     <ogc:Filter>
                         <ogc:And>
                             <ogc:PropertyIsEqualTo>
@@ -1099,17 +966,14 @@
                                 <ogc:Literal>3</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>stroke_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -1136,6 +1000,7 @@
                 </Rule>
 
                 <Rule>
+                    <Name>PolygonBorderWithDashWithFillPattern3</Name>
                     <ogc:Filter>
                         <ogc:And>
                             <ogc:PropertyIsEqualTo>
@@ -1153,17 +1018,14 @@
                                 <ogc:Literal>3</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
                             <ogc:PropertyIsNotEqualTo>
-                                <ogc:Function name="strLength">
-                                    <ogc:PropertyName>border_dasharray</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>0</ogc:Literal>
+                                <ogc:PropertyName>stroke_dasharray</ogc:PropertyName>
+                                <ogc:Literal></ogc:Literal>
                             </ogc:PropertyIsNotEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:Function name="isNull">
+                            <ogc:Not>
+                                <ogc:PropertyIsNull>
                                     <ogc:PropertyName>border_color</ogc:PropertyName>
-                                </ogc:Function>
-                                <ogc:Literal>false</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                                </ogc:PropertyIsNull>
+                            </ogc:Not>
                         </ogc:And>
                     </ogc:Filter>
                     <PolygonSymbolizer>
@@ -1189,8 +1051,9 @@
                         </Stroke>
                     </PolygonSymbolizer>
                 </Rule>
-                
+
                 <Rule>
+                    <Name>PolygonNoBorderFillOnly</Name>
                     <ogc:Filter>
                         <ogc:And>
                             <ogc:PropertyIsEqualTo>
@@ -1220,6 +1083,7 @@
                 </Rule>
 
                 <Rule>
+                    <Name>PolygonNoBorderFillPattern0</Name>
                     <ogc:Filter>
                         <ogc:And>
                             <ogc:PropertyIsEqualTo>
@@ -1260,6 +1124,7 @@
                 </Rule>
 
                 <Rule>
+                    <Name>PolygonNoBorderFillPattern1</Name>
                     <ogc:Filter>
                         <ogc:And>
                             <ogc:PropertyIsEqualTo>
@@ -1300,6 +1165,7 @@
                 </Rule>
 
                 <Rule>
+                    <Name>PolygonNoBorderFillPattern2</Name>
                     <ogc:Filter>
                         <ogc:And>
                             <ogc:PropertyIsEqualTo>
@@ -1340,6 +1206,7 @@
                 </Rule>
 
                 <Rule>
+                    <Name>PolygonNoBorderFillPattern3</Name>
                     <ogc:Filter>
                         <ogc:And>
                             <ogc:PropertyIsEqualTo>


### PR DESCRIPTION
For some reason the SLD for userlayers ( & analysis & my places) is no longer compatible with the updated GeoServer (2.10.5->2.13.2). Trying to get the map tiles through WMS results in errors like this:

	org.geoserver.platform.ServiceException: Rendering process failed
	at org.geoserver.wms.map.RenderedImageMapOutputFormat.produceMap(RenderedImageMapOutputFormat.java:610)

	..
	Caused by: java.lang.IndexOutOfBoundsException: Index: 3, Size: 3
	at java.util.ArrayList.rangeCheck(ArrayList.java:657)
	at java.util.ArrayList.get(ArrayList.java:433)
	..
	at org.geotools.filter.AndImpl.accept(AndImpl.java:48)
	at org.geotools.jdbc.SQLDialect.splitFilter(SQLDialect.java:1398)

The attribute data worked properly through Oskari WFS implementation.

The fix was to replace any filters having:

    <ogc:PropertyIsEqualTo>
        <ogc:Function name="isNull">
            <ogc:PropertyName>border_color</ogc:PropertyName>
        </ogc:Function>
        <ogc:Literal>false</ogc:Literal>
    </ogc:PropertyIsEqualTo>

With: 

    <ogc:Not>
        <ogc:PropertyIsNull>
            <ogc:PropertyName>border_color</ogc:PropertyName>
        </ogc:PropertyIsNull>
    </ogc:Not>

And any filters having:

    <ogc:PropertyIsEqualTo>
        <ogc:Function name="strLength">
            <ogc:PropertyName>border_dasharray</ogc:PropertyName>
        </ogc:Function>
        <ogc:Literal>0</ogc:Literal>
    </ogc:PropertyIsEqualTo>

With: 

    <ogc:PropertyIsEqualTo>
        <ogc:PropertyName>border_dasharray</ogc:PropertyName>
        <ogc:Literal></ogc:Literal>
    </ogc:PropertyIsEqualTo>

Commented out parts were removed and rules missing names were named while debugging,