### PR TITLE
Limit amount of requests sent to service on MVT caching

### DIFF
--- a/control-mvt/src/main/java/org/oskari/control/mvt/GetWFSVectorTileHandler.java
+++ b/control-mvt/src/main/java/org/oskari/control/mvt/GetWFSVectorTileHandler.java
@@ -114,6 +114,10 @@ public class GetWFSVectorTileHandler extends AbstractWFSFeaturesHandler {
         if (z > grid.getMaxZoom()) {
             throw new ActionParamsException("z must be <= " + grid.getMaxZoom());
         }
+        if (z < 7) {
+            // we always request features with z 8 and anything below 7 will trigger too many requests to services
+            throw new ActionParamsException("z must be > 6");
+        }
         int matrixWidthHeight = WFSTileGrid.getMatrixSize(z);
         if (x >= matrixWidthHeight) {
             throw new ActionParamsException("x must be < " + matrixWidthHeight + " (z = " + z + ")");
@@ -165,6 +169,7 @@ public class GetWFSVectorTileHandler extends AbstractWFSFeaturesHandler {
 
         List<TileCoord> wfsTiles;
         int dz = z - targetZ;
+
         if (dz < 0) {
             int d = (int) Math.pow(2, -dz);
             int targetX1 = x * d;

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/CachingWFSClient.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/CachingWFSClient.java
@@ -15,7 +15,11 @@ import fi.nls.oskari.cache.ComputeOnceCache;
 public class CachingWFSClient {
 
     private static final String CACHE_NAME = CachingWFSClient.class.getName();
-    private static final int CACHE_SIZE_LIMIT = 100;
+    // one user on z 7 will trigger about ~100 requests to the service since tiles are always loaded as z 8
+    // so this is enough for 100 users looking at different layers/areas without cache overflowing
+    // or 20 users looking at 5 wfs layers each on z 7
+    // consider using Redis for caching (how much does serialization/deserialization to GeoJSON add?)
+    private static final int CACHE_SIZE_LIMIT = 10000;
     private static final long CACHE_EXPIRATION = TimeUnit.MINUTES.toMillis(5L);
 
     private final ComputeOnceCache<SimpleFeatureCollection> cache;


### PR DESCRIPTION
Also changes the cache size from 100 to 10000 to accommodate more concurrent users. Previously the cache was overflowing on even a single request at the outer zoom levels.