### PR TITLE
Fix myplaces borders with null -> '' trigger

### DIFF
--- a/content-resources/src/main/resources/flyway/myplaces/V1_0_6__fix_border_dasharray.sql
+++ b/content-resources/src/main/resources/flyway/myplaces/V1_0_6__fix_border_dasharray.sql
@@ -1,0 +1,28 @@
+-- SLD assumes that the dasharray is empty instead of null
+-- with null border is ALWAYS dash
+-- with '' solid border AND dash works properly
+
+CREATE OR REPLACE FUNCTION procedure_categories_update()
+  RETURNS TRIGGER AS
+$BODY$
+BEGIN
+    IF NEW.stroke_dasharray is Null THEN
+        NEW.stroke_dasharray = '';
+    END IF;
+    IF NEW.border_dasharray is Null THEN
+        NEW.border_dasharray = '';
+    END IF;
+	
+    RETURN NEW;
+ END;
+ $BODY$
+ LANGUAGE 'plpgsql' VOLATILE;
+
+ 
+DROP TRIGGER IF EXISTS trigger_categories_update ON categories;
+
+CREATE TRIGGER trigger_categories_update
+BEFORE INSERT OR UPDATE
+ON categories
+FOR EACH ROW
+EXECUTE PROCEDURE procedure_categories_update();


### PR DESCRIPTION
After 1.51.0 border dasharray is saved as null instead of empty string and SLD requires it to be not null to work properly. As SLD update is a manual operation this is the easiest fix for everyone as this is automatically "fixed" by the trigger.