### PR TITLE
Add support for UserLayers in GetWFSFeatures and in GetWFSVectorTile

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandler.java
@@ -56,6 +56,7 @@ public class GetWFSFeaturesHandler extends ActionHandler {
 
     private PermissionHelper permissionHelper;
     private MyPlacesWFSHelper myPlacesHelper;
+    private UserLayerWFSHelper userlayerHelper;
 
     private CoordinateReferenceSystem nativeCRS;
 
@@ -72,6 +73,9 @@ public class GetWFSFeaturesHandler extends ActionHandler {
         };
         if (myPlacesHelper == null) {
             myPlacesHelper = new MyPlacesWFSHelper();
+        }
+        if (userlayerHelper == null) {
+            userlayerHelper = new UserLayerWFSHelper();
         }
     }
 
@@ -158,6 +162,9 @@ public class GetWFSFeaturesHandler extends ActionHandler {
         if (myPlacesHelper.isMyPlacesLayer(id)) {
             return myPlacesHelper.getMyPlacesLayerId();
         }
+        if (userlayerHelper.isUserlayerLayer(id)) {
+            return userlayerHelper.getUserlayerLayerId();
+        }
         try {
             return Integer.parseInt(id);
         } catch (NumberFormatException e) {
@@ -227,6 +234,9 @@ public class GetWFSFeaturesHandler extends ActionHandler {
         if (myPlacesHelper.isMyPlacesLayer(layer)) {
             int categoryId = myPlacesHelper.getCategoryId(id);
             filter = myPlacesHelper.getFilter(categoryId, uuid, bbox);
+        } else if (userlayerHelper.isUserlayerLayer(layer)) {
+            int userlayerId = userlayerHelper.getUserlayerId(id);
+            filter = userlayerHelper.getFilter(userlayerId, uuid, bbox);
         }
 
         return OskariWFSClient.tryGetFeatures(endPoint, version, user, pass, typeName, bbox, crs, maxFeatures, filter);

--- a/control-base/src/main/java/fi/nls/oskari/control/feature/UserLayerWFSHelper.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/feature/UserLayerWFSHelper.java
@@ -1,0 +1,76 @@
+package fi.nls.oskari.control.feature;
+
+import java.util.Arrays;
+
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
+import org.opengis.filter.Filter;
+import org.opengis.filter.FilterFactory;
+import org.opengis.filter.expression.Expression;
+
+import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.util.PropertyUtil;
+
+public class UserLayerWFSHelper {
+
+    public static final String PROP_USERLAYER_BASELAYER_ID = "userlayer.baselayer.id";
+
+    private static final String PREFIX_USERLAYER = "userlayer_";
+    private static final String USERLAYER_ATTR_GEOMETRY = "oskari:geometry";
+    private static final String USERLAYER_ATTR_USER_LAYER_ID = "oskari:user_layer_id";
+    private static final String USERLAYER_ATTR_UUID = "oskari:uuid";
+    private static final String USERLAYER_ATTR_PUBLISHER_NAME = "oskari:publisher_name";
+
+    private FilterFactory ff;
+    private int userlayerLayerId;
+
+    public UserLayerWFSHelper() {
+        init();
+    }
+
+    public void init() {
+        this.ff = CommonFactoryFinder.getFilterFactory();
+        this.userlayerLayerId = PropertyUtil.getOptional(PROP_USERLAYER_BASELAYER_ID, -2);
+    }
+
+    public int getUserlayerLayerId() {
+        return userlayerLayerId;
+    }
+
+    public boolean isUserlayerLayer(OskariLayer layer) {
+        return layer.getId() == userlayerLayerId;
+    }
+
+    public boolean isUserlayerLayer(String layerId) {
+        return layerId.startsWith(PREFIX_USERLAYER);
+    }
+
+    public int getUserlayerId(String layerId) {
+        return Integer.parseInt(layerId.substring(PREFIX_USERLAYER.length()));
+    }
+
+    public Filter getFilter(int userlayerId, String uuid, ReferencedEnvelope bbox) {
+        Expression _userlayerId = ff.property(USERLAYER_ATTR_USER_LAYER_ID);
+        Expression _uuid = ff.property(USERLAYER_ATTR_UUID);
+        Expression _publisherName = ff.property(USERLAYER_ATTR_PUBLISHER_NAME);
+
+        Filter userlayerIdEquals = ff.equals(_userlayerId, ff.literal(userlayerId));
+
+        Filter uuidEquals = ff.equals(_uuid, ff.literal(uuid));
+
+        Filter publisherNameNotNull = ff.not(ff.isNull(_publisherName));
+        Filter publisherNameNotEmpty = ff.notEqual(_publisherName, ff.literal(""));
+        Filter publisherNameNotNullNotEmpty = ff.and(publisherNameNotNull, publisherNameNotEmpty);
+
+        Filter uuidEqualsOrPublished = ff.or(uuidEquals, publisherNameNotNullNotEmpty);
+
+        Filter bboxFilter = ff.bbox(USERLAYER_ATTR_GEOMETRY,
+                bbox.getMinX(), bbox.getMinY(),
+                bbox.getMaxX(), bbox.getMaxY(),
+                CRS.toSRS(bbox.getCoordinateReferenceSystem()));
+
+        return ff.and(Arrays.asList(userlayerIdEquals, uuidEqualsOrPublished, bboxFilter));
+    }
+
+}

--- a/control-base/src/main/java/fi/nls/oskari/control/feature/UserLayerWFSHelper.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/feature/UserLayerWFSHelper.java
@@ -1,13 +1,25 @@
 package fi.nls.oskari.control.feature;
 
 import java.util.Arrays;
+import java.util.Iterator;
 
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.feature.DefaultFeatureCollection;
+import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory;
 import org.opengis.filter.expression.Expression;
+
+import com.vividsolutions.jts.geom.Geometry;
 
 import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.util.PropertyUtil;
@@ -21,6 +33,7 @@ public class UserLayerWFSHelper {
     private static final String USERLAYER_ATTR_USER_LAYER_ID = "oskari:user_layer_id";
     private static final String USERLAYER_ATTR_UUID = "oskari:uuid";
     private static final String USERLAYER_ATTR_PUBLISHER_NAME = "oskari:publisher_name";
+    private static final String USERLAYER_ATTR_PROPERTY_JSON = "oskari:property_json";
 
     private FilterFactory ff;
     private int userlayerLayerId;
@@ -71,6 +84,49 @@ public class UserLayerWFSHelper {
                 CRS.toSRS(bbox.getCoordinateReferenceSystem()));
 
         return ff.and(Arrays.asList(userlayerIdEquals, uuidEqualsOrPublished, bboxFilter));
+    }
+
+    public SimpleFeatureCollection retype(SimpleFeatureCollection sfc) throws Exception {
+        SimpleFeatureBuilder builder = null;
+        DefaultFeatureCollection fc = null;
+        
+        try (SimpleFeatureIterator it = sfc.features()) {
+            while (it.hasNext()) {
+                SimpleFeature f = it.next();
+                String property_json = (String) f.getAttribute(USERLAYER_ATTR_PROPERTY_JSON);
+                Geometry geometry = (Geometry) f.getAttribute(USERLAYER_ATTR_GEOMETRY);
+                JSONObject properties = new JSONObject(property_json);
+                if (builder == null) {
+                    SimpleFeatureType type = createType(properties);
+                    builder = new SimpleFeatureBuilder(type);
+                    fc = new DefaultFeatureCollection(null, type);
+                }
+                builder.reset();
+                builder.set(USERLAYER_ATTR_GEOMETRY, geometry);
+                Iterator keys = properties.keys();
+                while (keys.hasNext()) {
+                    String key = (String) keys.next();
+                    Object obj = properties.get(key);
+                    builder.set(key, obj);
+                }
+                fc.add(builder.buildFeature(f.getID()));
+            }
+        }
+        
+        return fc;
+    }
+    
+    private SimpleFeatureType createType(JSONObject properties) throws JSONException {
+        SimpleFeatureTypeBuilder typeBuilder = new SimpleFeatureTypeBuilder();
+        typeBuilder.add(USERLAYER_ATTR_GEOMETRY, Geometry.class);
+        typeBuilder.setDefaultGeometry(USERLAYER_ATTR_GEOMETRY);
+        Iterator keys = properties.keys();
+        while (keys.hasNext()) {
+            String key = (String) keys.next();
+            Object obj = properties.get(key);
+            typeBuilder.add(key, obj.getClass());
+        }
+        return typeBuilder.buildFeatureType();
     }
 
 }

--- a/control-base/src/test/java/fi/nls/oskari/control/feature/UserLayerWFSHelperTest.java
+++ b/control-base/src/test/java/fi/nls/oskari/control/feature/UserLayerWFSHelperTest.java
@@ -1,0 +1,12 @@
+package fi.nls.oskari.control.feature;
+
+import org.junit.Test;
+
+public class UserLayerWFSHelperTest {
+    
+    @Test
+    public void test() {
+        
+    }
+
+}

--- a/control-base/src/test/java/fi/nls/oskari/control/feature/UserLayerWFSHelperTest.java
+++ b/control-base/src/test/java/fi/nls/oskari/control/feature/UserLayerWFSHelperTest.java
@@ -1,12 +1,72 @@
 package fi.nls.oskari.control.feature;
 
+import static org.junit.Assert.assertEquals;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.data.simple.SimpleFeatureIterator;
+import org.geotools.feature.DefaultFeatureCollection;
+import org.geotools.feature.FeatureIterator;
 import org.junit.Test;
+import org.opengis.feature.Property;
+import org.opengis.feature.simple.SimpleFeature;
+import org.oskari.service.wfs.client.FeatureCollectionIterator;
+
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.MultiLineString;
 
 public class UserLayerWFSHelperTest {
-    
-    @Test
-    public void test() {
-        
-    }
 
+    @Test
+    public void testRetype() throws Exception {
+        DefaultFeatureCollection original = new DefaultFeatureCollection(null, null);
+        try (InputStream in = getClass().getResourceAsStream("geojson.json");
+                Reader utf8Reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
+                FeatureIterator<SimpleFeature> it = new FeatureCollectionIterator(utf8Reader)) {
+            while (it.hasNext()) {
+                original.add(it.next());
+            }
+        }
+
+        SimpleFeature f = null;
+        SimpleFeatureCollection retyped = new UserLayerWFSHelper().retype(original);
+        try (SimpleFeatureIterator it = retyped.features()) {
+            while (it.hasNext()) {
+                SimpleFeature feature = it.next();
+                if ("vuser_layer_data.2970316".equals(feature.getID())) {
+                    f = feature;
+                    break;
+                }
+            }
+        }
+
+        assertEquals(5, f.getAttributeCount());
+        Property geometry = f.getProperty(UserLayerWFSHelper.USERLAYER_ATTR_GEOMETRY);
+        Property defaultGeometry = f.getDefaultGeometryProperty();
+        Property interpoloi = f.getProperty("INTERPOLOI");
+        Property lahdeainei = f.getProperty("LAHDEAINEI");
+        Property id = f.getProperty("ID");
+        Property laji = f.getProperty("LAJI");
+
+        assertEquals(geometry.getName().getLocalPart(), defaultGeometry.getName().getLocalPart());
+        assertEquals(Geometry.class, geometry.getType().getBinding());
+        assertEquals(MultiLineString.class, geometry.getValue().getClass());
+
+        assertEquals(Integer.class, interpoloi.getValue().getClass());
+        assertEquals(1, interpoloi.getValue());
+
+        assertEquals(String.class, lahdeainei.getValue().getClass());
+        assertEquals("0", lahdeainei.getValue());
+
+        assertEquals(Double.class, id.getValue().getClass());
+        assertEquals(1.48627129E8, ((Double) id.getValue()).doubleValue(), 1e-8);
+
+        assertEquals(String.class, laji.getValue().getClass());
+        assertEquals("696", laji.getValue());
+    }
 }

--- a/control-base/src/test/resources/fi/nls/oskari/control/feature/geojson.json
+++ b/control-base/src/test/resources/fi/nls/oskari/control/feature/geojson.json
@@ -1,0 +1,232 @@
+{
+    "type": "FeatureCollection",
+    "totalFeatures": 40938,
+    "features": [{
+        "type": "Feature",
+        "id": "vuser_layer_data.2970316",
+        "geometry": {
+            "type": "MultiLineString",
+            "coordinates": [
+                [
+                    [316125.872, 6744907.0961],
+                    [316062.693, 6744820.0691]
+                ]
+            ]
+        },
+        "geometry_name": "geometry",
+        "properties": {
+            "uuid": "e1419f41-d092-44a2-a404-c15ee3520218",
+            "user_layer_id": 6217,
+            "feature_id": "Tilat5777033552889752525.21",
+            "property_json": "{\"INTERPOLOI\":1,\"LAHDEAINEI\":\"0\",\"ID\":1.48627129E8,\"LAJI\":\"696\"}",
+            "created": "2017-04-19T06:35:59.381Z",
+            "updated": null,
+            "bbox": [316062.693, 6744820.0691, 316125.872, 6744907.0961]
+        }
+    }, {
+        "type": "Feature",
+        "id": "vuser_layer_data.2970317",
+        "geometry": {
+            "type": "MultiLineString",
+            "coordinates": [
+                [
+                    [316029.455, 6744774.6421],
+                    [316062.693, 6744820.0691]
+                ]
+            ]
+        },
+        "geometry_name": "geometry",
+        "properties": {
+            "uuid": "e1419f41-d092-44a2-a404-c15ee3520218",
+            "user_layer_id": 6217,
+            "feature_id": "Tilat5777033552889752525.22",
+            "property_json": "{\"INTERPOLOI\":1,\"LAHDEAINEI\":\"0\",\"ID\":1.48627624E8,\"LAJI\":\"696\"}",
+            "created": "2017-04-19T06:35:59.385Z",
+            "updated": null,
+            "bbox": [316029.455, 6744774.6421, 316062.693, 6744820.0691]
+        }
+    }, {
+        "type": "Feature",
+        "id": "vuser_layer_data.2970318",
+        "geometry": {
+            "type": "MultiLineString",
+            "coordinates": [
+                [
+                    [316003.157, 6744738.7011],
+                    [316029.455, 6744774.6421]
+                ]
+            ]
+        },
+        "geometry_name": "geometry",
+        "properties": {
+            "uuid": "e1419f41-d092-44a2-a404-c15ee3520218",
+            "user_layer_id": 6217,
+            "feature_id": "Tilat5777033552889752525.23",
+            "property_json": "{\"INTERPOLOI\":1,\"LAHDEAINEI\":\"0\",\"ID\":1.48627625E8,\"LAJI\":\"696\"}",
+            "created": "2017-04-19T06:35:59.388Z",
+            "updated": null,
+            "bbox": [316003.157, 6744738.7011, 316029.455, 6744774.6421]
+        }
+    }, {
+        "type": "Feature",
+        "id": "vuser_layer_data.2970319",
+        "geometry": {
+            "type": "MultiLineString",
+            "coordinates": [
+                [
+                    [315959.454, 6744678.8541],
+                    [316003.157, 6744738.7011]
+                ]
+            ]
+        },
+        "geometry_name": "geometry",
+        "properties": {
+            "uuid": "e1419f41-d092-44a2-a404-c15ee3520218",
+            "user_layer_id": 6217,
+            "feature_id": "Tilat5777033552889752525.24",
+            "property_json": "{\"INTERPOLOI\":1,\"LAHDEAINEI\":\"0\",\"ID\":1.48628218E8,\"LAJI\":\"696\"}",
+            "created": "2017-04-19T06:35:59.391Z",
+            "updated": null,
+            "bbox": [315959.454, 6744678.8541, 316003.157, 6744738.7011]
+        }
+    }, {
+        "type": "Feature",
+        "id": "vuser_layer_data.2970320",
+        "geometry": {
+            "type": "MultiLineString",
+            "coordinates": [
+                [
+                    [315959.22, 6744679.0301],
+                    [315959.454, 6744678.8541]
+                ]
+            ]
+        },
+        "geometry_name": "geometry",
+        "properties": {
+            "uuid": "e1419f41-d092-44a2-a404-c15ee3520218",
+            "user_layer_id": 6217,
+            "feature_id": "Tilat5777033552889752525.25",
+            "property_json": "{\"INTERPOLOI\":1,\"LAHDEAINEI\":\"0\",\"ID\":1.48628217E8,\"LAJI\":\"696\"}",
+            "created": "2017-04-19T06:35:59.394Z",
+            "updated": null,
+            "bbox": [315959.22, 6744678.8541, 315959.454, 6744679.0301]
+        }
+    }, {
+        "type": "Feature",
+        "id": "vuser_layer_data.2970321",
+        "geometry": {
+            "type": "MultiLineString",
+            "coordinates": [
+                [
+                    [315896.913, 6744726.1411],
+                    [315959.22, 6744679.0301]
+                ]
+            ]
+        },
+        "geometry_name": "geometry",
+        "properties": {
+            "uuid": "e1419f41-d092-44a2-a404-c15ee3520218",
+            "user_layer_id": 6217,
+            "feature_id": "Tilat5777033552889752525.26",
+            "property_json": "{\"INTERPOLOI\":1,\"LAHDEAINEI\":\"0\",\"ID\":1.48628216E8,\"LAJI\":\"696\"}",
+            "created": "2017-04-19T06:35:59.397Z",
+            "updated": null,
+            "bbox": [315896.913, 6744679.0301, 315959.22, 6744726.1411]
+        }
+    }, {
+        "type": "Feature",
+        "id": "vuser_layer_data.2970322",
+        "geometry": {
+            "type": "MultiLineString",
+            "coordinates": [
+                [
+                    [315095.387, 6747177.4161],
+                    [315060.761, 6747161.7571]
+                ]
+            ]
+        },
+        "geometry_name": "geometry",
+        "properties": {
+            "uuid": "e1419f41-d092-44a2-a404-c15ee3520218",
+            "user_layer_id": 6217,
+            "feature_id": "Tilat5777033552889752525.27",
+            "property_json": "{\"INTERPOLOI\":1,\"LAHDEAINEI\":\"0\",\"ID\":1.4859457E8,\"LAJI\":\"696\"}",
+            "created": "2017-04-19T06:35:59.399Z",
+            "updated": null,
+            "bbox": [315060.761, 6747161.7571, 315095.387, 6747177.4161]
+        }
+    }, {
+        "type": "Feature",
+        "id": "vuser_layer_data.2970323",
+        "geometry": {
+            "type": "MultiLineString",
+            "coordinates": [
+                [
+                    [315043.866, 6747199.1141],
+                    [315060.761, 6747161.7571]
+                ]
+            ]
+        },
+        "geometry_name": "geometry",
+        "properties": {
+            "uuid": "e1419f41-d092-44a2-a404-c15ee3520218",
+            "user_layer_id": 6217,
+            "feature_id": "Tilat5777033552889752525.28",
+            "property_json": "{\"INTERPOLOI\":1,\"LAHDEAINEI\":\"0\",\"ID\":1.48594568E8,\"LAJI\":\"696\"}",
+            "created": "2017-04-19T06:35:59.402Z",
+            "updated": null,
+            "bbox": [315043.866, 6747161.7571, 315060.761, 6747199.1141]
+        }
+    }, {
+        "type": "Feature",
+        "id": "vuser_layer_data.2970324",
+        "geometry": {
+            "type": "MultiLineString",
+            "coordinates": [
+                [
+                    [315043.866, 6747199.1141],
+                    [315071.2, 6747211.4761]
+                ]
+            ]
+        },
+        "geometry_name": "geometry",
+        "properties": {
+            "uuid": "e1419f41-d092-44a2-a404-c15ee3520218",
+            "user_layer_id": 6217,
+            "feature_id": "Tilat5777033552889752525.29",
+            "property_json": "{\"INTERPOLOI\":1,\"LAHDEAINEI\":\"0\",\"ID\":1.48592223E8,\"LAJI\":\"696\"}",
+            "created": "2017-04-19T06:35:59.406Z",
+            "updated": null,
+            "bbox": [315043.866, 6747199.1141, 315071.2, 6747211.4761]
+        }
+    }, {
+        "type": "Feature",
+        "id": "vuser_layer_data.2970325",
+        "geometry": {
+            "type": "MultiLineString",
+            "coordinates": [
+                [
+                    [315071.2, 6747211.4761],
+                    [315078.668, 6747209.1531]
+                ]
+            ]
+        },
+        "geometry_name": "geometry",
+        "properties": {
+            "uuid": "e1419f41-d092-44a2-a404-c15ee3520218",
+            "user_layer_id": 6217,
+            "feature_id": "Tilat5777033552889752525.30",
+            "property_json": "{\"INTERPOLOI\":1,\"LAHDEAINEI\":\"0\",\"ID\":1.48592224E8,\"LAJI\":\"696\"}",
+            "created": "2017-04-19T06:35:59.409Z",
+            "updated": null,
+            "bbox": [315071.2, 6747209.1531, 315078.668, 6747211.4761]
+        }
+    }],
+    "crs": {
+        "type": "name",
+        "properties": {
+            "name": "urn:ogc:def:crs:EPSG::3067"
+        }
+    },
+    "bbox": [315043.866, 6744678.8541, 316125.872, 6747211.4761]
+}

--- a/control-mvt/src/main/java/org/oskari/control/mvt/GetWFSVectorTileHandler.java
+++ b/control-mvt/src/main/java/org/oskari/control/mvt/GetWFSVectorTileHandler.java
@@ -34,6 +34,7 @@ import fi.nls.oskari.control.ActionHandler;
 import fi.nls.oskari.control.ActionParameters;
 import fi.nls.oskari.control.ActionParamsException;
 import fi.nls.oskari.control.feature.MyPlacesWFSHelper;
+import fi.nls.oskari.control.feature.UserLayerWFSHelper;
 import fi.nls.oskari.control.layer.PermissionHelper;
 import fi.nls.oskari.domain.User;
 import fi.nls.oskari.domain.map.OskariLayer;
@@ -60,6 +61,7 @@ public class GetWFSVectorTileHandler extends ActionHandler {
 
     private PermissionHelper permissionHelper;
     private MyPlacesWFSHelper myPlacesHelper;
+    private UserLayerWFSHelper userlayerHelper;
     private CachingWFSClient wfsClient;
 
     @Override
@@ -68,6 +70,7 @@ public class GetWFSVectorTileHandler extends ActionHandler {
                 ServiceFactory.getMapLayerService(),
                 ServiceFactory.getPermissionsService());
         this.myPlacesHelper = new MyPlacesWFSHelper();
+        this.userlayerHelper = new UserLayerWFSHelper();
         this.wfsClient = new CachingWFSClient();
     }
 
@@ -116,6 +119,9 @@ public class GetWFSVectorTileHandler extends ActionHandler {
     private int getLayerId(String id) throws ActionParamsException {
         if (myPlacesHelper.isMyPlacesLayer(id)) {
             return myPlacesHelper.getMyPlacesLayerId();
+        }
+        if (userlayerHelper.isUserlayerLayer(id)) {
+            return userlayerHelper.getUserlayerLayerId();
         }
         try {
             return Integer.parseInt(id);
@@ -247,6 +253,9 @@ public class GetWFSVectorTileHandler extends ActionHandler {
         if (myPlacesHelper.isMyPlacesLayer(layer)) {
             int categoryId = myPlacesHelper.getCategoryId(id);
             filter = myPlacesHelper.getFilter(categoryId, uuid, bbox);
+        } else if (userlayerHelper.isUserlayerLayer(layer)) {
+            int userlayerId = userlayerHelper.getUserlayerId(id);
+            filter = userlayerHelper.getFilter(userlayerId, uuid, bbox);
         }
 
         return wfsClient.tryGetFeatures(endPoint, version, user, pass, typeName, bbox, crs, maxFeatures, filter);

--- a/control-mvt/src/main/java/org/oskari/control/mvt/GetWFSVectorTileHandler.java
+++ b/control-mvt/src/main/java/org/oskari/control/mvt/GetWFSVectorTileHandler.java
@@ -232,6 +232,14 @@ public class GetWFSVectorTileHandler extends ActionHandler {
             }
             sfc = union(sfc, tileFeatures);
         }
+        
+        if (userlayerHelper.isUserlayerLayer(layer)) {
+            try {
+                sfc = userlayerHelper.retype(sfc);
+            } catch (Exception e) {
+                throw new ServiceRuntimeException("Failed to post-process user layer", e);
+            }
+        }
 
         double[] bbox = grid.getTileExtent(new TileCoord(z, x, y));
         byte[] encoded = SimpleFeaturesMVTEncoder.encodeToByteArray(sfc, layer.getName(), bbox, 4096, 256);

--- a/control-mvt/src/main/java/org/oskari/control/mvt/GetWFSVectorTileHandler.java
+++ b/control-mvt/src/main/java/org/oskari/control/mvt/GetWFSVectorTileHandler.java
@@ -69,8 +69,8 @@ public class GetWFSVectorTileHandler extends ActionHandler {
 
     @Override
     public void init() {
-        tileCache = (ComputeOnceCache<byte[]>) CacheManager.getCache(getClass().getName(),
-                () -> new ComputeOnceCache<byte[]>(CACHE_LIMIT, CACHE_EXPIRATION));
+        tileCache = CacheManager.getCache(getClass().getName(),
+                () -> new ComputeOnceCache<>(CACHE_LIMIT, CACHE_EXPIRATION));
         this.permissionHelper = new PermissionHelper(
                 ServiceFactory.getMapLayerService(),
                 ServiceFactory.getPermissionsService());


### PR DESCRIPTION
Compliments https://github.com/oskariorg/oskari-server/pull/334

In `GetWFSFeatures` and `GetWFSVectorTile` the `id` parameter now also accepts values starting with `userlayer_` where the part after the prefix is recognized as the id of the UserLayer.
In `GetWFSVectorTile` get the tile cache from `CacheManager` making it flushable to users with admin priviledges.
