### PR TITLE
Route error handling

### DIFF
--- a/service-control/src/main/java/fi/nls/oskari/control/ActionControl.java
+++ b/service-control/src/main/java/fi/nls/oskari/control/ActionControl.java
@@ -135,7 +135,6 @@ public class ActionControl {
                     throw (ActionException) ex;
                 }
                 else {
-                    ex.printStackTrace();
                     throw new ActionException("Unhandled exception occured", ex);
                 }
             } finally {

--- a/servlet-map/src/main/java/fi/nls/oskari/AjaxController.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/AjaxController.java
@@ -36,7 +36,7 @@ public class AjaxController {
         } catch (ActionParamsException e) {
             // For cases where we dont want a stack trace
             log.error("Couldn't handle action:", route, ". Message: ", e.getMessage(), ". Parameters: ", params.getRequest().getParameterMap());
-            ResponseHelper.writeError(params, e.getMessage(), HttpServletResponse.SC_NOT_IMPLEMENTED, e.getOptions());
+            ResponseHelper.writeError(params, e.getMessage(), HttpServletResponse.SC_BAD_REQUEST, e.getOptions());
         } catch (ActionDeniedException e) {
             // User tried to execute action he/she is not authorized to execute or session had expired
             if(params.getUser().isGuest()) {


### PR DESCRIPTION
- Remove extra stacktrace on error
- Respond with 400 bad request instead of 501 not implemented when route throws ActionParamsException