### PR TITLE
Don't remove Point Features from MVT buffer zone

### DIFF
--- a/control-mvt/src/main/java/org/oskari/control/mvt/GetWFSVectorTileHandler.java
+++ b/control-mvt/src/main/java/org/oskari/control/mvt/GetWFSVectorTileHandler.java
@@ -50,6 +50,9 @@ public class GetWFSVectorTileHandler extends AbstractWFSFeaturesHandler {
         KNOWN_TILE_GRIDS.put("EPSG:3857", new WFSTileGrid(new double[] { -20037508.3427892, -20037508.3427892, 20037508.3427892, 20037508.3427892 }, 18));
     }
 
+    private static final int TILE_EXTENT = 4096;
+    private static final int TILE_BUFFER = 512;
+
     private static final int CACHE_LIMIT = 256;
     private static final long CACHE_EXPIRATION = TimeUnit.MINUTES.toMillis(5);
 
@@ -216,7 +219,7 @@ public class GetWFSVectorTileHandler extends AbstractWFSFeaturesHandler {
 
         // sfc always has features for z<=8 so we need to clip to smaller tiles based on requested x,y,z
         double[] bbox = grid.getTileExtent(new TileCoord(z, x, y));
-        byte[] encoded = SimpleFeaturesMVTEncoder.encodeToByteArray(sfc, layer.getName(), bbox, 4096, 256);
+        byte[] encoded = SimpleFeaturesMVTEncoder.encodeToByteArray(sfc, layer.getName(), bbox, TILE_EXTENT, TILE_BUFFER);
         try {
             return IOHelper.gzip(encoded).toByteArray();
         } catch (IOException e) {

--- a/control-mvt/src/main/java/org/oskari/control/mvt/GetWFSVectorTileHandler.java
+++ b/control-mvt/src/main/java/org/oskari/control/mvt/GetWFSVectorTileHandler.java
@@ -222,7 +222,7 @@ public class GetWFSVectorTileHandler extends AbstractWFSFeaturesHandler {
 
         // sfc always has features for z<=8 so we need to clip to smaller tiles based on requested x,y,z
         double[] bbox = grid.getTileExtent(new TileCoord(z, x, y));
-        int buffer = isPointMultipointFeaturesOnly(sfc) ? TILE_BUFFER_POINT : TILE_BUFFER;
+        int buffer = SimpleFeaturesMVTEncoder.isPointFeaturesOnly(sfc) ? TILE_BUFFER_POINT : TILE_BUFFER;
         byte[] encoded = SimpleFeaturesMVTEncoder.encodeToByteArray(sfc, layer.getName(), bbox, TILE_EXTENT, buffer);
         try {
             return IOHelper.gzip(encoded).toByteArray();
@@ -277,19 +277,6 @@ public class GetWFSVectorTileHandler extends AbstractWFSFeaturesHandler {
 
             return union;
         }
-    }
-
-    private boolean isPointMultipointFeaturesOnly(SimpleFeatureCollection fc) {
-        try (SimpleFeatureIterator it = fc.features()) {
-            while (it.hasNext()) {
-                SimpleFeature f = it.next();
-                Class<?> geomClass = f.getDefaultGeometry().getClass();
-                if (geomClass != Point.class && geomClass != MultiPoint.class) {
-                    return false;
-                }
-            }
-        }
-        return true;
     }
 
 }

--- a/service-mvt/src/main/java/org/oskari/service/mvt/SimpleFeaturesMVTEncoder.java
+++ b/service-mvt/src/main/java/org/oskari/service/mvt/SimpleFeaturesMVTEncoder.java
@@ -32,6 +32,19 @@ public class SimpleFeaturesMVTEncoder {
 
     private static final GeometryFactory GF = new GeometryFactory();
 
+    public static boolean isPointFeaturesOnly(SimpleFeatureCollection fc) {
+        try (SimpleFeatureIterator it = fc.features()) {
+            while (it.hasNext()) {
+                SimpleFeature f = it.next();
+                Class<?> geomClass = f.getDefaultGeometry().getClass();
+                if (geomClass != Point.class && geomClass != MultiPoint.class) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
     public static byte[] encodeToByteArray(SimpleFeatureCollection sfc,
             String layer, double[] bbox, int extent, int buffer) {
         return encode(sfc, layer, bbox, extent, buffer).toByteArray();
@@ -88,7 +101,7 @@ public class SimpleFeaturesMVTEncoder {
         return JtsAdapter.createTileGeom(geoms, tileEnvelope, clipEnvelope, GF,
                 new MvtLayerParams(256, extent), new GeomMinSizeFilter(6, 6)).mvtGeoms;
     }
-    */
+     */
 
     public static List<Geometry> asMVTGeoms(SimpleFeatureCollection sfc, double[] bbox, int extent, int buffer) {
         Envelope tileEnvelope = new Envelope(bbox[0], bbox[2], bbox[1], bbox[3]);
@@ -110,7 +123,7 @@ public class SimpleFeaturesMVTEncoder {
         double scaleX = (double) extent / tileEnvelope.getWidth();
         double scaleY = -((double) extent / tileEnvelope.getHeight());
         ToMVTSpace snapToGrid = new ToMVTSpace(translateX, translateY, scaleX, scaleY);
-        
+
         GeometryEditor editor = new GeometryEditor(GF);
 
         List<Geometry> mvtGeoms = new ArrayList<>();
@@ -193,7 +206,7 @@ public class SimpleFeaturesMVTEncoder {
             Coordinate c = ((Point) geom).getCoordinate();
             boolean within = c.x >= rect.getMinX() && c.x <= rect.getMaxX() && c.y >= rect.getMinY() && c.y <= rect.getMaxY();
             return within ? geom : null;
-            */
+             */
         }
 
         if (geom instanceof LineString) {
@@ -254,7 +267,7 @@ public class SimpleFeaturesMVTEncoder {
                 return geom;
             }
             return GF.createMultiPoint(Arrays.copyOf(subGeomsWithin, n));
-            */
+             */
         }
 
         if (geom instanceof MultiLineString) {

--- a/service-mvt/src/main/java/org/oskari/service/mvt/SimpleFeaturesMVTEncoder.java
+++ b/service-mvt/src/main/java/org/oskari/service/mvt/SimpleFeaturesMVTEncoder.java
@@ -32,19 +32,6 @@ public class SimpleFeaturesMVTEncoder {
 
     private static final GeometryFactory GF = new GeometryFactory();
 
-    public static boolean isPointFeaturesOnly(SimpleFeatureCollection fc) {
-        try (SimpleFeatureIterator it = fc.features()) {
-            while (it.hasNext()) {
-                SimpleFeature f = it.next();
-                Class<?> geomClass = f.getDefaultGeometry().getClass();
-                if (geomClass != Point.class && geomClass != MultiPoint.class) {
-                    return false;
-                }
-            }
-        }
-        return true;
-    }
-
     public static byte[] encodeToByteArray(SimpleFeatureCollection sfc,
             String layer, double[] bbox, int extent, int buffer) {
         return encode(sfc, layer, bbox, extent, buffer).toByteArray();

--- a/service-mvt/src/test/java/org/oskari/service/mvt/SimpleFeaturesMVTEncoderTest.java
+++ b/service-mvt/src/test/java/org/oskari/service/mvt/SimpleFeaturesMVTEncoderTest.java
@@ -2,7 +2,6 @@ package org.oskari.service.mvt;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.ByteArrayInputStream;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -20,46 +19,8 @@ import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.geom.LinearRing;
 import com.vividsolutions.jts.geom.Point;
 import com.vividsolutions.jts.geom.Polygon;
-import com.wdtinc.mapbox_vector_tile.adapt.jts.MvtReader;
-import com.wdtinc.mapbox_vector_tile.adapt.jts.TagKeyValueMapConverter;
-import com.wdtinc.mapbox_vector_tile.adapt.jts.model.JtsLayer;
-import com.wdtinc.mapbox_vector_tile.adapt.jts.model.JtsMvt;
 
 public class SimpleFeaturesMVTEncoderTest {
-
-    @Test
-    public void testIsPointFeaturesOnly() {
-        Coordinate[] ca = new Coordinate[5];
-        ca[0] = new Coordinate(-50, -50);
-        ca[1] = new Coordinate(150, -50);
-        ca[2] = new Coordinate(150, 150);
-        ca[3] = new Coordinate(-50, 150);
-        ca[4] = new Coordinate(-50, -50);
-
-        GeometryFactory gf = new GeometryFactory();
-        List<Point> points = Arrays.stream(ca)
-                .map(c -> gf.createPoint(c))
-                .collect(Collectors.toList());
-
-        SimpleFeatureTypeBuilder tBuilder = new SimpleFeatureTypeBuilder();
-        tBuilder.setName("test");
-        tBuilder.add("geom", Geometry.class);
-        SimpleFeatureType featureType = tBuilder.buildFeatureType();
-        DefaultFeatureCollection fc = new DefaultFeatureCollection("test", featureType);
-
-        SimpleFeatureBuilder fBuilder = new SimpleFeatureBuilder(featureType);
-        for (Point point : points) {
-            fBuilder.set("geom", point);
-            fc.add(fBuilder.buildFeature(null));
-        }
-
-        assertEquals(true, SimpleFeaturesMVTEncoder.isPointFeaturesOnly(fc));
-
-        fBuilder.set("geom", gf.createLineString(ca));
-        fc.add(fBuilder.buildFeature(null));
-
-        assertEquals(false, SimpleFeaturesMVTEncoder.isPointFeaturesOnly(fc));
-    }
 
     @Test
     public void pointFeaturesInBufferZoneWontBeRemoved() throws Exception {
@@ -100,45 +61,6 @@ public class SimpleFeaturesMVTEncoderTest {
 
         List<Geometry> inLargeTileNoBuffer = SimpleFeaturesMVTEncoder.asMVTGeoms(fc, largerBbox, 4096, 0);
         assertEquals(1, inLargeTileNoBuffer.size());
-    }
-
-    @Test
-    public void pointFeaturesInBufferZoneWontBeRemovedEvenIfBufferIsEnormous() throws Exception {
-        Coordinate[] ca = new Coordinate[3];
-        ca[0] = new Coordinate(-1000, -1000);
-        ca[1] = new Coordinate(1000, 1000);
-        ca[2] = new Coordinate(6000, 6000);
-
-        GeometryFactory gf = new GeometryFactory();
-        List<Point> points = Arrays.stream(ca)
-                .map(c -> gf.createPoint(c))
-                .collect(Collectors.toList());
-
-        SimpleFeatureTypeBuilder tBuilder = new SimpleFeatureTypeBuilder();
-        tBuilder.setName("test");
-        tBuilder.add("geom", Point.class);
-        SimpleFeatureType featureType = tBuilder.buildFeatureType();
-        DefaultFeatureCollection fc = new DefaultFeatureCollection("test", featureType);
-
-        SimpleFeatureBuilder fBuilder = new SimpleFeatureBuilder(featureType);
-        for (Point point : points) {
-            fBuilder.set("geom", point);
-            fc.add(fBuilder.buildFeature(null));
-        }
-
-        assertEquals(3, fc.size());
-
-        double[] bbox = { 0, 0, 4096, 4096 };
-        int extent = 4096;
-        int buffer = 2048;
-
-        List<Geometry> inTile = SimpleFeaturesMVTEncoder.asMVTGeoms(fc, bbox, extent, buffer);
-        assertEquals(3, inTile.size());
-
-        byte[] mvt = SimpleFeaturesMVTEncoder.encodeToByteArray(fc, "foo", bbox, extent, buffer);
-        JtsMvt jtsMvt = MvtReader.loadMvt(new ByteArrayInputStream(mvt), gf, new TagKeyValueMapConverter());
-        JtsLayer layer = jtsMvt.getLayer("foo");
-        assertEquals(3, layer.getGeometries().size());
     }
 
     @Test

--- a/service-mvt/src/test/java/org/oskari/service/mvt/SimpleFeaturesMVTEncoderTest.java
+++ b/service-mvt/src/test/java/org/oskari/service/mvt/SimpleFeaturesMVTEncoderTest.java
@@ -2,7 +2,9 @@ package org.oskari.service.mvt;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.geotools.feature.DefaultFeatureCollection;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
@@ -15,9 +17,52 @@ import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.geom.LinearRing;
+import com.vividsolutions.jts.geom.Point;
 import com.vividsolutions.jts.geom.Polygon;
 
 public class SimpleFeaturesMVTEncoderTest {
+
+    @Test
+    public void pointFeaturesInBufferZoneWontBeRemoved() throws Exception {
+        Coordinate[] ca = new Coordinate[5];
+        ca[0] = new Coordinate(-50, -50);
+        ca[1] = new Coordinate(150, -50);
+        ca[2] = new Coordinate(150, 150);
+        ca[3] = new Coordinate(-50, 150);
+        ca[4] = new Coordinate(-50, -50);
+
+        GeometryFactory gf = new GeometryFactory();
+        List<Point> points = Arrays.stream(ca)
+                .map(c -> gf.createPoint(c))
+                .collect(Collectors.toList());
+
+        double[] bbox = { 0, 0, 100, 100 };
+        double[] largerBbox = { 0, 0, 4096, 4096 };
+
+        SimpleFeatureTypeBuilder tBuilder = new SimpleFeatureTypeBuilder();
+        tBuilder.setName("test");
+        tBuilder.add("geom", Point.class);
+        SimpleFeatureType featureType = tBuilder.buildFeatureType();
+        DefaultFeatureCollection fc = new DefaultFeatureCollection("test", featureType);
+
+        SimpleFeatureBuilder fBuilder = new SimpleFeatureBuilder(featureType);
+        for (Point point : points) {
+            fBuilder.set("geom", point);
+            fc.add(fBuilder.buildFeature(null));
+        }
+
+        assertEquals(5, fc.size());
+
+        List<Geometry> inTile = SimpleFeaturesMVTEncoder.asMVTGeoms(fc, bbox, 4096, 256);
+        assertEquals(0, inTile.size());
+
+        List<Geometry> inLargeTile = SimpleFeaturesMVTEncoder.asMVTGeoms(fc, largerBbox, 4096, 256);
+        assertEquals(5, inLargeTile.size());
+
+        List<Geometry> inLargeTileNoBuffer = SimpleFeaturesMVTEncoder.asMVTGeoms(fc, largerBbox, 4096, 0);
+        assertEquals(1, inLargeTileNoBuffer.size());
+
+    }
 
     @Test
     public void whenFeaturePolygonFullyContainsTileExtentThenFeatureIsAccepted() {

--- a/service-mvt/src/test/java/org/oskari/service/mvt/SimpleFeaturesMVTEncoderTest.java
+++ b/service-mvt/src/test/java/org/oskari/service/mvt/SimpleFeaturesMVTEncoderTest.java
@@ -2,6 +2,7 @@ package org.oskari.service.mvt;
 
 import static org.junit.Assert.assertEquals;
 
+import java.io.ByteArrayInputStream;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -19,8 +20,46 @@ import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.geom.LinearRing;
 import com.vividsolutions.jts.geom.Point;
 import com.vividsolutions.jts.geom.Polygon;
+import com.wdtinc.mapbox_vector_tile.adapt.jts.MvtReader;
+import com.wdtinc.mapbox_vector_tile.adapt.jts.TagKeyValueMapConverter;
+import com.wdtinc.mapbox_vector_tile.adapt.jts.model.JtsLayer;
+import com.wdtinc.mapbox_vector_tile.adapt.jts.model.JtsMvt;
 
 public class SimpleFeaturesMVTEncoderTest {
+
+    @Test
+    public void testIsPointFeaturesOnly() {
+        Coordinate[] ca = new Coordinate[5];
+        ca[0] = new Coordinate(-50, -50);
+        ca[1] = new Coordinate(150, -50);
+        ca[2] = new Coordinate(150, 150);
+        ca[3] = new Coordinate(-50, 150);
+        ca[4] = new Coordinate(-50, -50);
+
+        GeometryFactory gf = new GeometryFactory();
+        List<Point> points = Arrays.stream(ca)
+                .map(c -> gf.createPoint(c))
+                .collect(Collectors.toList());
+
+        SimpleFeatureTypeBuilder tBuilder = new SimpleFeatureTypeBuilder();
+        tBuilder.setName("test");
+        tBuilder.add("geom", Geometry.class);
+        SimpleFeatureType featureType = tBuilder.buildFeatureType();
+        DefaultFeatureCollection fc = new DefaultFeatureCollection("test", featureType);
+
+        SimpleFeatureBuilder fBuilder = new SimpleFeatureBuilder(featureType);
+        for (Point point : points) {
+            fBuilder.set("geom", point);
+            fc.add(fBuilder.buildFeature(null));
+        }
+
+        assertEquals(true, SimpleFeaturesMVTEncoder.isPointFeaturesOnly(fc));
+
+        fBuilder.set("geom", gf.createLineString(ca));
+        fc.add(fBuilder.buildFeature(null));
+
+        assertEquals(false, SimpleFeaturesMVTEncoder.isPointFeaturesOnly(fc));
+    }
 
     @Test
     public void pointFeaturesInBufferZoneWontBeRemoved() throws Exception {
@@ -61,7 +100,45 @@ public class SimpleFeaturesMVTEncoderTest {
 
         List<Geometry> inLargeTileNoBuffer = SimpleFeaturesMVTEncoder.asMVTGeoms(fc, largerBbox, 4096, 0);
         assertEquals(1, inLargeTileNoBuffer.size());
+    }
 
+    @Test
+    public void pointFeaturesInBufferZoneWontBeRemovedEvenIfBufferIsEnormous() throws Exception {
+        Coordinate[] ca = new Coordinate[3];
+        ca[0] = new Coordinate(-1000, -1000);
+        ca[1] = new Coordinate(1000, 1000);
+        ca[2] = new Coordinate(6000, 6000);
+
+        GeometryFactory gf = new GeometryFactory();
+        List<Point> points = Arrays.stream(ca)
+                .map(c -> gf.createPoint(c))
+                .collect(Collectors.toList());
+
+        SimpleFeatureTypeBuilder tBuilder = new SimpleFeatureTypeBuilder();
+        tBuilder.setName("test");
+        tBuilder.add("geom", Point.class);
+        SimpleFeatureType featureType = tBuilder.buildFeatureType();
+        DefaultFeatureCollection fc = new DefaultFeatureCollection("test", featureType);
+
+        SimpleFeatureBuilder fBuilder = new SimpleFeatureBuilder(featureType);
+        for (Point point : points) {
+            fBuilder.set("geom", point);
+            fc.add(fBuilder.buildFeature(null));
+        }
+
+        assertEquals(3, fc.size());
+
+        double[] bbox = { 0, 0, 4096, 4096 };
+        int extent = 4096;
+        int buffer = 2048;
+
+        List<Geometry> inTile = SimpleFeaturesMVTEncoder.asMVTGeoms(fc, bbox, extent, buffer);
+        assertEquals(3, inTile.size());
+
+        byte[] mvt = SimpleFeaturesMVTEncoder.encodeToByteArray(fc, "foo", bbox, extent, buffer);
+        JtsMvt jtsMvt = MvtReader.loadMvt(new ByteArrayInputStream(mvt), gf, new TagKeyValueMapConverter());
+        JtsLayer layer = jtsMvt.getLayer("foo");
+        assertEquals(3, layer.getGeometries().size());
     }
 
     @Test


### PR DESCRIPTION
Reduces clipping when drawing Point/MultiPoint features as (text) labels and/or symbols.