### PR TITLE
Configurable wfs mvt

### DIFF
--- a/control-mvt/src/main/java/org/oskari/control/mvt/GetWFSVectorTileHandler.java
+++ b/control-mvt/src/main/java/org/oskari/control/mvt/GetWFSVectorTileHandler.java
@@ -45,6 +45,13 @@ public class GetWFSVectorTileHandler extends AbstractWFSFeaturesHandler {
     protected static final String PARAM_X = "x";
     protected static final String PARAM_Y = "y";
 
+    private static final Map<String, WFSTileGrid> KNOWN_TILE_GRIDS;
+    static {
+        KNOWN_TILE_GRIDS = new HashMap<>();
+        KNOWN_TILE_GRIDS.put("EPSG:3067", new WFSTileGrid(new double[] { -548576, 6291456, -548576 + (8192*256), 6291456 + (8192*256) }, 15));
+        KNOWN_TILE_GRIDS.put("EPSG:3857", new WFSTileGrid(new double[] { -20037508.3427892, -20037508.3427892, 20037508.3427892, 20037508.3427892 }, 18));
+    }
+
     private static final int CACHE_LIMIT = 256;
     private static final long CACHE_EXPIRATION = TimeUnit.MINUTES.toMillis(5);
 
@@ -73,7 +80,9 @@ public class GetWFSVectorTileHandler extends AbstractWFSFeaturesHandler {
 
         final OskariLayer layer = findLayer(id, params.getUser());
         final String uuid = params.getUser().getUuid();
-        final WFSTileGrid grid = tileGridProperties.getTileGrid(srs.toUpperCase());
+
+        final WFSTileGrid knownGrid = KNOWN_TILE_GRIDS.get(srs.toUpperCase());
+        final WFSTileGrid grid = knownGrid != null ? knownGrid : tileGridProperties.getTileGrid(srs.toUpperCase());
         validateTile(grid, z, x, y);
         validateScaleDenominator(layer, grid, z);
 

--- a/control-mvt/src/main/java/org/oskari/control/mvt/GetWFSVectorTileHandler.java
+++ b/control-mvt/src/main/java/org/oskari/control/mvt/GetWFSVectorTileHandler.java
@@ -81,8 +81,8 @@ public class GetWFSVectorTileHandler extends AbstractWFSFeaturesHandler {
         final OskariLayer layer = findLayer(id, params.getUser());
         final String uuid = params.getUser().getUuid();
 
-        final WFSTileGrid knownGrid = KNOWN_TILE_GRIDS.get(srs.toUpperCase());
-        final WFSTileGrid grid = knownGrid != null ? knownGrid : tileGridProperties.getTileGrid(srs.toUpperCase());
+        final WFSTileGrid gridFromProps = tileGridProperties.getTileGrid(srs.toUpperCase());
+        final WFSTileGrid grid = gridFromProps != null ? gridFromProps : KNOWN_TILE_GRIDS.get(srs.toUpperCase());
         validateTile(grid, z, x, y);
         validateScaleDenominator(layer, grid, z);
 

--- a/service-mvt/src/main/java/org/oskari/service/mvt/WFSTileGridProperties.java
+++ b/service-mvt/src/main/java/org/oskari/service/mvt/WFSTileGridProperties.java
@@ -19,11 +19,11 @@ public class WFSTileGridProperties {
         tileGridMap = new HashMap<>();
         final String[] srs = PropertyUtil.getCommaSeparatedList(WFS_MVT_PROPERTY_NAMESPACE + ".srs");
         if (srs.length != 0) {
-            Arrays.stream(srs).forEach(cur -> addKnownTileGrid(cur));
+            Arrays.stream(srs).forEach(cur -> addTileGrid(cur));
         }
     }
 
-    private void addKnownTileGrid (String srs) {
+    private void addTileGrid (String srs) {
         String srsCode = srs.toUpperCase();
         String srsNamespace = WFS_MVT_PROPERTY_NAMESPACE + "." + srsCode.replace("EPSG:", "");
         try {


### PR DESCRIPTION
Restore default tile grids so users don't have to add those to their server properties.
Use grids from the server properties when available.