### PR TITLE
Add support for prefixes in WMTS TileMatrixLimits/TileMatrix

### DIFF
--- a/service-map/src/test/java/fi/nls/oskari/wmts/WMTSCapabilitiesParserTest.java
+++ b/service-map/src/test/java/fi/nls/oskari/wmts/WMTSCapabilitiesParserTest.java
@@ -37,9 +37,11 @@ public class WMTSCapabilitiesParserTest {
     final String capabilitiesInput_NLS = ResourceHelper.readStringResource("WMTSCapabilitiesParserTest-input-NLS.xml", this);
     final String capabilitiesInput_Tampere = ResourceHelper.readStringResource("WMTSCapabilitiesParserTest-input-tampere.xml", this);
     final String capabilitiesInput_Spain = ResourceHelper.readStringResource("WMTSCapabilitiesParserTest-input-spain.xml", this);
+    final String capabilitiesInput_IS = ResourceHelper.readStringResource("WMTSCapabilitiesParserTest-input-is.xml", this);
     final String expectedJSON_NLS = ResourceHelper.readStringResource("WMTSCapabilitiesParserTest-expected-results-NLS.json", this);
     final String expectedJSON_tampere = ResourceHelper.readStringResource("WMTSCapabilitiesParserTest-expected-results-tampere.json", this);
     final String expectedJSON_Spain = ResourceHelper.readStringResource("WMTSCapabilitiesParserTest-expected-results-spain.json", this);
+    final String expectedJSON_IS = ResourceHelper.readStringResource("WMTSCapabilitiesParserTest-expected-results-is.json", this);
 
     @Test
     public void testASDIParsing() throws Exception {
@@ -82,6 +84,14 @@ public class WMTSCapabilitiesParserTest {
         WMTSCapabilities caps = WMTSCapabilitiesParser.parseCapabilities(capabilitiesInput_Spain);
         JSONObject expected = JSONHelper.createJSONObject(expectedJSON_Spain);
         JSONObject actual = WMTSCapabilitiesParser.asJSON(caps, "http://oskari.testing.fi", "EPSG:3067");
+        compareMatrixSets(expected, actual);
+    }
+
+    @Test
+    public void testAsJSON_IS() throws Exception {
+        WMTSCapabilities caps = WMTSCapabilitiesParser.parseCapabilities(capabilitiesInput_IS);
+        JSONObject expected = JSONHelper.createJSONObject(expectedJSON_IS);
+        JSONObject actual = WMTSCapabilitiesParser.asJSON(caps, "http://oskari.testing.fi", "EPSG3057");
         compareMatrixSets(expected, actual);
     }
 

--- a/service-map/src/test/resources/fi/nls/oskari/wmts/WMTSCapabilitiesParserTest-expected-results-is.json
+++ b/service-map/src/test/resources/fi/nls/oskari/wmts/WMTSCapabilitiesParserTest-expected-results-is.json
@@ -1,0 +1,134 @@
+{"layers": [
+    {
+        "title": "LMI_Landslag",
+        "TileMatrixSetLinks": {
+            "EPSG3057": [],
+            "EPSG3857": []
+        },
+        "style": "default",
+        "name": "LMI_Landslag",
+        "tileMatrixSetId": "EPSG3057",
+        "styles": [
+            {
+                "title": "default",
+                "name": "default"
+            }
+        ],
+        "layerName": "LMI_Landslag",
+        "type": "wmtslayer",
+        "url": "http://oskari.testing.fi",
+        "formats": {
+            "available": []
+        },
+        "isQueryable": false
+    }
+], "matrixSets": {
+    "EPSG3857": {
+        "matrixIds": [
+            {
+                "topLeftCorner": {
+                    "lon": -20026376.390000,
+                    "lat":  21167033.900000
+                },
+                "identifier": "0",
+                "scaleDenominator": 25000000.00000000372529029846,
+                "tileWidth": 256,
+                "tileHeight": 256,
+                "matrixWidth": 23,
+                "matrixHeight": 23
+            },
+            {
+                "topLeftCorner": {
+                    "lon": -20026376.390000,
+                    "lat":  20091833.900000
+                },
+                "identifier": "1",
+                "scaleDenominator": 20000000.00000000000000000000,
+                "tileWidth": 256,
+                "tileHeight": 256,
+                "matrixWidth": 28,
+                "matrixHeight": 28
+            },
+            {
+                "topLeftCorner": {
+                    "lon": -20026376.390000,
+                    "lat":  20808633.900000
+                },
+                "identifier": "2",
+                "scaleDenominator": 15000000.00000000186264514923,
+                "tileWidth": 256,
+                "tileHeight": 256,
+                "matrixWidth": 38,
+                "matrixHeight": 38
+            },
+            {
+                "topLeftCorner": {
+                    "lon": -20026376.390000,
+                    "lat":  20091833.900000
+                },
+                "identifier": "3",
+                "scaleDenominator": 10000000.00000000000000000000,
+                "tileWidth": 256,
+                "tileHeight": 256,
+                "matrixWidth": 56,
+                "matrixHeight": 56
+            },
+            {
+                "topLeftCorner": {
+                    "lon": -20026376.390000,
+                    "lat":  20091833.900000
+                },
+                "identifier": "4",
+                "scaleDenominator": 5000000.00000000000000000000,
+                "tileWidth": 256,
+                "tileHeight": 256,
+                "matrixWidth": 112,
+                "matrixHeight": 112
+            }
+        ],
+        "projection": "urn:ogc:def:crs:EPSG:6.3:3857",
+        "identifier": "EPSG3857"
+    },
+    "EPSG3057": {
+        "matrixIds": [
+            {
+                "topLeftCorner": {
+                    "lon": -2350000.000000,
+                    "lat":  3976000.000000
+                },
+                "identifier": "0",
+                "scaleDenominator": 25000000.00000000372529029846,
+                "tileWidth": 256,
+                "tileHeight": 256,
+                "matrixWidth": 4,
+                "matrixHeight": 3
+            },
+            {
+                "topLeftCorner": {
+                    "lon": -2350000.000000,
+                    "lat":  2900800.000000
+                },
+                "identifier": "1",
+                "scaleDenominator": 20000000.00000000000000000000,
+                "tileWidth": 256,
+                "tileHeight": 256,
+                "matrixWidth": 4,
+                "matrixHeight": 3
+            },
+            {
+                "topLeftCorner": {
+                    "lon": -2350000.000000,
+                    "lat":  2900800.000000
+                },
+                "identifier": "2",
+                "scaleDenominator": 15000000.00000000186264514923,
+                "tileWidth": 256,
+                "tileHeight": 256,
+                "matrixWidth": 6,
+                "matrixHeight": 4
+            }
+        ],
+        "projection": "urn:ogc:def:crs:EPSG:6.3:3057",
+        "identifier": "EPSG3057"
+    }
+}}

--- a/service-map/src/test/resources/fi/nls/oskari/wmts/WMTSCapabilitiesParserTest-input-is.xml
+++ b/service-map/src/test/resources/fi/nls/oskari/wmts/WMTSCapabilitiesParserTest-input-is.xml
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Capabilities xmlns="http://www.opengis.net/wmts/1.0" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wmts/1.0 http://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd" version="1.0.0">
+  <ows:ServiceIdentification>
+    <ows:ServiceType>OGC WMTS</ows:ServiceType>
+    <ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>
+  </ows:ServiceIdentification>
+  <ows:ServiceProvider>
+    <ows:ServiceContact>
+      <ows:ContactInfo />
+    </ows:ServiceContact>
+  </ows:ServiceProvider>
+  <ows:OperationsMetadata>
+    <ows:Operation name="GetCapabilities">
+      <ows:DCP>
+        <ows:HTTP>
+          <ows:Get xlink:href="http://gis.lmi.is/mapcache/wmts?">
+            <ows:Constraint name="GetEncoding">
+              <ows:AllowedValues>
+                <ows:Value>KVP</ows:Value>
+              </ows:AllowedValues>
+            </ows:Constraint>
+          </ows:Get>
+        </ows:HTTP>
+      </ows:DCP>
+    </ows:Operation>
+    <ows:Operation name="GetTile">
+      <ows:DCP>
+        <ows:HTTP>
+          <ows:Get xlink:href="http://gis.lmi.is/mapcache/wmts?">
+            <ows:Constraint name="GetEncoding">
+              <ows:AllowedValues>
+                <ows:Value>KVP</ows:Value>
+              </ows:AllowedValues>
+            </ows:Constraint>
+          </ows:Get>
+        </ows:HTTP>
+      </ows:DCP>
+    </ows:Operation>
+    <ows:Operation name="GetFeatureInfo">
+      <ows:DCP>
+        <ows:HTTP>
+          <ows:Get xlink:href="http://gis.lmi.is/mapcache/wmts?">
+            <ows:Constraint name="GetEncoding">
+              <ows:AllowedValues>
+                <ows:Value>KVP</ows:Value>
+              </ows:AllowedValues>
+            </ows:Constraint>
+          </ows:Get>
+        </ows:HTTP>
+      </ows:DCP>
+    </ows:Operation>
+  </ows:OperationsMetadata>
+  <Contents>
+    <Layer>
+      <ows:Title>LMI_Landslag</ows:Title>
+      <ows:Identifier>LMI_Landslag</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/png</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>EPSG3057</TileMatrixSet>
+        <TileMatrixSetLimits>
+          <TileMatrixLimits>
+            <TileMatrix>EPSG3057:0</TileMatrix>
+            <MinTileRow>0</MinTileRow>
+            <MaxTileRow>2</MaxTileRow>
+            <MinTileCol>0</MinTileCol>
+            <MaxTileCol>3</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>EPSG3057:1</TileMatrix>
+            <MinTileRow>0</MinTileRow>
+            <MaxTileRow>2</MaxTileRow>
+            <MinTileCol>0</MinTileCol>
+            <MaxTileCol>3</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>EPSG3057:2</TileMatrix>
+            <MinTileRow>0</MinTileRow>
+            <MaxTileRow>3</MaxTileRow>
+            <MinTileCol>0</MinTileCol>
+            <MaxTileCol>5</MaxTileCol>
+          </TileMatrixLimits>
+        </TileMatrixSetLimits>
+      </TileMatrixSetLink>
+      <TileMatrixSetLink>
+        <TileMatrixSet>EPSG3857</TileMatrixSet>
+        <TileMatrixSetLimits>
+          <TileMatrixLimits>
+            <TileMatrix>EPSG3857:0</TileMatrix>
+            <MinTileRow>7</MinTileRow>
+            <MaxTileRow>22</MaxTileRow>
+            <MinTileCol>0</MinTileCol>
+            <MaxTileCol>20</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>EPSG3857:1</TileMatrix>
+            <MinTileRow>11</MinTileRow>
+            <MaxTileRow>27</MaxTileRow>
+            <MinTileCol>0</MinTileCol>
+            <MaxTileCol>24</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>EPSG3857:2</TileMatrix>
+            <MinTileRow>16</MinTileRow>
+            <MaxTileRow>37</MaxTileRow>
+            <MinTileCol>1</MinTileCol>
+            <MaxTileCol>31</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>EPSG3857:3</TileMatrix>
+            <MinTileRow>27</MinTileRow>
+            <MaxTileRow>55</MaxTileRow>
+            <MinTileCol>5</MinTileCol>
+            <MaxTileCol>44</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>EPSG3857:4</TileMatrix>
+            <MinTileRow>59</MinTileRow>
+            <MaxTileRow>111</MaxTileRow>
+            <MinTileCol>15</MinTileCol>
+            <MaxTileCol>84</MaxTileCol>
+          </TileMatrixLimits>
+        </TileMatrixSetLimits>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/png" resourceType="tile" template="http://gis.lmi.is/mapcache/wmts/1.0.0/LMI_Landslag/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png" />
+    </Layer>
+    <TileMatrixSet>
+      <ows:Identifier>EPSG3857</ows:Identifier>
+      <ows:BoundingBox crs="urn:ogc:def:crs:EPSG:6.3:3857">
+        <ows:LowerCorner>-20026376.390000 -20048966.100000</ows:LowerCorner>
+        <ows:UpperCorner>20026376.390000 20048966.100000</ows:UpperCorner>
+      </ows:BoundingBox>
+      <ows:SupportedCRS>urn:ogc:def:crs:EPSG:6.3:3857</ows:SupportedCRS>
+      <TileMatrix>
+        <ows:Identifier>0</ows:Identifier>
+        <ScaleDenominator>25000000.00000000372529029846</ScaleDenominator>
+        <TopLeftCorner>-20026376.390000 21167033.900000</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>23</MatrixWidth>
+        <MatrixHeight>23</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>1</ows:Identifier>
+        <ScaleDenominator>20000000.00000000000000000000</ScaleDenominator>
+        <TopLeftCorner>-20026376.390000 20091833.900000</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>28</MatrixWidth>
+        <MatrixHeight>28</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>2</ows:Identifier>
+        <ScaleDenominator>15000000.00000000186264514923</ScaleDenominator>
+        <TopLeftCorner>-20026376.390000 20808633.900000</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>38</MatrixWidth>
+        <MatrixHeight>38</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>3</ows:Identifier>
+        <ScaleDenominator>10000000.00000000000000000000</ScaleDenominator>
+        <TopLeftCorner>-20026376.390000 20091833.900000</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>56</MatrixWidth>
+        <MatrixHeight>56</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>4</ows:Identifier>
+        <ScaleDenominator>5000000.00000000000000000000</ScaleDenominator>
+        <TopLeftCorner>-20026376.390000 20091833.900000</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>112</MatrixWidth>
+        <MatrixHeight>112</MatrixHeight>
+      </TileMatrix>
+    </TileMatrixSet>
+    <TileMatrixSet>
+      <ows:Identifier>EPSG3057</ows:Identifier>
+      <ows:BoundingBox crs="urn:ogc:def:crs:EPSG:6.3:3057">
+        <ows:LowerCorner>-2350000.000000 -1400000.000000</ows:LowerCorner>
+        <ows:UpperCorner>3200000.000000 2500000.000000</ows:UpperCorner>
+      </ows:BoundingBox>
+      <ows:SupportedCRS>urn:ogc:def:crs:EPSG:6.3:3057</ows:SupportedCRS>
+      <TileMatrix>
+        <ows:Identifier>0</ows:Identifier>
+        <ScaleDenominator>25000000.00000000372529029846</ScaleDenominator>
+        <TopLeftCorner>-2350000.000000 3976000.000000</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>4</MatrixWidth>
+        <MatrixHeight>3</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>1</ows:Identifier>
+        <ScaleDenominator>20000000.00000000000000000000</ScaleDenominator>
+        <TopLeftCorner>-2350000.000000 2900800.000000</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>4</MatrixWidth>
+        <MatrixHeight>3</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>2</ows:Identifier>
+        <ScaleDenominator>15000000.00000000186264514923</ScaleDenominator>
+        <TopLeftCorner>-2350000.000000 2900800.000000</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>6</MatrixWidth>
+        <MatrixHeight>4</MatrixHeight>
+      </TileMatrix>
+    </TileMatrixSet>
+  </Contents>
+</Capabilities>


### PR DESCRIPTION
Some WMTS services prefix the TileMatrix in TileMatrixLimits with the identifier of the linked TileMatrixSet. Add support for parsing the GetCapabilities of such services.