### PR TITLE
Add support for MyPlaces in GetWFSFeatures and in GetWFSVectorTile

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandler.java
@@ -83,9 +83,8 @@ public class GetWFSFeaturesHandler extends ActionHandler {
         }
 
         String id = params.getRequiredParam(ActionConstants.PARAM_ID);
-        int layerId = getLayerId(id);
         String bboxStr = params.getRequiredParam(PARAM_BBOX);
-        OskariLayer layer = findLayer(layerId, params.getUser());
+        OskariLayer layer = findLayer(id, params.getUser());
         String uuid = params.getUser().getUuid();
 
         String targetSRS = params.getHttpParam(ActionConstants.PARAM_SRS, "EPSG:3857");
@@ -111,17 +110,6 @@ public class GetWFSFeaturesHandler extends ActionHandler {
             }
         } catch (IOException e) {
             ResponseHelper.writeError(params, ERR_GEOJSON_ENCODE_FAIL);
-        }
-    }
-
-    private int getLayerId(String id) throws ActionParamsException {
-        if (myPlacesHelper.isMyPlacesLayer(id)) {
-            return myPlacesHelper.getMyPlacesLayerId();
-        }
-        try {
-            return Integer.parseInt(id);
-        } catch (NumberFormatException e) {
-            throw new ActionParamsException("Invalid id");
         }
     }
 
@@ -157,12 +145,24 @@ public class GetWFSFeaturesHandler extends ActionHandler {
         }
     }
 
-    private OskariLayer findLayer(int layerId, User user) throws ActionException {
+    private OskariLayer findLayer(String id, User user) throws ActionException {
+        int layerId = getLayerId(id);
         OskariLayer layer = permissionHelper.getLayer(layerId, user);
         if (!OskariLayer.TYPE_WFS.equals(layer.getType())) {
             throw new ActionParamsException(ERR_LAYER_TYPE_NOT_WFS);
         }
         return layer;
+    }
+
+    private int getLayerId(String id) throws ActionParamsException {
+        if (myPlacesHelper.isMyPlacesLayer(id)) {
+            return myPlacesHelper.getMyPlacesLayerId();
+        }
+        try {
+            return Integer.parseInt(id);
+        } catch (NumberFormatException e) {
+            throw new ActionParamsException("Invalid id");
+        }
     }
 
     protected SimpleFeatureCollection getFeatures(String id, String uuid, OskariLayer layer, ReferencedEnvelope bbox,

--- a/control-base/src/main/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandler.java
@@ -218,8 +218,8 @@ public class GetWFSFeaturesHandler extends ActionHandler {
         String endPoint = layer.getUrl();
         String version = layer.getVersion();
         String typeName = layer.getName();
-        String username = layer.getUsername();
-        String password = layer.getPassword();
+        String user = layer.getUsername();
+        String pass = layer.getPassword();
         // TODO: Figure out the maxFeatures from the layer
         int maxFeatures = 10000;
 
@@ -229,7 +229,7 @@ public class GetWFSFeaturesHandler extends ActionHandler {
             filter = myPlacesHelper.getFilter(categoryId, uuid, bbox);
         }
 
-        return OskariWFSClient.tryGetFeatures(endPoint, version, username, password, typeName, bbox, crs, maxFeatures, filter);
+        return OskariWFSClient.tryGetFeatures(endPoint, version, user, pass, typeName, bbox, crs, maxFeatures, filter);
     }
 
     /**

--- a/control-base/src/main/java/fi/nls/oskari/control/feature/MyPlacesWFSHelper.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/feature/MyPlacesWFSHelper.java
@@ -1,0 +1,76 @@
+package fi.nls.oskari.control.feature;
+
+import java.util.Arrays;
+
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
+import org.opengis.filter.Filter;
+import org.opengis.filter.FilterFactory;
+import org.opengis.filter.expression.Expression;
+
+import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.util.PropertyUtil;
+
+public class MyPlacesWFSHelper {
+
+    public static final String PROP_MYPLACES_BASELAYER_ID = "myplaces.baselayer.id";
+
+    private static final String PREFIX_MYPLACES = "myplaces_";
+    private static final String MYPLACES_ATTR_GEOMETRY = "oskari:geometry";
+    private static final String MYPLACES_ATTR_CATEGORY_ID = "oskari:category_id";
+    private static final String MYPLACES_ATTR_UUID = "oskari:uuid";
+    private static final String MYPLACES_ATTR_PUBLISHER_NAME = "oskari:publisher_name";
+
+    private FilterFactory ff;
+    private int myPlacesLayerId;
+
+    public MyPlacesWFSHelper() {
+        init();
+    }
+
+    public void init() {
+        this.ff = CommonFactoryFinder.getFilterFactory();
+        this.myPlacesLayerId = PropertyUtil.getOptional(PROP_MYPLACES_BASELAYER_ID, -2);
+    }
+
+    public int getMyPlacesLayerId() {
+        return myPlacesLayerId;
+    }
+
+    public boolean isMyPlacesLayer(OskariLayer layer) {
+        return layer.getId() == myPlacesLayerId;
+    }
+
+    public boolean isMyPlacesLayer(String layerId) {
+        return layerId.startsWith(PREFIX_MYPLACES);
+    }
+
+    public int getCategoryId(String layerId) {
+        return Integer.parseInt(layerId.substring(PREFIX_MYPLACES.length()));
+    }
+
+    public Filter getFilter(int categoryId, String uuid, ReferencedEnvelope bbox) {
+        Expression _categoryId = ff.property(MYPLACES_ATTR_CATEGORY_ID);
+        Expression _uuid = ff.property(MYPLACES_ATTR_UUID);
+        Expression _publisherName = ff.property(MYPLACES_ATTR_PUBLISHER_NAME);
+
+        Filter categoryIdEquals = ff.equals(_categoryId, ff.literal(categoryId));
+
+        Filter uuidEquals = ff.equals(_uuid, ff.literal(uuid));
+
+        Filter publisherNameNotNull = ff.not(ff.isNull(_publisherName));
+        Filter publisherNameNotEmpty = ff.notEqual(_publisherName, ff.literal("''"));
+        Filter publisherNameNotNullNotEmpty = ff.and(publisherNameNotNull, publisherNameNotEmpty);
+
+        Filter uuidEqualsOrPublished = ff.or(uuidEquals, publisherNameNotNullNotEmpty);
+
+        Filter bboxFilter = ff.bbox(MYPLACES_ATTR_GEOMETRY,
+                bbox.getMinX(), bbox.getMinY(),
+                bbox.getMaxX(), bbox.getMaxY(),
+                CRS.toSRS(bbox.getCoordinateReferenceSystem()));
+
+        return ff.and(Arrays.asList(categoryIdEquals, uuidEqualsOrPublished, bboxFilter));
+    }
+
+}

--- a/control-base/src/main/java/fi/nls/oskari/control/feature/MyPlacesWFSHelper.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/feature/MyPlacesWFSHelper.java
@@ -60,7 +60,7 @@ public class MyPlacesWFSHelper {
         Filter uuidEquals = ff.equals(_uuid, ff.literal(uuid));
 
         Filter publisherNameNotNull = ff.not(ff.isNull(_publisherName));
-        Filter publisherNameNotEmpty = ff.notEqual(_publisherName, ff.literal("''"));
+        Filter publisherNameNotEmpty = ff.notEqual(_publisherName, ff.literal(""));
         Filter publisherNameNotNullNotEmpty = ff.and(publisherNameNotNull, publisherNameNotEmpty);
 
         Filter uuidEqualsOrPublished = ff.or(uuidEquals, publisherNameNotNullNotEmpty);

--- a/control-base/src/test/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandlerTest.java
+++ b/control-base/src/test/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandlerTest.java
@@ -40,7 +40,7 @@ public class GetWFSFeaturesHandlerTest {
         CoordinateReferenceSystem nativeCRS = CRS.decode("EPSG:3067", true);
         Envelope envelope = new Envelope(2775356, 2875356, 8441866, 8541866);
         ReferencedEnvelope bbox = new ReferencedEnvelope(envelope, webMercator);
-        SimpleFeatureCollection sfc = handler.getFeatures(layer, bbox, nativeCRS, webMercator);
+        SimpleFeatureCollection sfc = handler.getFeatures(Integer.toString(layer.getId()), null, layer, bbox, nativeCRS, webMercator);
         CoordinateReferenceSystem actualCRS = sfc.getSchema().getGeometryDescriptor().getCoordinateReferenceSystem();
         assertTrue(CRS.equalsIgnoreMetadata(webMercator, actualCRS));
     }

--- a/control-mvt/src/main/java/org/oskari/control/mvt/GetWFSVectorTileHandler.java
+++ b/control-mvt/src/main/java/org/oskari/control/mvt/GetWFSVectorTileHandler.java
@@ -236,8 +236,8 @@ public class GetWFSVectorTileHandler extends ActionHandler {
         String endPoint = layer.getUrl();
         String version = layer.getVersion();
         String typeName = layer.getName();
-        String username = layer.getUsername();
-        String password = layer.getPassword();
+        String user = layer.getUsername();
+        String pass = layer.getPassword();
         double[] box = grid.getTileExtent(tile);
         Envelope envelope = new Envelope(box[0], box[2], box[1], box[3]);
         ReferencedEnvelope bbox = new ReferencedEnvelope(envelope, crs);
@@ -249,7 +249,7 @@ public class GetWFSVectorTileHandler extends ActionHandler {
             filter = myPlacesHelper.getFilter(categoryId, uuid, bbox);
         }
 
-        return wfsClient.tryGetFeatures(endPoint, version, username, password, typeName, bbox, crs, maxFeatures, filter);
+        return wfsClient.tryGetFeatures(endPoint, version, user, pass, typeName, bbox, crs, maxFeatures, filter);
     }
 
     public static SimpleFeatureCollection union(SimpleFeatureCollection a, SimpleFeatureCollection b) {

--- a/service-base/src/main/java/fi/nls/oskari/cache/CacheManager.java
+++ b/service-base/src/main/java/fi/nls/oskari/cache/CacheManager.java
@@ -3,6 +3,7 @@ package fi.nls.oskari.cache;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.Supplier;
 
 /**
  * Generic cache factory for Oskari.
@@ -37,13 +38,17 @@ public class CacheManager {
      * @return
      */
     public static <T> Cache<T> getCache(final String name) {
+        return getCache(name, () -> new Cache<>());
+    }
+
+    public static <T> Cache<T> getCache(final String name, final Supplier<? extends Cache<T>> supplier) {
         final Cache existing = CACHE_STORE.get(name);
         if (existing != null) {
             return existing;
         }
 
         // create a new one
-        final Cache<T> cache = new Cache<T>();
+        final Cache<T> cache = supplier.get();
         cache.setName(name);
         CACHE_STORE.put(name, cache);
         return cache;

--- a/service-base/src/main/java/fi/nls/oskari/cache/CacheManager.java
+++ b/service-base/src/main/java/fi/nls/oskari/cache/CacheManager.java
@@ -52,11 +52,11 @@ public class CacheManager {
      * @return
      */
     @SuppressWarnings("unchecked")
-    public static <T> Cache<T> getCache(final String name, final Supplier<? extends Cache<T>> supplier) {
+    public static <T1 extends Cache<T2>, T2> T1 getCache(final String name, final Supplier<T1> supplier) {
         Objects.requireNonNull(name);
         Objects.requireNonNull(supplier);
-        return (Cache<T>) CACHE_STORE.computeIfAbsent(name, __ -> {
-            Cache<T> cache = supplier.get();
+        return (T1) CACHE_STORE.computeIfAbsent(name, __ -> {
+            Cache<T2> cache = supplier.get();
             cache.setName(name);
             return cache;
         });

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/CachingWFSClient.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/CachingWFSClient.java
@@ -27,6 +27,13 @@ public class CachingWFSClient {
             String user, String pass, String typeName,
             ReferencedEnvelope bbox, CoordinateReferenceSystem crs,
             Integer maxFeatures, Filter filter) {
+        if (filter != null) {
+            // Don't cache requests with a Filter
+            return OskariWFSClient.tryGetFeatures(
+                    endPoint, version,
+                    user, pass, typeName,
+                    bbox, crs, maxFeatures, filter);
+        }
         String key = getCacheKey(endPoint, typeName, bbox, crs, maxFeatures);
         return cache.get(key, __ -> OskariWFSClient.tryGetFeatures(
                 endPoint, version,

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/CachingWFSClient.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/CachingWFSClient.java
@@ -21,8 +21,8 @@ public class CachingWFSClient {
     private final ComputeOnceCache<SimpleFeatureCollection> cache;
 
     public CachingWFSClient() {
-        cache = (ComputeOnceCache<SimpleFeatureCollection>) CacheManager.getCache(CACHE_NAME,
-                () -> new ComputeOnceCache<SimpleFeatureCollection>(CACHE_SIZE_LIMIT, CACHE_EXPIRATION));
+        cache = CacheManager.getCache(CACHE_NAME,
+                () -> new ComputeOnceCache<>(CACHE_SIZE_LIMIT, CACHE_EXPIRATION));
     }
 
     public SimpleFeatureCollection tryGetFeatures(String endPoint, String version,

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/CachingWFSClient.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/CachingWFSClient.java
@@ -2,6 +2,7 @@ package org.oskari.service.wfs.client;
 
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.opengis.filter.Filter;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 import com.vividsolutions.jts.geom.Envelope;
@@ -24,12 +25,13 @@ public class CachingWFSClient {
 
     public SimpleFeatureCollection tryGetFeatures(String endPoint, String version,
             String user, String pass, String typeName,
-            ReferencedEnvelope bbox, CoordinateReferenceSystem crs, Integer maxFeatures) {
+            ReferencedEnvelope bbox, CoordinateReferenceSystem crs,
+            Integer maxFeatures, Filter filter) {
         String key = getCacheKey(endPoint, typeName, bbox, crs, maxFeatures);
         return cache.get(key, __ -> OskariWFSClient.tryGetFeatures(
                 endPoint, version,
                 user, pass, typeName,
-                bbox, crs, maxFeatures));
+                bbox, crs, maxFeatures, filter));
     }
 
     private String getCacheKey(String endPoint, String typeName, Envelope bbox,

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/CachingWFSClient.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/CachingWFSClient.java
@@ -1,5 +1,7 @@
 package org.oskari.service.wfs.client;
 
+import java.util.concurrent.TimeUnit;
+
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.opengis.filter.Filter;
@@ -7,20 +9,20 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 import com.vividsolutions.jts.geom.Envelope;
 
+import fi.nls.oskari.cache.CacheManager;
 import fi.nls.oskari.cache.ComputeOnceCache;
 
 public class CachingWFSClient {
 
-    private static final int DEFAULT_LIMIT = 100;
+    private static final String CACHE_NAME = CachingWFSClient.class.getName();
+    private static final int CACHE_SIZE_LIMIT = 100;
+    private static final long CACHE_EXPIRATION = TimeUnit.MINUTES.toMillis(5L);
 
     private final ComputeOnceCache<SimpleFeatureCollection> cache;
 
     public CachingWFSClient() {
-        this(DEFAULT_LIMIT);
-    }
-
-    public CachingWFSClient(int cacheSize) {
-        cache = new ComputeOnceCache<>(cacheSize);
+        cache = (ComputeOnceCache<SimpleFeatureCollection>) CacheManager.getCache(CACHE_NAME,
+                () -> new ComputeOnceCache<SimpleFeatureCollection>(CACHE_SIZE_LIMIT, CACHE_EXPIRATION));
     }
 
     public SimpleFeatureCollection tryGetFeatures(String endPoint, String version,

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS110Client.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS110Client.java
@@ -2,6 +2,7 @@ package org.oskari.service.wfs.client;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
@@ -14,8 +15,11 @@ import java.util.Map;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.feature.DefaultFeatureCollection;
 import org.geotools.feature.FeatureIterator;
+import org.geotools.filter.v1_0.OGCConfiguration;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.xml.Encoder;
 import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.filter.Filter;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 import fi.nls.oskari.log.LogFactory;
@@ -37,17 +41,17 @@ public class OskariWFS110Client {
      * @return SimpleFeatureCollection containing the parsed Features, or null if all fails
      */
     public static SimpleFeatureCollection tryGetFeatures(String endPoint, String user, String pass,
-            String typeName, ReferencedEnvelope bbox, CoordinateReferenceSystem crs, Integer maxFeatures) {
+            String typeName, ReferencedEnvelope bbox, CoordinateReferenceSystem crs, Integer maxFeatures, Filter filter) {
         // First try GeoJSON
         try {
-            return getFeaturesGeoJSON(endPoint, user, pass, typeName, bbox, crs, maxFeatures);
+            return getFeaturesGeoJSON(endPoint, user, pass, typeName, bbox, crs, maxFeatures, filter);
         } catch (Exception e) {
             LOG.warn(e, "Failed to read WFS response as GeoJSON");
         }
 
         // Fallback to GML
         try {
-            return getFeaturesGML(endPoint, user, pass, typeName, bbox, crs, maxFeatures);
+            return getFeaturesGML(endPoint, user, pass, typeName, bbox, crs, maxFeatures, filter);
         } catch (Exception e) {
             LOG.warn(e, "Failed to read WFS response as GML");
         }
@@ -56,8 +60,8 @@ public class OskariWFS110Client {
     }
 
     public static SimpleFeatureCollection getFeaturesGeoJSON(String endPoint, String user, String pass,
-            String typeName, ReferencedEnvelope bbox, CoordinateReferenceSystem crs, Integer maxFeatures) throws Exception {
-        Map<String, String> query = getQueryParams(typeName, bbox, crs, maxFeatures);
+            String typeName, ReferencedEnvelope bbox, CoordinateReferenceSystem crs, Integer maxFeatures, Filter filter) throws Exception {
+        Map<String, String> query = getQueryParams(typeName, bbox, crs, maxFeatures, filter);
         query.put("OUTPUTFORMAT", "application/json");
         HttpURLConnection conn = IOHelper.getConnection(endPoint, user, pass, query);
         conn = IOHelper.followRedirect(conn, user, pass, query, MAX_REDIRECTS);
@@ -83,8 +87,8 @@ public class OskariWFS110Client {
     }
 
     public static SimpleFeatureCollection getFeaturesGML(String endPoint, String user, String pass, String typeName,
-            ReferencedEnvelope bbox, CoordinateReferenceSystem crs, Integer maxFeatures) throws Exception {
-        Map<String, String> query = getQueryParams(typeName, bbox, crs, maxFeatures);
+            ReferencedEnvelope bbox, CoordinateReferenceSystem crs, Integer maxFeatures, Filter filter) throws Exception {
+        Map<String, String> query = getQueryParams(typeName, bbox, crs, maxFeatures, filter);
         HttpURLConnection conn = IOHelper.getConnection(endPoint, user, pass, query);
         conn = IOHelper.followRedirect(conn, user, pass, query, MAX_REDIRECTS);
         if (conn.getResponseCode() != 200) {
@@ -97,14 +101,18 @@ public class OskariWFS110Client {
     }
 
     protected static Map<String, String> getQueryParams(String typeName, ReferencedEnvelope bbox,
-            CoordinateReferenceSystem crs, Integer maxFeatures) {
+            CoordinateReferenceSystem crs, Integer maxFeatures, Filter filter) {
         Map<String, String> parameters = new LinkedHashMap<>();
         parameters.put("SERVICE", "WFS");
         parameters.put("VERSION", "1.1.0");
         parameters.put("REQUEST", "GetFeature");
         parameters.put("TYPENAME", typeName);
         parameters.put("SRSNAME", crs.getIdentifiers().iterator().next().toString());
-        parameters.put("BBOX", getBBOX(bbox));
+        if (filter == null) {
+            parameters.put("BBOX", getBBOX(bbox));
+        } else {
+            parameters.put("FILTER", getFilter(filter));
+        }
         if (maxFeatures != null) {
             parameters.put("MAXFEATURES", maxFeatures.toString());
         }
@@ -124,6 +132,20 @@ public class OskariWFS110Client {
                 bbox.getMinX(), bbox.getMinY(),
                 bbox.getMaxX(), bbox.getMaxY(),
                 srsName);
+    }
+
+    protected static String getFilter(Filter filter) {
+        if (filter == null) {
+            return null;
+        }
+        try {
+            Encoder encoder = new Encoder(new OGCConfiguration());
+            encoder.setOmitXMLDeclaration(true);
+            return encoder.encodeAsString(filter, org.geotools.filter.v1_0.OGC.Filter);
+        } catch (IOException e) {
+            LOG.warn("Failed to encode filter!");
+        }
+        return null;
     }
 
 }

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS110Client.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS110Client.java
@@ -37,6 +37,11 @@ public class OskariWFS110Client {
 
     private OskariWFS110Client() {}
 
+    public static SimpleFeatureCollection tryGetFeatures(String endPoint, String user, String pass,
+            String typeName, ReferencedEnvelope bbox, CoordinateReferenceSystem crs, Integer maxFeatures) {
+        return tryGetFeatures(endPoint, user, pass, typeName, bbox, crs, maxFeatures, null);
+    }
+
     /**
      * @return SimpleFeatureCollection containing the parsed Features, or null if all fails
      */

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFSClient.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFSClient.java
@@ -2,6 +2,7 @@ package org.oskari.service.wfs.client;
 
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.opengis.filter.Filter;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 public class OskariWFSClient {
@@ -14,12 +15,13 @@ public class OskariWFSClient {
             String endPoint, String version,
             String user, String pass,
             String typeName, ReferencedEnvelope bbox,
-            CoordinateReferenceSystem crs, Integer maxFeatures) {
+            CoordinateReferenceSystem crs, Integer maxFeatures,
+            Filter filter) {
         switch (version) {
         case WFS_3_VERSION:
             return OskariWFS3Client.tryGetFeatures(endPoint, user, pass, typeName, bbox, crs, maxFeatures);
         default:
-            return OskariWFS110Client.tryGetFeatures(endPoint, user, pass, typeName, bbox, crs, maxFeatures);
+            return OskariWFS110Client.tryGetFeatures(endPoint, user, pass, typeName, bbox, crs, maxFeatures, filter);
         }
     }
 

--- a/service-wfs-client/src/test/java/org/oskari/service/wfs/client/OskariWFS110ClientTest.java
+++ b/service-wfs-client/src/test/java/org/oskari/service/wfs/client/OskariWFS110ClientTest.java
@@ -1,0 +1,26 @@
+package org.oskari.service.wfs.client;
+
+import static org.junit.Assert.assertEquals;
+
+import org.geotools.factory.CommonFactoryFinder;
+import org.junit.Test;
+import org.opengis.filter.Filter;
+import org.opengis.filter.FilterFactory;
+
+public class OskariWFS110ClientTest {
+
+    @Test
+    public void testGetFilter() {
+        FilterFactory ff = CommonFactoryFinder.getFilterFactory();
+        Filter f = ff.equals(ff.property("bar"), ff.literal("foo"));
+        String actual = OskariWFS110Client.getFilter(f);
+        String expected = "<ogc:Filter xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:gml=\"http://www.opengis.net/gml\" xmlns:ogc=\"http://www.opengis.net/ogc\">"
+                + "<ogc:PropertyIsEqualTo>"
+                + "<ogc:PropertyName>bar</ogc:PropertyName>"
+                + "<ogc:Literal>foo</ogc:Literal>"
+                + "</ogc:PropertyIsEqualTo>"
+                + "</ogc:Filter>";
+        assertEquals(expected, actual);
+    }
+
+}


### PR DESCRIPTION
The `id` parameter now accepts Strings instead of only integers in `GetWFSFeatures` and `GetWFSVectorTile` action routes. If the `id` parameter starts with `myplaces_` prefix then the part after the prefix is handled as the id of the MyPlaces category. Otherwise it is handled as previously (expecting the maplayer id as an integer).
To make this work `WFS110Client` now accepts a `Filter` that can be used for the request. If the `Filter` is set then it is used instead of the `ReferencedEnvelope bbox` when constructing the GetFeature request (so be sure to include the bounding box filter in the actual Filter if you want one to be used).
Change `ComputeOnceCache` to extend `Cache` so that the `CacheManager` can actually manage them. Also refactor how `CacheManager` works both internally and also externally by adding a `getCache(String key, Supplier<Cache>)` function to the class.