### PR TITLE
Prevent excessive logging

### DIFF
--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWMS.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWMS.java
@@ -168,8 +168,8 @@ public class LayerJSONFormatterWMS extends LayerJSONFormatter {
      *         otherwise a Set containing both (can be empty)
      */
     protected static Set<String> getSRSs(JSONObject attributes, JSONObject capabilities) {
-        JSONArray jsonForcedSRS = JSONHelper.getJSONArray(attributes, KEY_ATTRIBUTE_FORCED_SRS);
-        JSONArray jsonCapabilitiesSRS = JSONHelper.getJSONArray(capabilities, KEY_SRS);
+        JSONArray jsonForcedSRS = attributes != null ? attributes.optJSONArray(KEY_ATTRIBUTE_FORCED_SRS): null;
+        JSONArray jsonCapabilitiesSRS = capabilities != null ? capabilities.optJSONArray(KEY_SRS): null;
         if (jsonForcedSRS == null && jsonCapabilitiesSRS == null) {
             log.debug("No SRS information found from either attributes or capabilities");
             return null;


### PR DESCRIPTION
With an instance having many map layers AND log level "info" the log is spammed with messages like:

      INFO  fi.nls.oskari.util.JSONHelper - Couldn't get JSONArray from {} with key = forcedSRS
      INFO  fi.nls.oskari.util.JSONHelper - Couldn't get JSONArray from {"formats":{"available":["text/html","text/plain","application/vnd.ogc.gml"],"value":"text/html"},"isQueryable":true,...,"version":"1.3.0"} with key = srs


This helps with that.