### PR TITLE
Enable component scan for org.oskari.* packages

### DIFF
--- a/servlet-map/src/main/java/fi/nls/oskari/spring/SpringConfig.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/spring/SpringConfig.java
@@ -43,7 +43,7 @@ import java.util.Locale;
 @EnableWebMvc
 @ComponentScan(
         excludeFilters = @ComponentScan.Filter(type= FilterType.ASSIGNABLE_TYPE, value={SpringConfig.class}),
-        basePackages="fi.nls.oskari")
+        basePackages="fi.nls.oskari, org.oskari")
 public class SpringConfig extends WebMvcConfigurerAdapter implements ApplicationListener<ContextRefreshedEvent> {
 
     private static final Logger LOG = LogFactory.getLogger(SpringConfig.class);


### PR DESCRIPTION
So applications built on top of Oskari don't have to use fi.nls.oskari package for Spring configs. Now also org.oskari is available.