### PR TITLE
Remove bbox out of crs bounds check from GetWFSFeatures

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandler.java
@@ -3,7 +3,6 @@ package fi.nls.oskari.control.feature;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
-import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
@@ -22,11 +21,15 @@ import fi.nls.oskari.control.ActionException;
 import fi.nls.oskari.control.ActionParameters;
 import fi.nls.oskari.control.ActionParamsException;
 import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.service.ServiceRuntimeException;
 import fi.nls.oskari.util.ResponseHelper;
 
 @OskariActionRoute("GetWFSFeatures")
 public class GetWFSFeaturesHandler extends AbstractWFSFeaturesHandler {
+
+    private static final Logger LOG = LogFactory.getLogger(GetWFSFeaturesHandler.class);
 
     protected static final String ERR_BBOX_INVALID = "Invalid bbox";
     protected static final String ERR_GEOJSON_ENCODE_FAIL = "Failed to write GeoJSON";
@@ -67,8 +70,9 @@ public class GetWFSFeaturesHandler extends AbstractWFSFeaturesHandler {
         try {
             fc = featureClient.getFeatures(id, layer, bbox, targetCRS, contentProcessor);
         } catch (ServiceRuntimeException e) {
-            // ActionParamsException because we don't want to log stacktrace of these  
-            throw new ActionParamsException(ERR_FAILED_TO_RETRIEVE_FEATURES, e);
+            LOG.debug(e, e.getMessage());
+            // throw ActionParamsException because we don't want to log stacktrace of these
+            throw new ActionParamsException(ERR_FAILED_TO_RETRIEVE_FEATURES);
         }
 
         if (fc.isEmpty()) {

--- a/control-base/src/main/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandler.java
@@ -1,6 +1,8 @@
 package fi.nls.oskari.control.feature;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
@@ -32,7 +34,7 @@ public class GetWFSFeaturesHandler extends AbstractWFSFeaturesHandler {
 
     private static final String PARAM_BBOX = "bbox";
 
-    private static final String GEOJSON_CONTENT_TYPE = "application/vnd.geo+json";
+    private static final String GEOJSON_CONTENT_TYPE = "application/vnd.geo+json; charset=utf-8";
     private static final byte[] EMPTY_GEOJSON_FEATURE_COLLECTION =
             "{\"type\": \"FeatureCollection\", \"features\": []}".getBytes(StandardCharsets.UTF_8);
 
@@ -76,10 +78,11 @@ public class GetWFSFeaturesHandler extends AbstractWFSFeaturesHandler {
         }
 
         try {
-            StringWriter writer = new StringWriter();
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            OutputStreamWriter writer = new OutputStreamWriter(baos, StandardCharsets.UTF_8);
             int decimals = getNumDecimals(targetCRS);
             new FeatureJSON(new GeometryJSON(decimals)).writeFeatureCollection(fc, writer);
-            ResponseHelper.writeResponse(params, 200, GEOJSON_CONTENT_TYPE, writer.getBuffer().toString());
+            ResponseHelper.writeResponse(params, 200, GEOJSON_CONTENT_TYPE, baos);
         } catch (IOException e) {
             ResponseHelper.writeError(params, ERR_GEOJSON_ENCODE_FAIL);
         }

--- a/control-base/src/main/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandler.java
@@ -71,8 +71,7 @@ public class GetWFSFeaturesHandler extends AbstractWFSFeaturesHandler {
             fc = featureClient.getFeatures(id, layer, bbox, targetCRS, contentProcessor);
         } catch (ServiceRuntimeException e) {
             LOG.debug(e, e.getMessage());
-            // throw ActionParamsException because we don't want to log stacktrace of these
-            throw new ActionParamsException(ERR_FAILED_TO_RETRIEVE_FEATURES);
+            throw new ActionException(ERR_FAILED_TO_RETRIEVE_FEATURES);
         }
 
         if (fc.isEmpty()) {

--- a/control-base/src/main/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandler.java
@@ -16,24 +16,21 @@ import org.oskari.service.user.UserLayerService;
 import org.oskari.service.wfs.client.OskariWFSClient;
 
 import fi.nls.oskari.annotation.OskariActionRoute;
+import fi.nls.oskari.control.ActionCommonException;
 import fi.nls.oskari.control.ActionConstants;
 import fi.nls.oskari.control.ActionException;
 import fi.nls.oskari.control.ActionParameters;
 import fi.nls.oskari.control.ActionParamsException;
 import fi.nls.oskari.domain.map.OskariLayer;
-import fi.nls.oskari.log.LogFactory;
-import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.service.ServiceRuntimeException;
 import fi.nls.oskari.util.ResponseHelper;
 
 @OskariActionRoute("GetWFSFeatures")
 public class GetWFSFeaturesHandler extends AbstractWFSFeaturesHandler {
 
-    private static final Logger LOG = LogFactory.getLogger(GetWFSFeaturesHandler.class);
-
     protected static final String ERR_BBOX_INVALID = "Invalid bbox";
-    protected static final String ERR_GEOJSON_ENCODE_FAIL = "Failed to write GeoJSON";
     protected static final String ERR_FAILED_TO_RETRIEVE_FEATURES = "Failed to retrieve features";
+    protected static final String ERR_GEOJSON_ENCODE_FAIL = "Failed to write GeoJSON";
 
     private static final String PARAM_BBOX = "bbox";
 
@@ -70,8 +67,7 @@ public class GetWFSFeaturesHandler extends AbstractWFSFeaturesHandler {
         try {
             fc = featureClient.getFeatures(id, layer, bbox, targetCRS, contentProcessor);
         } catch (ServiceRuntimeException e) {
-            LOG.debug(e, e.getMessage());
-            throw new ActionException(ERR_FAILED_TO_RETRIEVE_FEATURES);
+            throw new ActionCommonException(ERR_FAILED_TO_RETRIEVE_FEATURES);
         }
 
         if (fc.isEmpty()) {
@@ -87,7 +83,7 @@ public class GetWFSFeaturesHandler extends AbstractWFSFeaturesHandler {
             new FeatureJSON(new GeometryJSON(decimals)).writeFeatureCollection(fc, writer);
             ResponseHelper.writeResponse(params, 200, GEOJSON_CONTENT_TYPE, baos);
         } catch (IOException e) {
-            ResponseHelper.writeError(params, ERR_GEOJSON_ENCODE_FAIL);
+            throw new ActionCommonException(ERR_GEOJSON_ENCODE_FAIL, e);
         }
     }
 

--- a/control-base/src/main/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandler.java
@@ -14,8 +14,6 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.oskari.service.user.UserLayerService;
 import org.oskari.service.wfs.client.OskariWFSClient;
 
-import com.vividsolutions.jts.geom.Envelope;
-
 import fi.nls.oskari.annotation.OskariActionRoute;
 import fi.nls.oskari.control.ActionConstants;
 import fi.nls.oskari.control.ActionException;
@@ -29,7 +27,6 @@ import fi.nls.oskari.util.ResponseHelper;
 public class GetWFSFeaturesHandler extends AbstractWFSFeaturesHandler {
 
     protected static final String ERR_BBOX_INVALID = "Invalid bbox";
-    protected static final String ERR_BBOX_OUT_OF_CRS = "bbox not within CRS extent";
     protected static final String ERR_GEOJSON_ENCODE_FAIL = "Failed to write GeoJSON";
     protected static final String ERR_FAILED_TO_RETRIEVE_FEATURES = "Failed to retrieve features";
 
@@ -105,11 +102,7 @@ public class GetWFSFeaturesHandler extends AbstractWFSFeaturesHandler {
             double y1 = Double.parseDouble(a[1]);
             double x2 = Double.parseDouble(a[2]);
             double y2 = Double.parseDouble(a[3]);
-            Envelope envelope = new Envelope(x1, x2, y1, y2);
-            if (!featureClient.isWithin(crs, envelope)) {
-                throw new ActionParamsException(ERR_BBOX_OUT_OF_CRS);
-            }
-            return new ReferencedEnvelope(envelope, crs);
+            return new ReferencedEnvelope(x1, x2, y1, y2, crs);
         } catch (NumberFormatException e) {
             throw new ActionParamsException(ERR_BBOX_INVALID);
         }

--- a/control-base/src/test/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandlerTest.java
+++ b/control-base/src/test/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandlerTest.java
@@ -1,8 +1,6 @@
 package fi.nls.oskari.control.feature;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.Optional;
 
@@ -12,13 +10,10 @@ import org.geotools.referencing.CRS;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.opengis.referencing.FactoryException;
-import org.opengis.referencing.NoSuchAuthorityCodeException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 import com.vividsolutions.jts.geom.Envelope;
 
-import fi.nls.oskari.control.ActionParamsException;
 import fi.nls.oskari.domain.map.OskariLayer;
 
 public class GetWFSFeaturesHandlerTest {
@@ -47,17 +42,6 @@ public class GetWFSFeaturesHandlerTest {
         SimpleFeatureCollection sfc = handler.featureClient.getFeatures(id, layer, bbox, nativeCRS, webMercator, Optional.empty());
         CoordinateReferenceSystem actualCRS = sfc.getSchema().getGeometryDescriptor().getCoordinateReferenceSystem();
         assertTrue(CRS.equalsIgnoreMetadata(webMercator, actualCRS));
-    }
-
-    @Test
-    public void testBboxOutOfBounds() throws NoSuchAuthorityCodeException, FactoryException {
-        CoordinateReferenceSystem crs = CRS.decode("EPSG:3857");
-        try {
-            handler.parseBbox("20040000,20040000,20041000,20041000", crs);
-            fail();
-        } catch (ActionParamsException e) {
-            assertEquals(GetWFSFeaturesHandler.ERR_BBOX_OUT_OF_CRS, e.getMessage());
-        }
     }
 
 }

--- a/service-control/src/main/java/fi/nls/oskari/control/ActionCommonException.java
+++ b/service-control/src/main/java/fi/nls/oskari/control/ActionCommonException.java
@@ -1,0 +1,17 @@
+package fi.nls.oskari.control;
+
+/**
+ * Generic "something went wrong" exception but one that is rather common
+ * and we don't want to log the stack trace (except at debug log level).
+ */
+public class ActionCommonException extends ActionException {
+
+    public ActionCommonException(final String message, final Exception e) {
+        super(message, e);
+    }
+
+    public ActionCommonException(final String message) {
+        super(message);
+    }
+
+}

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariFeatureClient.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariFeatureClient.java
@@ -7,12 +7,9 @@ import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
 import org.opengis.filter.Filter;
-import org.opengis.geometry.DirectPosition;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.oskari.service.user.UserLayerService;
 import org.oskari.service.wfs3.CoordinateTransformer;
-
-import com.vividsolutions.jts.geom.Envelope;
 
 import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.service.ServiceException;
@@ -98,25 +95,6 @@ public class OskariFeatureClient {
         }
 
         return sfc;
-    }
-
-    public boolean isWithin(CoordinateReferenceSystem targetCRS, Envelope bbox) {
-        org.opengis.geometry.Envelope targetCRSEnvelope = CRS.getEnvelope(targetCRS);
-        DirectPosition lc = targetCRSEnvelope.getLowerCorner();
-        if (bbox.getMinX() < lc.getOrdinate(0)) {
-            return false;
-        }
-        if (bbox.getMinY() < lc.getOrdinate(1)) {
-            return false;
-        }
-        DirectPosition uc = targetCRSEnvelope.getUpperCorner();
-        if (bbox.getMaxX() > uc.getOrdinate(0)) {
-            return false;
-        }
-        if (bbox.getMaxY() > uc.getOrdinate(1)) {
-            return false;
-        }
-        return true;
     }
 
 }

--- a/servlet-map/src/main/java/fi/nls/oskari/AjaxController.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/AjaxController.java
@@ -46,6 +46,17 @@ public class AjaxController {
                 log.error("Action was denied:", route, ", Error msg:", e.getMessage(), ". User: ", params.getUser(), ". Parameters: ", params.getRequest().getParameterMap());
             }
             ResponseHelper.writeError(params, e.getMessage(), HttpServletResponse.SC_FORBIDDEN, e.getOptions());
+        } catch (ActionCommonException e) {
+            Throwable error = e;
+            if (e.getCause() != null) {
+                error = e.getCause();
+            }
+            if (log.isDebugEnabled()) {
+                log.debug(error, "Couldn't handle action:", route, "Message: ", e.getMessage(), ". Parameters: ", params.getRequest().getParameterMap());
+            } else {
+                log.error("Couldn't handle action:", route, ". Message: ", e.getMessage(), ". Parameters: ", params.getRequest().getParameterMap());
+            }
+            ResponseHelper.writeError(params, e.getMessage());
         } catch (ActionException e) {
             // Internal failure -> print stack trace
             Throwable error = e;


### PR DESCRIPTION
Don't check whether or not the bbox is out of crs bounds. The idea was nice, but ended up causing more problems than it solved.

Add new ActionException class `ActionCommonException`. The stack trace gets logged only if debug logging is enabled and otherwise only the message. Response to client is 500 with the Exception#getMessage() as the message.

Use the new ActionCommonException if something goes wrong reading the features from WFS.

Also replace StringWriter with ByteArrayOutputStream+OutputStreamWriter with UTF-8 charset to reduce the amount of garbage created a bit. Previously we used just the ByteArrayOutputStream which caused charset issues because GeoTools wraps the OutputStream with `new OutputStreamWriter(OutputStream out)` which "uses the default character encoding".
