### PR TITLE
Fix support for user generated content (myplaces etc) for the new WFS-client

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/feature/AbstractWFSFeaturesHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/feature/AbstractWFSFeaturesHandler.java
@@ -1,0 +1,153 @@
+package fi.nls.oskari.control.feature;
+
+import fi.nls.oskari.control.*;
+import fi.nls.oskari.control.layer.PermissionHelper;
+import fi.nls.oskari.domain.User;
+import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.service.ServiceRuntimeException;
+import fi.nls.oskari.util.PropertyUtil;
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
+import org.opengis.filter.Filter;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.oskari.service.util.ServiceFactory;
+import org.oskari.service.wfs.client.CachingWFSClient;
+import org.oskari.service.wfs3.CoordinateTransformer;
+
+
+public abstract class AbstractWFSFeaturesHandler extends ActionHandler {
+
+    private static final Logger LOG = LogFactory.getLogger(AbstractWFSFeaturesHandler.class);
+
+    protected static final String ERR_LAYER_TYPE_NOT_WFS = "Specified layer is not a WFS layer";
+    protected static final String ERR_REPOJECTION_FAIL = "Reprojection failed";
+    private static final String PROPERTY_NATIVE_SRS = "oskari.native.srs";
+
+    private PermissionHelper permissionHelper;
+    private MyPlacesWFSHelper myPlacesHelper;
+    private UserLayerWFSHelper userlayerHelper;
+
+    private CoordinateReferenceSystem nativeCRS;
+    private CachingWFSClient wfsClient;
+
+    protected void setPermissionHelper(PermissionHelper permissionHelper) {
+        this.permissionHelper = permissionHelper;
+    }
+
+    @Override
+    public void init() {
+        if (permissionHelper == null) {
+            permissionHelper = new PermissionHelper(
+                    ServiceFactory.getMapLayerService(),
+                    ServiceFactory.getPermissionsService());
+        };
+        if (myPlacesHelper == null) {
+            myPlacesHelper = new MyPlacesWFSHelper();
+        }
+        if (userlayerHelper == null) {
+            userlayerHelper = new UserLayerWFSHelper();
+        }
+        this.wfsClient = new CachingWFSClient();
+    }
+
+    @Override
+    public abstract void handleAction(ActionParameters params) throws ActionException;
+
+    protected CoordinateReferenceSystem getNativeCRS() {
+        if (nativeCRS == null) {
+            try {
+                String nativeSrs = PropertyUtil.get(PROPERTY_NATIVE_SRS, "EPSG:4326");
+                nativeCRS = CRS.decode(nativeSrs, true);
+            } catch (Exception e) {
+                LOG.error(e, "Failed to decode Native CRS!");
+            }
+        }
+        return nativeCRS;
+    }
+
+    protected OskariLayer findLayer(String id, User user) throws ActionException {
+        int layerId = getLayerId(id);
+        OskariLayer layer = permissionHelper.getLayer(layerId, user);
+        if (!OskariLayer.TYPE_WFS.equals(layer.getType())) {
+            throw new ActionParamsException(ERR_LAYER_TYPE_NOT_WFS);
+        }
+        return layer;
+    }
+
+    private int getLayerId(String id) throws ActionParamsException {
+        if (myPlacesHelper.isMyPlacesLayer(id)) {
+            return myPlacesHelper.getMyPlacesLayerId();
+        }
+        if (userlayerHelper.isUserlayerLayer(id)) {
+            return userlayerHelper.getUserlayerLayerId();
+        }
+        try {
+            return Integer.parseInt(id);
+        } catch (NumberFormatException e) {
+            throw new ActionParamsException("Invalid id");
+        }
+    }
+
+    protected SimpleFeatureCollection getFeatures(String id, String uuid, OskariLayer layer, ReferencedEnvelope bbox,
+            CoordinateReferenceSystem nativeCRS, CoordinateReferenceSystem targetCRS) throws ActionException {
+        boolean needsTransform = !CRS.equalsIgnoreMetadata(nativeCRS, targetCRS);
+
+        // Request features in nativeCRS (of the installation)
+        // Most likely supported by all WFS layers
+        ReferencedEnvelope requestBbox = bbox;
+        if (needsTransform) {
+            try {
+                requestBbox = bbox.transform(nativeCRS, true);
+            } catch (Exception e) {
+                throw new ActionException(ERR_REPOJECTION_FAIL, e);
+            }
+        }
+
+        SimpleFeatureCollection features = getFeatures(id, uuid, layer, requestBbox, nativeCRS);
+        if (!needsTransform) {
+            return features;
+        }
+
+        // Transform features to targetCRS
+        try {
+            CoordinateTransformer transformer = new CoordinateTransformer(nativeCRS, targetCRS);
+            return transformer.transform(features);
+        } catch (Exception e) {
+            throw new ActionException(ERR_REPOJECTION_FAIL, e);
+        }
+    }
+
+    protected SimpleFeatureCollection getFeatures(String id, String uuid, OskariLayer layer, ReferencedEnvelope bbox,
+            CoordinateReferenceSystem crs) {
+        String endPoint = layer.getUrl();
+        String version = layer.getVersion();
+        String typeName = layer.getName();
+        String user = layer.getUsername();
+        String pass = layer.getPassword();
+        // TODO: Figure out the maxFeatures from the layer
+        int maxFeatures = 10000;
+
+        Filter filter = null;
+        if (myPlacesHelper.isMyPlacesLayer(layer)) {
+            int categoryId = myPlacesHelper.getCategoryId(id);
+            filter = myPlacesHelper.getFilter(categoryId, uuid, bbox);
+        } else if (userlayerHelper.isUserlayerLayer(layer)) {
+            int userlayerId = userlayerHelper.getUserlayerId(id);
+            filter = userlayerHelper.getFilter(userlayerId, uuid, bbox);
+        }
+
+        SimpleFeatureCollection sfc = wfsClient.tryGetFeatures(endPoint, version, user, pass, typeName, bbox, crs, maxFeatures, filter);
+        if (userlayerHelper.isUserlayerLayer(layer)) {
+            try {
+                sfc = userlayerHelper.retype(sfc);
+            } catch (Exception e) {
+                throw new ServiceRuntimeException("Failed to post-process user layer", e);
+            }
+        }
+        return sfc;
+    }
+
+}

--- a/control-base/src/main/java/fi/nls/oskari/control/feature/AbstractWFSFeaturesHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/feature/AbstractWFSFeaturesHandler.java
@@ -53,9 +53,6 @@ public abstract class AbstractWFSFeaturesHandler extends ActionHandler {
         this.wfsClient = new CachingWFSClient();
     }
 
-    @Override
-    public abstract void handleAction(ActionParameters params) throws ActionException;
-
     protected CoordinateReferenceSystem getNativeCRS() {
         if (nativeCRS == null) {
             try {

--- a/control-base/src/main/java/fi/nls/oskari/control/feature/MyPlacesWFSHelper.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/feature/MyPlacesWFSHelper.java
@@ -53,17 +53,23 @@ public class MyPlacesWFSHelper {
     public Filter getFilter(int categoryId, String uuid, ReferencedEnvelope bbox) {
         Expression _categoryId = ff.property(MYPLACES_ATTR_CATEGORY_ID);
         Expression _uuid = ff.property(MYPLACES_ATTR_UUID);
-        Expression _publisherName = ff.property(MYPLACES_ATTR_PUBLISHER_NAME);
 
         Filter categoryIdEquals = ff.equals(_categoryId, ff.literal(categoryId));
 
         Filter uuidEquals = ff.equals(_uuid, ff.literal(uuid));
 
+/*
+// FIXME: Referencing publisher name requires the layer is oskari:my_places_categories instead of oskari:my_places
+// which brings more attributes that we want AND breaks transport
+// TODO: We might need to check if the use has right to view the layer that is not his/her own in another way
+// Leaving this logic out means that guests won't see the published user content layer
+        Expression _publisherName = ff.property(MYPLACES_ATTR_PUBLISHER_NAME);
         Filter publisherNameNotNull = ff.not(ff.isNull(_publisherName));
         Filter publisherNameNotEmpty = ff.notEqual(_publisherName, ff.literal(""));
         Filter publisherNameNotNullNotEmpty = ff.and(publisherNameNotNull, publisherNameNotEmpty);
-
         Filter uuidEqualsOrPublished = ff.or(uuidEquals, publisherNameNotNullNotEmpty);
+*/
+        Filter uuidEqualsOrPublished = uuidEquals;
 
         Filter bboxFilter = ff.bbox(MYPLACES_ATTR_GEOMETRY,
                 bbox.getMinX(), bbox.getMinY(),

--- a/control-base/src/main/java/fi/nls/oskari/control/feature/UserLayerWFSHelper.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/feature/UserLayerWFSHelper.java
@@ -67,17 +67,24 @@ public class UserLayerWFSHelper {
     public Filter getFilter(int userlayerId, String uuid, ReferencedEnvelope bbox) {
         Expression _userlayerId = ff.property(USERLAYER_ATTR_USER_LAYER_ID);
         Expression _uuid = ff.property(USERLAYER_ATTR_UUID);
-        Expression _publisherName = ff.property(USERLAYER_ATTR_PUBLISHER_NAME);
 
         Filter userlayerIdEquals = ff.equals(_userlayerId, ff.literal(userlayerId));
 
         Filter uuidEquals = ff.equals(_uuid, ff.literal(uuid));
-
+/*
+// FIXME: Referencing publisher name requires the layer is oskari:my_places_categories instead of oskari:my_places
+// which brings more attributes that we want AND breaks transport
+// TODO: We might need to check if the use has right to view the layer that is not his/her own in another way
+// Leaving this logic out means that guests won't see the published user content layer
+        Expression _publisherName = ff.property(USERLAYER_ATTR_PUBLISHER_NAME);
         Filter publisherNameNotNull = ff.not(ff.isNull(_publisherName));
         Filter publisherNameNotEmpty = ff.notEqual(_publisherName, ff.literal(""));
         Filter publisherNameNotNullNotEmpty = ff.and(publisherNameNotNull, publisherNameNotEmpty);
 
         Filter uuidEqualsOrPublished = ff.or(uuidEquals, publisherNameNotNullNotEmpty);
+ */
+
+        Filter uuidEqualsOrPublished = uuidEquals;
 
         Filter bboxFilter = ff.bbox(USERLAYER_ATTR_GEOMETRY,
                 bbox.getMinX(), bbox.getMinY(),

--- a/control-base/src/main/java/fi/nls/oskari/control/feature/UserLayerWFSHelper.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/feature/UserLayerWFSHelper.java
@@ -72,7 +72,7 @@ public class UserLayerWFSHelper {
 
         Filter uuidEquals = ff.equals(_uuid, ff.literal(uuid));
 /*
-// FIXME: Referencing publisher name requires the layer is oskari:my_places_categories instead of oskari:my_places
+// FIXME: Referencing publisher name requires the layer is oskari:user_layer_data_style instead of oskari:vuser_layer_data
 // which brings more attributes that we want AND breaks transport
 // TODO: We might need to check if the use has right to view the layer that is not his/her own in another way
 // Leaving this logic out means that guests won't see the published user content layer

--- a/control-base/src/main/java/fi/nls/oskari/control/layer/PermissionHelper.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/PermissionHelper.java
@@ -46,6 +46,10 @@ public class PermissionHelper {
         if (layer == null) {
             throw new ActionParamsException("Layer not found for id: " + layerId);
         }
+        if(layer.isInternal()) {
+            // myplaces etc don't have resources
+            return layer;
+        }
 
         // Check permissions
         final Resource resource = getResource(layer);


### PR DESCRIPTION
New base class for GetWFSFeatures and GetWFSVectorTile action routes to remove duplicated code. 

PermissionHelper now returns layer without permisssions if it's tagged as "internal" like myplaces, userlayers, analysislayers are. 

Also requires layers to be updated in the database to reference the combined view of layer/feature to make filters work properly:

    UPDATE oskari_maplayer set name = 'oskari:my_places_categories' where name = 'oskari:my_places';
    UPDATE oskari_maplayer set name = 'oskari:user_layer_data_style' where name = 'oskari:vuser_layer_data';
    UPDATE oskari_maplayer set name = 'oskari:analysis_data_style' where name = 'oskari:analysis_data';

I'll make a flyway update of this when this is ready.