### PR TITLE
Pass language as control param

### DIFF
--- a/servlet-map/src/main/java/fi/nls/oskari/MapController.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/MapController.java
@@ -195,6 +195,8 @@ public class MapController {
 
 
         JSONHelper.putValue(controlParams, PARAM_SECURE, request.getParameter(PARAM_SECURE));
+        // pass language as control param so we don't have to rely on cookie for getting the same language for GetAppSetup
+        JSONHelper.putValue(controlParams, PARAM_LANGUAGE, params.getLocale().getLanguage());
         JSONHelper.putValue(controlParams, GetAppSetupHandler.PARAM_NO_SAVED_STATE, request.getParameter(GetAppSetupHandler.PARAM_NO_SAVED_STATE));
         model.addAttribute(KEY_CONTROL_PARAMS, controlParams.toString());
 


### PR DESCRIPTION
Fixes an issue where published map is not opened with the default language AND third party cookies are blocked. Without this the HTML-page might link (==load) english localizations but GetAppSetup will use the default language of the instance like finnish. The frontend breaks since the application tries to start with language for which localizations haven't been loaded.