### PR TITLE
Fix an issue where lazyloaded views didn't have bundles

### DIFF
--- a/service-map/src/main/resources/fi/nls/oskari/map/view/AppSetupMapper.xml
+++ b/service-map/src/main/resources/fi/nls/oskari/map/view/AppSetupMapper.xml
@@ -23,7 +23,7 @@
         <result property="isPublic" column="is_public" />
         <result property="isDefault" column="is_default" />
         <result property="metadata" column="metadata" jdbcType="VARCHAR" javaType="org.json.JSONObject" />
-        <collection property="bundles" column="id" select="getBundlesByViewId" />
+        <collection property="bundles" column="id" select="getBundlesByViewId" fetchType="eager" />
     </resultMap>
 
     <resultMap id="bundle" type="Bundle">


### PR DESCRIPTION
MyBatis defaults to lazy loading. For some reason this results https://github.com/oskariorg/oskari-server/blob/1.51.0/control-base/src/main/java/fi/nls/oskari/control/view/GetAppSetupHandler.java#L114 getting Views without Bundles on "normal" server running. When debugging the bundles are loaded so it's easy to miss.

This changes the fetchType to eager == immediate fetching of the bundles when a view is loaded.

Most visibly this fixes an issue where the GetAppSetup XHR response now again includes srsName for env.defaultApps (behavior changed when moving from Ibatis to Mybatis).