### PR TITLE
Fix querystring encoding for IOHelper

### DIFF
--- a/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
@@ -967,8 +967,8 @@ public class IOHelper {
             if (key == null || key.isEmpty()) {
                 continue;
             }
-            final String keyEnc = urlEncode(key);
-            final String valueEnc = urlEncode(value);
+            final String keyEnc = urlEncodePayload(key);
+            final String valueEnc = urlEncodePayload(value);
             if (!first) {
                 sb.append('&');
             }
@@ -996,12 +996,12 @@ public class IOHelper {
             if (key == null || key.isEmpty() || values == null || values.length == 0) {
                 continue;
             }
-            String keyEnc = urlEncode(key);
+            String keyEnc = urlEncodePayload(key);
             for (String value : values) {
                 if (value == null || value.isEmpty()) {
                     continue;
                 }
-                String valueEnc = urlEncode(value);
+                String valueEnc = urlEncodePayload(value);
                 if (!first) {
                     sb.append('&');
                 }
@@ -1012,6 +1012,23 @@ public class IOHelper {
         return sb.toString();
     }
 
+    /**
+     * Use for encoding querystring params and payload in POST
+     * @param s
+     * @return
+     */
+    public static String urlEncodePayload(String s) {
+        // URLEncoder changes white space to + that only works on application/x-www-form-urlencoded-type encoding AND needs to be used in paths
+        // For parameters etc we want to have it as %20 instead
+        // so http://domain/my path?q=my value SHOULD be encoded as -> http://domain/my+path?q=my%20value
+        return urlEncode(s).replace("+", "%20");
+    }
+
+    /**
+     * Use for encoding URLs without querystring
+     * @param s
+     * @return
+     */
     public static String urlEncode(String s) {
         try {
             return URLEncoder.encode(s, CHARSET_UTF8);

--- a/service-base/src/test/java/fi/nls/oskari/util/IOHelperTest.java
+++ b/service-base/src/test/java/fi/nls/oskari/util/IOHelperTest.java
@@ -72,7 +72,7 @@ public class IOHelperTest {
         params.remove("foo+bar");
 
         params.put("key1", "baz qux");
-        assertEquals("Space characters are replaced by '+' in form encoding", "key1=baz+qux", IOHelper.getParams(params));
+        assertEquals("Space characters are replaced by '%20' in encoding", "key1=baz%20qux", IOHelper.getParams(params));
     }
 
     @Test

--- a/service-print/src/test/java/org/oskari/print/wmts/GetTileRequestBuilderKVPTest.java
+++ b/service-print/src/test/java/org/oskari/print/wmts/GetTileRequestBuilderKVPTest.java
@@ -87,7 +87,7 @@ public class GetTileRequestBuilderKVPTest {
         String expected = "foo?SERVICE=WMTS"
                 + "&VERSION=1.0.0"
                 + "&REQUEST=GetTile"
-                + "&LAYER=foo+bar"
+                + "&LAYER=foo%20bar"
                 + "&STYLE="
                 + "&FORMAT=image%2Fpng"
                 + "&TILEMATRIXSET=ETRS-TM35FIN"


### PR DESCRIPTION
Replace + to %20 for params in urlEncode(url, params) since servers tend to accept + as space in paths but not in param values.

Fixes an issue in #334 where filter includes spaces as + characters resulting in filter-parsing errors on GeoServer.