### PR TITLE
Encode complex properties as JSON in MVT tiles

### DIFF
--- a/control-mvt/src/main/java/org/oskari/control/mvt/GetLocalizedPropertyNamesHandler.java
+++ b/control-mvt/src/main/java/org/oskari/control/mvt/GetLocalizedPropertyNamesHandler.java
@@ -17,7 +17,7 @@ import org.oskari.service.util.ServiceFactory;
 import java.util.*;
 
 @OskariActionRoute("GetLocalizedPropertyNames")
-public class GetLocalizedPropertyNames extends ActionHandler {
+public class GetLocalizedPropertyNamesHandler extends ActionHandler {
 
     private PermissionHelper permissionHelper;
     private WFSLayerConfigurationService wfsLayerService;

--- a/service-mvt/pom.xml
+++ b/service-mvt/pom.xml
@@ -31,14 +31,6 @@
             <groupId>org.geotools</groupId>
             <artifactId>gt-main</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.geotools</groupId>
-            <artifactId>gt-epsg-hsql</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.geotools</groupId>
-            <artifactId>gt-geojson</artifactId>
-        </dependency>
     </dependencies>
 
 </project>

--- a/service-mvt/src/main/java/org/oskari/service/mvt/SimpleFeatureConverter.java
+++ b/service-mvt/src/main/java/org/oskari/service/mvt/SimpleFeatureConverter.java
@@ -1,7 +1,11 @@
 package org.oskari.service.mvt;
 
 import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
 
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.opengis.feature.Property;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.type.Name;
@@ -18,6 +22,7 @@ public class SimpleFeatureConverter implements IUserDataConverter {
     private static final Logger LOG = LogFactory.getLogger(SimpleFeatureConverter.class);
 
     private static final String KEY_ID = "_oid";
+    private static final String COMPLEX_PROP_PREFIX = "$";
 
     @Override
     public void addTags(Object userData, MvtLayerProps layerProps, Builder featureBuilder) {
@@ -39,27 +44,65 @@ public class SimpleFeatureConverter implements IUserDataConverter {
             }
             String prop = name.getLocalPart();
             Object value = p.getValue();
-            if (value == null) {
+
+            String mvtProp = convertPropertyNameToMVT(prop, value);
+            Object mvtValue = convertValueToMVT(value);
+            if (mvtValue == null) {
+                LOG.debug("Skipping", id + "." + prop,
+                        "could not handle class:", value.getClass());
                 continue;
             }
-            if (value instanceof BigDecimal) {
-                value = ((BigDecimal) value).doubleValue();
-            }
 
-            int valueIndex = layerProps.addValue(value);
+            int valueIndex = layerProps.addValue(mvtValue);
             if (valueIndex < 0) {
                 // Value wasn't IN (Boolean,Integer,Long,Float,Double,String)
                 // => Can't be encoded to MVT
                 // TODO: Check how dates and datetimes are handled
-                LOG.debug("Skipping", id + "." + prop,
+                LOG.warn("Skipping", id + "." + prop,
                         "value type not valid for MVT encoding, class:", value.getClass());
                 continue;
             }
 
-            int keyIndex = layerProps.addKey(prop);
+            int keyIndex = layerProps.addKey(mvtProp);
             featureBuilder.addTags(keyIndex);
             featureBuilder.addTags(valueIndex);
         }
+    }
+
+    private String convertPropertyNameToMVT(String prop, Object value) {
+        if (value == null
+                || value instanceof Boolean
+                || value instanceof Map
+                || value instanceof List) {
+            return COMPLEX_PROP_PREFIX + prop;
+        }
+        return prop;
+    }
+
+    private Object convertValueToMVT(Object value) {
+        if (value == null) {
+            return "null";
+        }
+        if (value instanceof Integer
+                || value instanceof Long
+                || value instanceof Float
+                || value instanceof Double
+                || value instanceof String) {
+            return value;
+        }
+        if (value instanceof Boolean) {
+            return (Boolean) value ? "true" : "false";
+        }
+        if (value instanceof BigDecimal) {
+            return ((BigDecimal) value).doubleValue();
+        }
+        if (value instanceof Map) {
+            return new JSONObject((Map) value).toString();
+        }
+        if (value instanceof List) {
+            return new JSONArray((List) value).toString();
+        }
+        return null;
     }
 
     private void addId(MvtLayerProps layerProps, Builder featureBuilder, String id) {

--- a/service-mvt/src/test/java/org/oskari/service/mvt/SimpleFeatureConverterTest.java
+++ b/service-mvt/src/test/java/org/oskari/service/mvt/SimpleFeatureConverterTest.java
@@ -1,0 +1,78 @@
+package org.oskari.service.mvt;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.geotools.feature.DefaultFeatureCollection;
+import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.junit.Test;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.Point;
+import com.wdtinc.mapbox_vector_tile.adapt.jts.IUserDataConverter;
+import com.wdtinc.mapbox_vector_tile.adapt.jts.JtsAdapter;
+import com.wdtinc.mapbox_vector_tile.build.MvtLayerProps;
+
+public class SimpleFeatureConverterTest {
+
+    @Test
+    public void whenFeatureHasComplexFeaturesTheyGetStringifiedToJSON() {
+        GeometryFactory gf = new GeometryFactory();
+        Point p = gf.createPoint(new Coordinate(1.0, 2.0));
+
+        double[] bbox = { 0, 0, 100, 100 };
+        SimpleFeatureTypeBuilder tBuilder = new SimpleFeatureTypeBuilder();
+        tBuilder.setName("test");
+        tBuilder.add("geom", Point.class);
+        tBuilder.add("myComplexProperty", Map.class);
+        SimpleFeatureType featureType = tBuilder.buildFeatureType();
+        SimpleFeatureBuilder fBuilder = new SimpleFeatureBuilder(featureType);
+
+        List<String> words = Arrays.asList("foo", "bar", "baz");
+        Map<String, Object> complexProperty = new HashMap<>();
+        complexProperty.put("cool-words", words);
+
+        fBuilder.set("geom", p);
+        fBuilder.set("myComplexProperty", complexProperty);
+
+        SimpleFeature f = fBuilder.buildFeature(null);
+
+        DefaultFeatureCollection fc = new DefaultFeatureCollection("test");
+        fc.add(f);
+
+        List<Geometry> mvtGeoms = SimpleFeaturesMVTEncoder.asMVTGeoms(fc, bbox, 4096, 256);
+
+        MvtLayerProps layerProps = new MvtLayerProps();
+        IUserDataConverter converter = new SimpleFeatureConverter();
+        JtsAdapter.toFeatures(mvtGeoms, layerProps, converter);
+
+        Iterator<String> keys = layerProps.getKeys().iterator();
+        Iterator<Object> vals = layerProps.getVals().iterator();
+        while (true) {
+            if (!keys.hasNext() || !vals.hasNext()) {
+                break;
+            }
+            String k = keys.next();
+            Object v = vals.next();
+            if (k.equals("$myComplexProperty")) {
+                assertTrue(v instanceof String);
+                assertEquals("{'cool-words':['foo','bar','baz']}".replace('\'', '"'), (String) v);
+                return;
+            }
+        }
+        fail();
+    }
+
+}


### PR DESCRIPTION
Encode Maps as stringified JSON Objects and Lists as stringified JSON Arrays in MVT tiles. Prepend the name of the property with a `$` character to let the decoder know this property should be handled as a special case.

