### PR TITLE
Use referer to detect where to take the user after login

### DIFF
--- a/servlet-map/src/main/java/fi/nls/oskari/spring/security/database/OskariAuthenticationSuccessHandler.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/spring/security/database/OskariAuthenticationSuccessHandler.java
@@ -17,6 +17,10 @@ import java.io.IOException;
 public class OskariAuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
     private Logger log = LogFactory.getLogger(OskariAuthenticationSuccessHandler.class);
     private OskariUserHelper helper = new OskariUserHelper();
+    public OskariAuthenticationSuccessHandler() {
+        super();
+        setUseReferer(true);
+    }
 
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication)
             throws IOException, javax.servlet.ServletException {


### PR DESCRIPTION
This makes login redirect the user back to the page the login form was submitted from instead of the geoportal. This can be used to  for example enable login form on embedded maps.