### PR TITLE
Register configurable tile grid handler

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/view/modifier/bundle/LogoPluginHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/view/modifier/bundle/LogoPluginHandler.java
@@ -4,6 +4,7 @@ import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.util.JSONHelper;
 import fi.nls.oskari.util.PropertyUtil;
+import fi.nls.oskari.view.modifier.ModifierParams;
 import org.json.JSONObject;
 
 import java.util.Map;
@@ -11,7 +12,7 @@ import java.util.Map;
 /**
  * Helper for
  */
-public class LogoPluginHandler {
+public class LogoPluginHandler implements PluginHandler {
 
     private static final Logger LOGGER = LogFactory.getLogger(LogoPluginHandler.class);
     public static final String PLUGIN_NAME = "Oskari.mapframework.bundle.mapmodule.plugin.LogoPlugin";
@@ -20,21 +21,28 @@ public class LogoPluginHandler {
     public static final String KEY_MAP_URL = "mapUrlPrefix";
     public static final String KEY_TERMS_URL = "termsUrl";
 
-    public JSONObject setupLogoPluginConfig(final JSONObject originalPlugin) {
+    @Override
+    public boolean modifyPlugin(final JSONObject plugin,
+                                final ModifierParams params,
+                                final String mapSrs) {
+        return setupLogoPluginConfig(plugin);
+    }
+
+    private boolean setupLogoPluginConfig(final JSONObject originalPlugin) {
         if(originalPlugin == null) {
             LOGGER.debug("Tried to modify LogoPlugin URLS, but plugin didn't exist!");
-            return null;
+            return false;
         }
         if(!PLUGIN_NAME.equals(originalPlugin.optString(KEY_ID))) {
             LOGGER.debug("Tried to modify LogoPlugin URLS, but given JSON isn't LogoPlugin!");
-            return null;
+            return false;
         }
 
         JSONObject config = getConfig(originalPlugin);
         setupMapUrl(config);
         setupTerms(config);
 
-        return originalPlugin;
+        return true;
     }
 
     private JSONObject getConfig(JSONObject original) {

--- a/control-base/src/main/java/fi/nls/oskari/control/view/modifier/bundle/PluginHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/view/modifier/bundle/PluginHandler.java
@@ -1,0 +1,9 @@
+package fi.nls.oskari.control.view.modifier.bundle;
+
+import fi.nls.oskari.view.modifier.ModifierParams;
+import org.json.JSONObject;
+
+public interface PluginHandler {
+
+    public boolean modifyPlugin(final JSONObject plugin, final ModifierParams params, final String mapSRS);
+}

--- a/control-base/src/main/java/fi/nls/oskari/control/view/modifier/bundle/WfsLayerPluginHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/view/modifier/bundle/WfsLayerPluginHandler.java
@@ -5,12 +5,13 @@ import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.util.JSONHelper;
 import fi.nls.oskari.util.PropertyUtil;
+import fi.nls.oskari.view.modifier.ModifierParams;
 import org.json.JSONObject;
 
 /**
  *  modifier for WfsLayerPlugin config
  */
-public class WfsLayerPluginHandler {
+public class WfsLayerPluginHandler implements PluginHandler {
 
     private static final Logger LOGGER = LogFactory.getLogger(WfsLayerPluginHandler.class);
     public static final String PLUGIN_NAME = "Oskari.mapframework.bundle.mapwfs2.plugin.WfsLayerPlugin";
@@ -25,15 +26,21 @@ public class WfsLayerPluginHandler {
     private static final String PORT = PropertyUtil.getOptional("oskari.transport.port");
     private static final String PATH = PropertyUtil.getOptional("oskari.transport.url");
 
+    @Override
+    public boolean modifyPlugin(final JSONObject plugin,
+                                final ModifierParams params,
+                                final String mapSrs) {
+        return setupWfsLayerPluginConfig(plugin, params.getViewType());
+    }
 
-    public JSONObject setupWfsLayerPluginConfig(final JSONObject originalPlugin, final String viewType) {
+    private boolean setupWfsLayerPluginConfig(final JSONObject originalPlugin, final String viewType) {
         if(originalPlugin == null) {
             LOGGER.debug("Tried to modify WfsLayerPlugin, but plugin didn't exist!");
-            return null;
+            return false;
         }
         if(!PLUGIN_NAME.equals(originalPlugin.optString(KEY_ID))) {
             LOGGER.debug("Tried to modify WfsLayerPlugin, but given JSON isn't WfsLayerPlugin!");
-            return null;
+            return false;
         }
 
         JSONObject config = getConfig(originalPlugin);
@@ -50,7 +57,7 @@ public class WfsLayerPluginHandler {
         if(PATH != null && !config.has(KEY_PATH)) {
             JSONHelper.putValue(config, KEY_PATH, PATH);
         }
-        return originalPlugin;
+        return true;
     }
 
     private JSONObject getConfig(JSONObject original) {

--- a/control-base/src/test/java/fi/nls/oskari/control/view/modifier/bundle/LogoPluginHandlerTest.java
+++ b/control-base/src/test/java/fi/nls/oskari/control/view/modifier/bundle/LogoPluginHandlerTest.java
@@ -24,22 +24,23 @@ public class LogoPluginHandlerTest extends TestCase {
 
     @Test
     public void testSetupLogoPluginConfigNullValue() {
-        JSONObject modified = handler.setupLogoPluginConfig(null);
-        assertNull("Should return null if given null", modified);
+        JSONObject plugin = null;
+        boolean success = handler.modifyPlugin(plugin, null, null);
+        assertFalse("Should return false if given null", success);
     }
 
     @Test
     public void testSetupLogoPluginConfigWrongPlugin() {
         JSONObject pluginConfig = JSONHelper.createJSONObject(LogoPluginHandler.KEY_ID, "Wrong plugin");
-        JSONObject modified = handler.setupLogoPluginConfig(pluginConfig);
-        assertNull("Should return null if given wrong plugin", modified);
+        boolean success = handler.modifyPlugin(pluginConfig, null,  null);
+        assertFalse("Should return false if given wrong plugin", success);
     }
 
     @Test
     public void testSetupLogoPluginConfigNoProperties() {
         JSONObject pluginConfig = ResourceHelper.readJSONResource("LogoPluginConfig-empty.json", this);
-        JSONObject modified = handler.setupLogoPluginConfig(pluginConfig);
-        JSONTestHelper.shouldEqual(modified, ResourceHelper.readJSONResource("LogoPluginConfig-empty-expected.json", this));
+        handler.modifyPlugin(pluginConfig, null,  null);
+        JSONTestHelper.shouldEqual(pluginConfig, ResourceHelper.readJSONResource("LogoPluginConfig-empty-expected.json", this));
     }
 
     @Test
@@ -47,8 +48,8 @@ public class LogoPluginHandlerTest extends TestCase {
         PropertyUtil.addProperty("oskari.map.url", "/");
         PropertyUtil.addProperty("oskari.map.terms.url", "http://my.map.net/terms");
         JSONObject pluginConfig = ResourceHelper.readJSONResource("LogoPluginConfig-empty.json", this);
-        JSONObject modified = handler.setupLogoPluginConfig(pluginConfig);
-        JSONTestHelper.shouldEqual(modified, ResourceHelper.readJSONResource("LogoPluginConfig-expected-config-simple.json", this));
+        handler.modifyPlugin(pluginConfig, null,  null);
+        JSONTestHelper.shouldEqual(pluginConfig, ResourceHelper.readJSONResource("LogoPluginConfig-expected-config-simple.json", this));
     }
 
     @Test
@@ -58,8 +59,8 @@ public class LogoPluginHandlerTest extends TestCase {
         PropertyUtil.addProperty("oskari.map.terms.url.en", "/terms");
         PropertyUtil.addProperty("oskari.map.terms.url.fi", "/ehdot");
         JSONObject pluginConfig = ResourceHelper.readJSONResource("LogoPluginConfig-empty.json", this);
-        JSONObject modified = handler.setupLogoPluginConfig(pluginConfig);
-        JSONTestHelper.shouldEqual(modified, ResourceHelper.readJSONResource("LogoPluginConfig-expected-config-localized.json", this));
+        handler.modifyPlugin(pluginConfig, null,  null);
+        JSONTestHelper.shouldEqual(pluginConfig, ResourceHelper.readJSONResource("LogoPluginConfig-expected-config-localized.json", this));
     }
 
     @Test
@@ -71,8 +72,8 @@ public class LogoPluginHandlerTest extends TestCase {
         PropertyUtil.addProperty("oskari.map.terms.url.fi", "/ehdot");
         // this provides existing mapurl
         JSONObject pluginConfig = ResourceHelper.readJSONResource("LogoPluginConfig-existing-config.json", this);
-        JSONObject modified = handler.setupLogoPluginConfig(pluginConfig);
+        handler.modifyPlugin(pluginConfig, null,  null);
         // check that only terms url has been updated
-        JSONTestHelper.shouldEqual(modified, ResourceHelper.readJSONResource("LogoPluginConfig-existing-config-expected.json", this));
+        JSONTestHelper.shouldEqual(pluginConfig, ResourceHelper.readJSONResource("LogoPluginConfig-existing-config-expected.json", this));
     }
 }

--- a/control-mvt/src/main/java/org/oskari/control/mvt/WFSVectorLayerPluginViewModifier.java
+++ b/control-mvt/src/main/java/org/oskari/control/mvt/WFSVectorLayerPluginViewModifier.java
@@ -1,0 +1,79 @@
+package org.oskari.control.mvt;
+
+import fi.nls.oskari.control.view.modifier.bundle.PluginHandler;
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.util.JSONHelper;
+import fi.nls.oskari.view.modifier.ModifierParams;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.oskari.service.mvt.WFSTileGrid;
+import org.oskari.service.mvt.WFSTileGridProperties;
+
+/**
+ *  modifier for WfsVectorLayerPlugin config
+ */
+public class WFSVectorLayerPluginViewModifier implements PluginHandler {
+
+    private static final Logger LOGGER = LogFactory.getLogger(WFSVectorLayerPluginViewModifier.class);
+    public static final String PLUGIN_NAME = "Oskari.wfsvector.WfsVectorLayerPlugin";
+    public static final String KEY_ID = "id";
+    public static final String KEY_CONFIG = "config";
+
+    private WFSTileGridProperties tileGridProperties;
+
+    public WFSVectorLayerPluginViewModifier() {
+        tileGridProperties = new WFSTileGridProperties();
+    }
+
+    @Override
+    public boolean modifyPlugin(final JSONObject plugin,
+                                final ModifierParams params,
+                                final String mapSrs) {
+        return setupPluginConfig(plugin, mapSrs);
+    }
+
+    public boolean setupPluginConfig(JSONObject plugin, String mapSrs) {
+        if(plugin == null) {
+            LOGGER.debug("Tried to modify WfsVectorLayerPlugin, but plugin didn't exist!");
+            return false;
+        }
+        if(!PLUGIN_NAME.equals(plugin.optString(KEY_ID))) {
+            LOGGER.debug("Tried to modify WfsVectorLayerPlugin, but given JSON isn't WfsVectorLayerPlugin!");
+            return false;
+        }
+
+        WFSTileGrid tileGrid = tileGridProperties.getTileGrid(mapSrs);
+        if (tileGrid == null) {
+            return false;
+        }
+        JSONObject config = getConfig(plugin);
+        JSONArray resolutionArray = new JSONArray();
+        try {
+            for (double resolution : tileGrid.getResolutions()) {
+                resolutionArray.put(resolution);
+            }
+        }
+        catch (JSONException ex) {
+            LOGGER.debug("Tried to modify WfsVectorLayerPlugin, but could not create resolution array", ex);
+            return false;
+        }
+        JSONHelper.put(config, "resolutions", resolutionArray);
+        JSONHelper.putValue(config, "tileSize", tileGrid.getTileSize());
+        JSONHelper.putValue(config, "origin", tileGrid.getOrigin());
+
+        return false;
+    }
+
+    private JSONObject getConfig(JSONObject original) {
+        JSONObject config = original.optJSONObject(KEY_CONFIG);
+        if(config == null) {
+            config = new JSONObject();
+            JSONHelper.putValue(original, KEY_CONFIG, config);
+        }
+        return config;
+    }
+
+
+}

--- a/service-mvt/src/main/java/org/oskari/service/mvt/WFSTileGrid.java
+++ b/service-mvt/src/main/java/org/oskari/service/mvt/WFSTileGrid.java
@@ -6,6 +6,7 @@ public class WFSTileGrid {
 
     private final double originX;
     private final double originY;
+    private final double[] origin;
     private final double[] resolutions;
 
     public WFSTileGrid(double[] extent, int maxZoom) {
@@ -17,13 +18,26 @@ public class WFSTileGrid {
 
         this.originX = extent[0];
         this.originY = extent[3];
+        this.origin = new double[]{this.originX, this.originY};
 
         this.resolutions = new double[maxZoom + 1];
 
         resolutions[0] = w / TILE_SIZE;
-        for (int i = 1; i < maxZoom; i++) {
+        for (int i = 1; i <= maxZoom; i++) {
             resolutions[i] = resolutions[i - 1] / 2;
         }
+    }
+
+    public double[] getOrigin() {
+        return origin;
+    }
+
+    public double[] getResolutions() {
+        return resolutions;
+    }
+
+    public double getTileSize() {
+        return TILE_SIZE;
     }
 
     public int getMaxZoom() {

--- a/service-mvt/src/main/java/org/oskari/service/mvt/WFSTileGridProperties.java
+++ b/service-mvt/src/main/java/org/oskari/service/mvt/WFSTileGridProperties.java
@@ -1,0 +1,50 @@
+package org.oskari.service.mvt;
+
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.util.PropertyUtil;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+public class WFSTileGridProperties {
+
+    private static final Logger LOG = LogFactory.getLogger(WFSTileGridProperties.class);
+    private static final String WFS_MVT_PROPERTY_NAMESPACE = "oskari.wfs.mvt";
+
+    private Map<String, WFSTileGrid> tileGridMap;
+
+    public WFSTileGridProperties () {
+        tileGridMap = new HashMap<>();
+        final String[] srs = PropertyUtil.getCommaSeparatedList(WFS_MVT_PROPERTY_NAMESPACE + ".srs");
+        if (srs.length != 0) {
+            Arrays.stream(srs).forEach(cur -> addKnownTileGrid(cur));
+        }
+    }
+
+    private void addKnownTileGrid (String srs) {
+        String srsCode = srs.toUpperCase();
+        String srsNamespace = WFS_MVT_PROPERTY_NAMESPACE + "." + srsCode.replace("EPSG:", "");
+        try {
+            // Parse from properties file
+            String maxZoomPropName = srsNamespace + ".maxZoomLevel";
+            int maxZoomLevel = Integer.parseInt(PropertyUtil.get(maxZoomPropName));
+
+            String extentPropName = srsNamespace + ".extent";
+            final String[] extentStr = PropertyUtil.getCommaSeparatedList(extentPropName);
+            double [] extent = Arrays.stream(extentStr).mapToDouble(num -> Double.parseDouble(num)).toArray();
+
+            WFSTileGrid tileGrid = new WFSTileGrid(extent, maxZoomLevel);
+            tileGridMap.put(srsCode, tileGrid);
+        }
+        catch (Exception ex) {
+            LOG.error("Couldn't add WFS MVT tile grid: " + srs, ex);
+        }
+    }
+
+    public WFSTileGrid getTileGrid(String srs) {
+        return tileGridMap.get(srs.toUpperCase());
+    }
+
+}


### PR DESCRIPTION
Mapfull bundle handler can now register plugin handlers.
* Refactored `LogoPluginHandler` and `WfsLayerPluginHandler` to make use of the new interface.

Added a PluginHandler for WfsVectorLayerPlugin.
* Adds a tile grid to plugin config based on app setup's srs name.

Tile grids can be specified in `oskari-ext.properties` like 
```
oskari.wfs.mvt.srs=EPSG:3067, EPSG:3857
oskari.wfs.mvt.3067.extent=-548576, 6291456, 1548576, 8388608
oskari.wfs.mvt.3067.maxZoomLevel=15
oskari.wfs.mvt.3857.extent=-20037508.3427892, -20037508.3427892, 20037508.3427892, 20037508.3427892
oskari.wfs.mvt.3857.maxZoomLevel=18
```

Resolutions calculation bug fix for `z too high for layer`