### PR TITLE
MVT cache z-level

### DIFF
--- a/service-mvt/src/main/java/org/oskari/service/mvt/WFSTileGrid.java
+++ b/service-mvt/src/main/java/org/oskari/service/mvt/WFSTileGrid.java
@@ -3,7 +3,6 @@ package org.oskari.service.mvt;
 public class WFSTileGrid {
 
     public static final int TILE_SIZE = 256;
-
     private final double originX;
     private final double originY;
     private final double[] origin;
@@ -70,9 +69,9 @@ public class WFSTileGrid {
                 case -1:
                     return z - 1;
                 case  0:
-                    double dcurr = Math.abs(resolutions[z - 1] - resolution);
-                    double dnext = Math.abs(resolutions[z] - resolution);
-                    return dcurr < dnext ? z : z + 1;
+                    double dcurr = Math.abs(resolutions[z] - resolution);
+                    double dprev = Math.abs(resolutions[z - 1] - resolution);
+                    return dcurr < dprev ? z : z - 1;
                 case  1:
                     return z;
                 }


### PR DESCRIPTION
Calculate cache z-level based on tile size in nature instead of using fixed 8 level. For EPSG:3067 tileSize 8192 gives cache z = 8 and minzoom = 7.

Changed getZForResolution 0 direction return current or previous z-level.