### PR TITLE
Reduce clipping in MVT (Point) features

### DIFF
--- a/control-mvt/src/main/java/org/oskari/control/mvt/GetWFSVectorTileHandler.java
+++ b/control-mvt/src/main/java/org/oskari/control/mvt/GetWFSVectorTileHandler.java
@@ -44,6 +44,11 @@ public class GetWFSVectorTileHandler extends AbstractWFSFeaturesHandler {
     protected static final String PARAM_X = "x";
     protected static final String PARAM_Y = "y";
 
+    // Resolution (metres per px) we are aiming for with the WFS requests
+    // This value is used to find the zoom level that is closest to the resolution specified here
+    // For ETRS-TME35FIN TileGrid this translates to z=8
+    private static final int TARGET_ZOOM_LEVEL_RESOLUTION = 8192 / 256;
+
     private static final int DEFAULT_CACHE_ZOOM_LEVEL = 8;
     private static final int MIN_ZOOM_OVER_CACHE_ZOOM = 1;
     private static final Map<String, WFSTileGrid> KNOWN_TILE_GRIDS;
@@ -56,7 +61,6 @@ public class GetWFSVectorTileHandler extends AbstractWFSFeaturesHandler {
     private static final int TILE_EXTENT = 4096;
     private static final int TILE_BUFFER = 256;
     private static final int TILE_BUFFER_POINT = 1024;
-    private static final int TILE_SIZE_IN_NATURE = 8192;
 
     private static final int CACHE_LIMIT = 256;
     private static final long CACHE_EXPIRATION = TimeUnit.MINUTES.toMillis(5);
@@ -124,8 +128,9 @@ public class GetWFSVectorTileHandler extends AbstractWFSFeaturesHandler {
         params.getResponse().addHeader("Content-Encoding", "gzip");
         ResponseHelper.writeResponse(params, 200, MVT_CONTENT_TYPE, resp);
     }
+
     private void setGridToModifiers (WFSVectorLayerPluginViewModifier handler, String srsName, WFSTileGrid grid) {
-        int z = grid.getZForResolution(TILE_SIZE_IN_NATURE / WFSTileGrid.TILE_SIZE, 0);
+        int z = grid.getZForResolution(TARGET_ZOOM_LEVEL_RESOLUTION, 0);
         cacheZLevels.put(srsName, z);
         handler.setMinZoomLevelForSRS(srsName, z - MIN_ZOOM_OVER_CACHE_ZOOM);
         handler.setTileGridForSRS(srsName, grid);

--- a/control-mvt/src/test/java/org/oskari/control/mvt/GetWFSVectorTileHandlerTest.java
+++ b/control-mvt/src/test/java/org/oskari/control/mvt/GetWFSVectorTileHandlerTest.java
@@ -1,0 +1,131 @@
+package org.oskari.control.mvt;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import org.junit.Test;
+import org.oskari.service.mvt.TileCoord;
+
+public class GetWFSVectorTileHandlerTest {
+
+    @Test
+    public void testGetTilesToLoad() {
+        int targetZ = 5;
+
+        int z = 5;
+        int x = 16;
+        int y = 17;
+
+        // Expect that we load the tile and the tiles around it
+        // Which should be
+        // 15<=x<=17
+        // 16<=y<=18
+
+        int minExpectedX = 15;
+        int minExpectedY = 16;
+        int expectedMatrixLen = 3;
+        int expectedLen = expectedMatrixLen * expectedMatrixLen;
+
+        List<TileCoord> tiles = GetWFSVectorTileHandler.getTilesToLoad(targetZ, z, x, y);
+        for (TileCoord tile : tiles) {
+            assertEquals(targetZ, tile.getZ());
+        }
+        assertEquals(expectedLen, tiles.size());
+        Collections.sort(tiles, Comparator.comparing(TileCoord::getX).thenComparing(TileCoord::getY));
+
+        int index = 0;
+        for (int i = 0; i < expectedMatrixLen; i++) {
+            int expectedX = minExpectedX + i;
+            for (int j = 0; j < expectedMatrixLen; j++) {
+                int expectedY = minExpectedY + j;
+                TileCoord tile = tiles.get(index++);
+                assertEquals(expectedX, tile.getX());
+                assertEquals(expectedY, tile.getY());
+            }
+        }
+    }
+
+    @Test
+    public void testGetTilesToLoadLowerZoom() {
+        int targetZ = 5;
+
+        int z = 4;
+        int x = 10;
+        int y = 20;
+
+        // Expect that we load all the tiles inside (z=4, x=10, y=20)
+        // Which should be (in z=5):
+        // - (x=20, y=40)
+        // - (x=20, y=41)
+        // - (x=21, y=40)
+        // - (x=21, y=41)
+
+        // Then adding the buffer we should get
+        // 19<=x<=22
+        // 39<=y<=42
+
+        int minExpectedX = 19;
+        int minExpectedY = 39;
+        int expectedMatrixLen = 4;
+        int expectedLen = expectedMatrixLen * expectedMatrixLen;
+
+        List<TileCoord> tiles = GetWFSVectorTileHandler.getTilesToLoad(targetZ, z, x, y);
+        for (TileCoord tile : tiles) {
+            assertEquals(targetZ, tile.getZ());
+        }
+        assertEquals(expectedLen, tiles.size());
+        Collections.sort(tiles, Comparator.comparing(TileCoord::getX).thenComparing(TileCoord::getY));
+
+        int index = 0;
+        for (int i = 0; i < expectedMatrixLen; i++) {
+            int expectedX = minExpectedX + i;
+            for (int j = 0; j < expectedMatrixLen; j++) {
+                int expectedY = minExpectedY + j;
+                TileCoord tile = tiles.get(index++);
+                assertEquals(expectedX, tile.getX());
+                assertEquals(expectedY, tile.getY());
+            }
+        }
+    }
+
+    @Test
+    public void testGetTilesToLoadHigherZoom() {
+        int targetZ = 5;
+
+        int z = 6;
+        int x = 62;
+        int y = 35;
+
+        // Expect that we load the tile in which this tile belongs to
+        // which is x = 62/2 = 31, y = 35/2 = 17 (rounding down)
+        // And then the tiles around that for buffer bringing us to:
+        // 30<=x<=32
+        // 16<=y<=18
+        int minExpectedX = 30;
+        int minExpectedY = 16;
+        int expectedMatrixLen = 3;
+        int expectedLen = expectedMatrixLen * expectedMatrixLen;
+
+        List<TileCoord> tiles = GetWFSVectorTileHandler.getTilesToLoad(targetZ, z, x, y);
+        for (TileCoord tile : tiles) {
+            assertEquals(targetZ, tile.getZ());
+        }
+        assertEquals(expectedLen, tiles.size());
+        Collections.sort(tiles, Comparator.comparing(TileCoord::getX).thenComparing(TileCoord::getY));
+
+        int index = 0;
+        for (int i = 0; i < expectedMatrixLen; i++) {
+            int expectedX = minExpectedX + i;
+            for (int j = 0; j < expectedMatrixLen; j++) {
+                int expectedY = minExpectedY + j;
+                TileCoord tile = tiles.get(index++);
+                assertEquals(expectedX, tile.getX());
+                assertEquals(expectedY, tile.getY());
+            }
+        }
+    }
+
+}

--- a/oskari-geojson/src/main/java/org/oskari/geojson/GeoJSONSchemaDetector.java
+++ b/oskari-geojson/src/main/java/org/oskari/geojson/GeoJSONSchemaDetector.java
@@ -3,6 +3,7 @@ package org.oskari.geojson;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.opengis.feature.simple.SimpleFeatureType;
@@ -39,6 +40,11 @@ public class GeoJSONSchemaDetector {
             break;
         default:
             throw new IllegalArgumentException("Invalid type");
+        }
+
+        if (bindings.isEmpty()) {
+            // Empty FeatureCollection
+            return null;
         }
 
         SimpleFeatureTypeBuilder sftb = new SimpleFeatureTypeBuilder();

--- a/oskari-geojson/src/test/java/org/oskari/geojson/GeoJSONReader2Test.java
+++ b/oskari-geojson/src/test/java/org/oskari/geojson/GeoJSONReader2Test.java
@@ -293,4 +293,16 @@ public class GeoJSONReader2Test {
         }
     }
 
+    @Test
+    public void testEmptyFeatureCollection() throws Exception {
+        Map<String, Object> json = loadJSONResource("featureCollectionEmpty.json");
+        CoordinateReferenceSystem crs84 = CRS.decode("EPSG:4326", true);
+        SimpleFeatureType schema = GeoJSONSchemaDetector.getSchema(json, crs84);
+        assertNull(schema);
+        SimpleFeatureCollection fc = GeoJSONReader2.toFeatureCollection(json, schema);
+        try (SimpleFeatureIterator it = fc.features()) {
+            assertFalse(it.hasNext());
+        }
+    }
+
 }

--- a/oskari-geojson/src/test/resources/org/oskari/geojson/featureCollectionEmpty.json
+++ b/oskari-geojson/src/test/resources/org/oskari/geojson/featureCollectionEmpty.json
@@ -1,0 +1,5 @@
+{
+  "type": "FeatureCollection",
+  "features": [],
+  "timeStamp": "2019-02-13T06:57:56.906Z"
+}

--- a/service-mvt/src/main/java/org/oskari/service/mvt/SimpleFeaturesMVTEncoder.java
+++ b/service-mvt/src/main/java/org/oskari/service/mvt/SimpleFeaturesMVTEncoder.java
@@ -2,6 +2,7 @@ package org.oskari.service.mvt;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.geotools.data.simple.SimpleFeatureCollection;
@@ -91,6 +92,10 @@ public class SimpleFeaturesMVTEncoder {
      */
 
     public static List<Geometry> asMVTGeoms(SimpleFeatureCollection sfc, double[] bbox, int extent, int buffer) {
+        if (sfc.isEmpty()) {
+            return Collections.emptyList();
+        }
+
         Envelope tileEnvelope = new Envelope(bbox[0], bbox[2], bbox[1], bbox[3]);
         Envelope clipEnvelope = new Envelope(tileEnvelope);
         if (buffer > 0) {

--- a/service-mvt/src/test/java/org/oskari/service/mvt/SimpleFeaturesMVTEncoderTest.java
+++ b/service-mvt/src/test/java/org/oskari/service/mvt/SimpleFeaturesMVTEncoderTest.java
@@ -130,4 +130,34 @@ public class SimpleFeaturesMVTEncoderTest {
         assertEquals(0, geom.size());
     }
 
+    @Test
+    public void whenPolygonIsClippedItRemains() {
+        GeometryFactory gf = new GeometryFactory();
+
+        Coordinate[] ca = new Coordinate[4];
+        ca[0] = new Coordinate(-20,  10);
+        ca[1] = new Coordinate( 20, -10);
+        ca[2] = new Coordinate(-20, -10);
+        ca[3] = new Coordinate(-20,  10);
+        LinearRing exterior = gf.createLinearRing(ca);
+
+        Polygon p = gf.createPolygon(exterior, null);
+
+        double[] bbox = { 0, 0, 100, 100 };
+        SimpleFeatureTypeBuilder tBuilder = new SimpleFeatureTypeBuilder();
+        tBuilder.setName("test");
+        tBuilder.add("geom", Polygon.class);
+        SimpleFeatureType featureType = tBuilder.buildFeatureType();
+
+        SimpleFeatureBuilder fBuilder = new SimpleFeatureBuilder(featureType);
+        fBuilder.set("geom", p);
+        SimpleFeature f = fBuilder.buildFeature(null);
+
+        DefaultFeatureCollection fc = new DefaultFeatureCollection("test");
+        fc.add(f);
+
+        List<Geometry> geom = SimpleFeaturesMVTEncoder.asMVTGeoms(fc, bbox, 4096, 0);
+        assertEquals(1, geom.size());
+    }
+
 }


### PR DESCRIPTION
Use larger buffer size for MVT tiles when layer contains only Point or MultiPoint features.
Remove buffer zone from WFS requests, instead request more (cacheable) adjacent tiles.
Fix NPE in `GeoJSONSchemaDetector` when there are no features in the GeoJSON.
