### PR TITLE
GeoServer autoconfig

### DIFF
--- a/content-resources/src/main/java/fi/nls/oskari/geoserver/AnalysisHelper.java
+++ b/content-resources/src/main/java/fi/nls/oskari/geoserver/AnalysisHelper.java
@@ -44,6 +44,8 @@ public class AnalysisHelper {
 
             ds.connectionParameters.user = info.user;
             ds.connectionParameters.passwd = info.pass;
+            ds.connectionParameters.host = info.getHost();
+            ds.connectionParameters.port = info.getPort();
             ds.connectionParameters.database = info.getDBName();
             // !! in 2.5.2 namespace = NS PREFIX, in 2.7.1 it needs to be the NS URI!!
             ds.connectionParameters.namespace = ns.uri;

--- a/content-resources/src/main/java/fi/nls/oskari/geoserver/AnalysisHelper.java
+++ b/content-resources/src/main/java/fi/nls/oskari/geoserver/AnalysisHelper.java
@@ -62,7 +62,7 @@ public class AnalysisHelper {
             FeatureType featureData = new FeatureType();
             featureData.enabled = true;
             featureData.name = "analysis_data";
-            featureData.srs = srs;
+            GeoserverPopulator.resolveCRS(featureData, srs);
 
             geoserver.createFeatureType(featureData, GeoserverPopulator.NAMESPACE, storeName);
             LOG.info("Added featuretype:", featureData);
@@ -75,7 +75,7 @@ public class AnalysisHelper {
         try {
             featureStyledData.enabled = true;
             featureStyledData.name = "analysis_data_style";
-            featureStyledData.srs = srs;
+            GeoserverPopulator.resolveCRS(featureStyledData, srs);
 
             geoserver.createFeatureType(featureStyledData, GeoserverPopulator.NAMESPACE, storeName);
             LOG.info("Added featuretype:", featureStyledData);

--- a/content-resources/src/main/java/fi/nls/oskari/geoserver/GeoserverPopulator.java
+++ b/content-resources/src/main/java/fi/nls/oskari/geoserver/GeoserverPopulator.java
@@ -6,6 +6,7 @@ import feign.Feign;
 import feign.auth.BasicAuthRequestInterceptor;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
+import fi.nls.oskari.db.DatasourceHelper;
 import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.domain.map.wfs.WFSLayerConfiguration;
 import fi.nls.oskari.log.LogFactory;
@@ -33,25 +34,31 @@ public class GeoserverPopulator {
     public static void setupAll(final String srs)
             throws Exception {
 
-        try{
-            MyplacesHelper.setupMyplaces(srs);
-        }catch(Exception e){
-            LOG.error(e, "Error when setting my places");
-            LOG.debug(e.getMessage());
+        if (DatasourceHelper.isModuleEnabled("myplaces")) {
+            try {
+                MyplacesHelper.setupMyplaces(srs);
+            } catch(Exception e){
+                LOG.error(e, "Error when setting my places");
+                LOG.debug(e.getMessage());
+            }
         }
 
-        try{
-            AnalysisHelper.setupAnalysis(srs);
-        }catch(Exception e){
-            LOG.error(e, "Error when setting analysis");
-            LOG.debug(e.getMessage());
+        if (DatasourceHelper.isModuleEnabled("analysis")) {
+            try {
+                AnalysisHelper.setupAnalysis(srs);
+            } catch(Exception e){
+                LOG.error(e, "Error when setting analysis");
+                LOG.debug(e.getMessage());
+            }
         }
 
-        try{
-            UserlayerHelper.setupUserlayers(srs);
-        }catch(Exception e){
-            LOG.error(e, "Error when setting user layers");
-            LOG.debug(e.getMessage());
+        if (DatasourceHelper.isModuleEnabled("userlayer")) {
+            try {
+                UserlayerHelper.setupUserlayers(srs);
+            } catch(Exception e){
+                LOG.error(e, "Error when setting user layers");
+                LOG.debug(e.getMessage());
+            }
         }
     }
 

--- a/content-resources/src/main/java/fi/nls/oskari/geoserver/MyplacesHelper.java
+++ b/content-resources/src/main/java/fi/nls/oskari/geoserver/MyplacesHelper.java
@@ -62,7 +62,7 @@ public class MyplacesHelper {
             FeatureType featureCategories = new FeatureType();
             featureCategories.enabled = true;
             featureCategories.name = "categories";
-            featureCategories.srs = srs;
+            GeoserverPopulator.resolveCRS(featureCategories, srs);
 
             geoserver.createFeatureType(featureCategories, GeoserverPopulator.NAMESPACE, storeName);
             LOG.info("Added featuretype:", featureCategories);
@@ -75,7 +75,7 @@ public class MyplacesHelper {
             FeatureType featurePlaces = new FeatureType();
             featurePlaces.enabled = true;
             featurePlaces.name = "my_places";
-            featurePlaces.srs = srs;
+            GeoserverPopulator.resolveCRS(featurePlaces, srs);
 
             geoserver.createFeatureType(featurePlaces, GeoserverPopulator.NAMESPACE, storeName);
             LOG.info("Added featuretype:", featurePlaces);
@@ -88,7 +88,7 @@ public class MyplacesHelper {
         try {
             featurePlacesCategories.enabled = true;
             featurePlacesCategories.name = "my_places_categories";
-            featurePlacesCategories.srs = srs;
+            GeoserverPopulator.resolveCRS(featurePlacesCategories, srs);
 
             geoserver.createFeatureType(featurePlacesCategories, GeoserverPopulator.NAMESPACE, storeName);
             LOG.info("Added featuretype:", featurePlacesCategories);

--- a/content-resources/src/main/java/fi/nls/oskari/geoserver/MyplacesHelper.java
+++ b/content-resources/src/main/java/fi/nls/oskari/geoserver/MyplacesHelper.java
@@ -44,6 +44,8 @@ public class MyplacesHelper {
 
             ds.connectionParameters.user = info.user;
             ds.connectionParameters.passwd = info.pass;
+            ds.connectionParameters.host = info.getHost();
+            ds.connectionParameters.port = info.getPort();
             ds.connectionParameters.database = info.getDBName();
             // in 2.5.2 namespace = NAMESPACE, in 2.7.1 it needs to be the uri?
             ds.connectionParameters.namespace = ns.uri;

--- a/content-resources/src/main/java/fi/nls/oskari/geoserver/UserlayerHelper.java
+++ b/content-resources/src/main/java/fi/nls/oskari/geoserver/UserlayerHelper.java
@@ -63,7 +63,7 @@ public class UserlayerHelper {
             FeatureType featureData = new FeatureType();
             featureData.enabled = true;
             featureData.name = "vuser_layer_data";
-            featureData.srs = srs;
+            GeoserverPopulator.resolveCRS(featureData, srs);
 
             geoserver.createFeatureType(featureData, GeoserverPopulator.NAMESPACE, storeName);
             LOG.info("Added featuretype:", featureData);
@@ -76,7 +76,7 @@ public class UserlayerHelper {
         try {
             featureStyledData.enabled = true;
             featureStyledData.name = "user_layer_data_style";
-            featureStyledData.srs = srs;
+            GeoserverPopulator.resolveCRS(featureStyledData, srs);
 
             geoserver.createFeatureType(featureStyledData, GeoserverPopulator.NAMESPACE, storeName);
             LOG.info("Added featuretype:", featureStyledData);

--- a/content-resources/src/main/java/fi/nls/oskari/geoserver/UserlayerHelper.java
+++ b/content-resources/src/main/java/fi/nls/oskari/geoserver/UserlayerHelper.java
@@ -44,6 +44,8 @@ public class UserlayerHelper {
 
             ds.connectionParameters.user = info.user;
             ds.connectionParameters.passwd = info.pass;
+            ds.connectionParameters.host = info.getHost();
+            ds.connectionParameters.port = info.getPort();
             ds.connectionParameters.database = info.getDBName();
             // !! in 2.5.2 namespace = NS PREFIX, in 2.7.1 it needs to be the NS URI!!
             ds.connectionParameters.namespace = ns.uri;

--- a/content-resources/src/main/resources/sld/userlayer/UserLayerDefaultStyle.sld
+++ b/content-resources/src/main/resources/sld/userlayer/UserLayerDefaultStyle.sld
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="ISO-8859-1"?>
 <StyledLayerDescriptor version="1.0.0"
                        xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd"
                        xmlns="http://www.opengis.net/sld"

--- a/content-resources/src/main/resources/sld/userlayer/UserLayerSimple.sld
+++ b/content-resources/src/main/resources/sld/userlayer/UserLayerSimple.sld
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="ISO-8859-1"?>
 <StyledLayerDescriptor version="1.0.0"
     xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd"
     xmlns="http://www.opengis.net/sld"

--- a/geoserver-ext/geoserver-rest-client/src/main/java/fi/nls/oskari/geoserver/FeatureType.java
+++ b/geoserver-ext/geoserver-rest-client/src/main/java/fi/nls/oskari/geoserver/FeatureType.java
@@ -1,6 +1,10 @@
 package fi.nls.oskari.geoserver;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonRootName;
+
+import java.util.HashMap;
+import java.util.Map;
 
 
 /**
@@ -11,6 +15,15 @@ public class FeatureType {
     public String name;
     public boolean enabled = true;
     public String srs;
-    public String projectionPolicy = "FORCE_DECLARED";
+    public String nativeCRS;
+    public Map<String, Double> nativeBoundingBox = new HashMap<>();
+
+    @JsonIgnore
+    public void setBounds(double minx, double maxx, double miny, double maxy) {
+        nativeBoundingBox.put("minx", minx);
+        nativeBoundingBox.put("maxx", maxx);
+        nativeBoundingBox.put("miny", miny);
+        nativeBoundingBox.put("maxy", maxy);
+    }
 
 }

--- a/geoserver-ext/geoserver-rest-client/src/main/java/fi/nls/oskari/geoserver/Geoserver.java
+++ b/geoserver-ext/geoserver-rest-client/src/main/java/fi/nls/oskari/geoserver/Geoserver.java
@@ -40,19 +40,19 @@ interface Geoserver {
     void createFeatureType(FeatureType ds, @Param("ns") String namespace, @Param("ds") String dataStore);
 
     // Use raw-param: https://github.com/boundlessgeo/gsconfig/pull/94
-    @RequestLine("POST /styles.sld?name={name}&raw=true")
+    @RequestLine("POST /styles?name={name}&raw=true")
     @Headers("Content-Type: application/vnd.ogc.sld+xml") // , Accept: application/vnd.ogc.sld+xml
     @Body("{content}") // Body template is needed so content isn't transformed by Jackson
     void createSLD(@Param("name") final String name, @Param("content") final String content);
 
     // Use raw-param: https://github.com/boundlessgeo/gsconfig/pull/94
-    @RequestLine("POST /workspaces/{ws}/styles.sld?name={name}&raw=true")
+    @RequestLine("POST /workspaces/{ws}/styles?name={name}&raw=true")
     @Headers("Content-Type: application/vnd.ogc.sld+xml") // , Accept: application/vnd.ogc.sld+xml
     @Body("{content}") // Body template is needed so content isn't transformed by Jackson
     void createSLD(@Param("name") final String name, @Param("content") final String content, @Param("ws") final String workspace);
 
     // XML is simpler here, use it instead of json
-    @RequestLine("POST /layers/{layer}/styles.xml")
+    @RequestLine("POST /layers/{layer}/styles")
     @Headers("Content-Type: text/xml")
     @Body("<style><name>{style}</name></style>")
     void linkStyleToLayer(@Param("style") final String stylename, @Param("layer") final String layername);

--- a/webapp-setup/src/main/java/fi/nls/oskari/SetupController.java
+++ b/webapp-setup/src/main/java/fi/nls/oskari/SetupController.java
@@ -44,7 +44,12 @@ public class SetupController {
     public ModelAndView index(ModelAndView model) {
         model.setViewName("index");
         Map<String, String> map = new LinkedHashMap<>(9);
+        final String srs = getSRS();
+        model.addObject("srs", srs);
+        map.put("oskari.native.srs", srs);
+
         model.addObject(KEY_PROPERTIES, map);
+        map.put("geoserver.myplaces.url", GeoserverPopulator.getGeoserverProp(MyplacesHelper.MODULE_NAME, GeoserverPopulator.KEY_URL));
         if (DatasourceHelper.isModuleEnabled("myplaces")) {
             map.put("geoserver.myplaces.url", GeoserverPopulator.getGeoserverProp(MyplacesHelper.MODULE_NAME, GeoserverPopulator.KEY_URL));
             map.put("geoserver.myplaces.user", GeoserverPopulator.getGeoserverProp(MyplacesHelper.MODULE_NAME, GeoserverPopulator.KEY_USER));
@@ -81,8 +86,12 @@ public class SetupController {
         model.setViewName("geoserver_result");
         try {
             GeoserverPopulator.setupAll(srs);
+            final String configuredSrs = getSRS();
             model.addObject(KEY_MESSAGE, "success");
-            Map<String, Integer> ids = new HashMap<>(3);
+            Map<String, Object> ids = new HashMap<>(3);
+            if(!srs.equalsIgnoreCase(configuredSrs)) {
+                ids.put("oskari.native.srs", srs);
+            }
             model.addObject(KEY_PROPERTIES, ids);
             if (DatasourceHelper.isModuleEnabled("myplaces")) {
                 int myplacesId = GeoserverPopulator.setupMyplacesLayer(srs);
@@ -112,6 +121,10 @@ public class SetupController {
             model.addObject(KEY_MESSAGE, errorMsg);
         }
         return model;
+    }
+
+    private String getSRS() {
+        return PropertyUtil.get("oskari.native.srs", "EPSG:4326");
     }
 
 }

--- a/webapp-setup/src/main/java/fi/nls/oskari/SetupController.java
+++ b/webapp-setup/src/main/java/fi/nls/oskari/SetupController.java
@@ -1,5 +1,6 @@
 package fi.nls.oskari;
 
+import fi.nls.oskari.db.DatasourceHelper;
 import fi.nls.oskari.geoserver.AnalysisHelper;
 import fi.nls.oskari.geoserver.GeoserverPopulator;
 import fi.nls.oskari.geoserver.MyplacesHelper;
@@ -44,17 +45,22 @@ public class SetupController {
         model.setViewName("index");
         Map<String, String> map = new LinkedHashMap<>(9);
         model.addObject(KEY_PROPERTIES, map);
-        map.put("geoserver.myplaces.url", GeoserverPopulator.getGeoserverProp(MyplacesHelper.MODULE_NAME, GeoserverPopulator.KEY_URL));
-        map.put("geoserver.myplaces.user", GeoserverPopulator.getGeoserverProp(MyplacesHelper.MODULE_NAME, GeoserverPopulator.KEY_USER));
-        map.put("geoserver.myplaces.password", GeoserverPopulator.getGeoserverProp(MyplacesHelper.MODULE_NAME, GeoserverPopulator.KEY_PASSWD));
+        if (DatasourceHelper.isModuleEnabled("myplaces")) {
+            map.put("geoserver.myplaces.url", GeoserverPopulator.getGeoserverProp(MyplacesHelper.MODULE_NAME, GeoserverPopulator.KEY_URL));
+            map.put("geoserver.myplaces.user", GeoserverPopulator.getGeoserverProp(MyplacesHelper.MODULE_NAME, GeoserverPopulator.KEY_USER));
+            map.put("geoserver.myplaces.password", GeoserverPopulator.getGeoserverProp(MyplacesHelper.MODULE_NAME, GeoserverPopulator.KEY_PASSWD));
+        }
 
-        map.put("geoserver.analysis.url", GeoserverPopulator.getGeoserverProp(AnalysisHelper.MODULE_NAME, GeoserverPopulator.KEY_URL));
-        map.put("geoserver.analysis.user", GeoserverPopulator.getGeoserverProp(AnalysisHelper.MODULE_NAME, GeoserverPopulator.KEY_USER));
-        map.put("geoserver.analysis.password", GeoserverPopulator.getGeoserverProp(AnalysisHelper.MODULE_NAME, GeoserverPopulator.KEY_PASSWD));
-
-        map.put("geoserver.userlayer.url", GeoserverPopulator.getGeoserverProp(UserlayerHelper.MODULE_NAME, GeoserverPopulator.KEY_URL));
-        map.put("geoserver.userlayer.user", GeoserverPopulator.getGeoserverProp(UserlayerHelper.MODULE_NAME, GeoserverPopulator.KEY_USER));
-        map.put("geoserver.userlayer.password", GeoserverPopulator.getGeoserverProp(UserlayerHelper.MODULE_NAME, GeoserverPopulator.KEY_PASSWD));
+        if (DatasourceHelper.isModuleEnabled("analysis")) {
+            map.put("geoserver.analysis.url", GeoserverPopulator.getGeoserverProp(AnalysisHelper.MODULE_NAME, GeoserverPopulator.KEY_URL));
+            map.put("geoserver.analysis.user", GeoserverPopulator.getGeoserverProp(AnalysisHelper.MODULE_NAME, GeoserverPopulator.KEY_USER));
+            map.put("geoserver.analysis.password", GeoserverPopulator.getGeoserverProp(AnalysisHelper.MODULE_NAME, GeoserverPopulator.KEY_PASSWD));
+        }
+        if (DatasourceHelper.isModuleEnabled("userlayer")) {
+            map.put("geoserver.userlayer.url", GeoserverPopulator.getGeoserverProp(UserlayerHelper.MODULE_NAME, GeoserverPopulator.KEY_URL));
+            map.put("geoserver.userlayer.user", GeoserverPopulator.getGeoserverProp(UserlayerHelper.MODULE_NAME, GeoserverPopulator.KEY_USER));
+            map.put("geoserver.userlayer.password", GeoserverPopulator.getGeoserverProp(UserlayerHelper.MODULE_NAME, GeoserverPopulator.KEY_PASSWD));
+        }
         return model;
     }
 
@@ -78,19 +84,25 @@ public class SetupController {
             model.addObject(KEY_MESSAGE, "success");
             Map<String, Integer> ids = new HashMap<>(3);
             model.addObject(KEY_PROPERTIES, ids);
-            int myplacesId = GeoserverPopulator.setupMyplacesLayer(srs);
-            if (PropertyUtil.getOptional(PROP_MYPLACES, -1) != myplacesId) {
-                ids.put(PROP_MYPLACES, myplacesId);
+            if (DatasourceHelper.isModuleEnabled("myplaces")) {
+                int myplacesId = GeoserverPopulator.setupMyplacesLayer(srs);
+                if (PropertyUtil.getOptional(PROP_MYPLACES, -1) != myplacesId) {
+                    ids.put(PROP_MYPLACES, myplacesId);
+                }
             }
 
-            int analysisId = GeoserverPopulator.setupAnalysisLayer(srs);
-            if (PropertyUtil.getOptional(PROP_ANALYSIS, -1) != analysisId) {
-                ids.put(PROP_ANALYSIS, analysisId);
+            if (DatasourceHelper.isModuleEnabled("analysis")) {
+                int analysisId = GeoserverPopulator.setupAnalysisLayer(srs);
+                if (PropertyUtil.getOptional(PROP_ANALYSIS, -1) != analysisId) {
+                    ids.put(PROP_ANALYSIS, analysisId);
+                }
             }
 
-            int userlayerId = GeoserverPopulator.setupUserLayer(srs);
-            if (PropertyUtil.getOptional(PROP_USERLAYER, -1) != userlayerId) {
-                ids.put(PROP_USERLAYER, userlayerId);
+            if (DatasourceHelper.isModuleEnabled("userlayer")) {
+                int userlayerId = GeoserverPopulator.setupUserLayer(srs);
+                if (PropertyUtil.getOptional(PROP_USERLAYER, -1) != userlayerId) {
+                    ids.put(PROP_USERLAYER, userlayerId);
+                }
             }
 
             return model;

--- a/webapp-setup/src/main/webapp/WEB-INF/jsp/geoserver_result.jsp
+++ b/webapp-setup/src/main/webapp/WEB-INF/jsp/geoserver_result.jsp
@@ -14,6 +14,9 @@
     <c:forEach var="prop" items="${properties}">
         <li>${prop.key} = ${prop.value}</li>
     </c:forEach>
+    <c:if test="${empty properties}">
+        <li>No updates required</li>
+    </c:if>
     </ul>
 </div>
 </body>

--- a/webapp-setup/src/main/webapp/WEB-INF/jsp/index.jsp
+++ b/webapp-setup/src/main/webapp/WEB-INF/jsp/index.jsp
@@ -15,7 +15,7 @@
     </c:forEach>
     </ul>
     <form action="setup">
-        <input type="text" name="srs" value="EPSG:4326" />
+        <input type="text" name="srs" value="${srs}" />
         <input type="submit" />
     </form>
 </div>

--- a/webapp-transport/src/main/webapp/WEB-INF/web.xml
+++ b/webapp-transport/src/main/webapp/WEB-INF/web.xml
@@ -82,17 +82,6 @@
         <servlet-class>fi.nls.oskari.transport.StatusServlet</servlet-class>
     </servlet>
 
-    <servlet>
-        <display-name>HystrixMetricsStreamServlet</display-name>
-        <servlet-name>HystrixMetricsStreamServlet</servlet-name>
-        <servlet-class>com.netflix.hystrix.contrib.metrics.eventstream.HystrixMetricsStreamServlet</servlet-class>
-    </servlet>
-
-    <servlet-mapping>
-        <servlet-name>HystrixMetricsStreamServlet</servlet-name>
-        <url-pattern>/hystrix.stream</url-pattern>
-    </servlet-mapping>
-
     <servlet-mapping>
         <servlet-name>image</servlet-name>
         <url-pattern>/image/*</url-pattern>


### PR DESCRIPTION
Fix issues with the populating initial GeoServer configuration:
- SLD styles for user generated content are now successfully imported via REST
- oskariorg/oskari-docs#48 implemented on the side
- Disabled modules are not mentioned when running the auto-configuration (like analysis).
- Setup now offers configured "oskari.native.srs" as default and notifies about need for properties update if it isn't used.
- GeoServer featuretypes for user generated content are now initialized with native SRS and bounds  based on SRS so everything should work out of the box.

Includes an unrelated change to remove HystrixStreamServlet from transport. Sorry about that.