### PR TITLE
Parse OWSExceptions

### DIFF
--- a/service-wfs-client/pom.xml
+++ b/service-wfs-client/pom.xml
@@ -43,10 +43,6 @@
             <groupId>org.geotools</groupId>
             <artifactId>gt-epsg-hsql</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.geotools</groupId>
-            <artifactId>gt-geojson</artifactId>
-        </dependency>
     </dependencies>
 
 </project>

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/ExceptionReportParser.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/ExceptionReportParser.java
@@ -1,0 +1,12 @@
+package org.oskari.service.wfs.client;
+
+import java.io.InputStream;
+import java.util.Optional;
+
+public class ExceptionReportParser {
+    
+    public Optional<OWSException> parseException(InputStream in) {
+        return null;
+    }
+
+}

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/ExceptionReportParser.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/ExceptionReportParser.java
@@ -3,10 +3,45 @@ package org.oskari.service.wfs.client;
 import java.io.InputStream;
 import java.util.Optional;
 
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+import fi.nls.oskari.util.XmlHelper;
+
 public class ExceptionReportParser {
-    
-    public Optional<OWSException> parseException(InputStream in) {
-        return null;
+
+    public static OWSException parse(InputStream in) throws Exception {
+        DocumentBuilderFactory dbf = XmlHelper.newDocumentBuilderFactory();
+        dbf.setNamespaceAware(true);
+        DocumentBuilder db = dbf.newDocumentBuilder();
+        Document doc = db.parse(in);
+        Element root = doc.getDocumentElement();
+        if (!"ExceptionReport".equals(root.getLocalName())) {
+            throw new IllegalArgumentException("Invalid root element");
+        }
+
+        Element exception = getFirstChildElement(root, "Exception")
+                .orElseThrow(() -> new IllegalArgumentException("Missing Exception element"));
+        String exceptionCode = exception.getAttribute("exceptionCode");
+        String locator = exception.getAttribute("locator");
+        String exceptionText = getFirstChildElement(exception, "ExceptionText")
+                .map(e -> e.getTextContent())
+                .orElse("");
+
+        return new OWSException(exceptionCode, locator, exceptionText);
+    }
+
+    private static Optional<Element> getFirstChildElement(Element parent, String localName) {
+        for (Node node = parent.getFirstChild(); node != null; node = node.getNextSibling()) {
+            if (node.getNodeType() == Node.ELEMENT_NODE && localName.equals(node.getLocalName())) {
+                return Optional.of((Element) node);
+            }
+        }
+        return Optional.empty();
     }
 
 }

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OWSException.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OWSException.java
@@ -2,32 +2,26 @@ package org.oskari.service.wfs.client;
 
 public class OWSException {
 
-    private String exceptionCode;
-    private String locator;
-    private String exceptionText;
+    private final String exceptionCode;
+    private final String locator;
+    private final String exceptionText;
+
+    public OWSException(String exceptionCode, String locator, String exceptionText) {
+        this.exceptionCode = exceptionCode;
+        this.locator = locator;
+        this.exceptionText = exceptionText;
+    }
 
     public String getExceptionCode() {
         return exceptionCode;
-    }
-
-    public void setExceptionCode(String exceptionCode) {
-        this.exceptionCode = exceptionCode;
     }
 
     public String getLocator() {
         return locator;
     }
 
-    public void setLocator(String locator) {
-        this.locator = locator;
-    }
-
     public String getExceptionText() {
         return exceptionText;
-    }
-
-    public void setExceptionText(String exceptionText) {
-        this.exceptionText = exceptionText;
     }
 
 }

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OWSException.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OWSException.java
@@ -1,0 +1,33 @@
+package org.oskari.service.wfs.client;
+
+public class OWSException {
+
+    private String exceptionCode;
+    private String locator;
+    private String exceptionText;
+
+    public String getExceptionCode() {
+        return exceptionCode;
+    }
+
+    public void setExceptionCode(String exceptionCode) {
+        this.exceptionCode = exceptionCode;
+    }
+
+    public String getLocator() {
+        return locator;
+    }
+
+    public void setLocator(String locator) {
+        this.locator = locator;
+    }
+
+    public String getExceptionText() {
+        return exceptionText;
+    }
+
+    public void setExceptionText(String exceptionText) {
+        this.exceptionText = exceptionText;
+    }
+
+}

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OWSExceptionReportParser.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OWSExceptionReportParser.java
@@ -12,7 +12,7 @@ import org.w3c.dom.Node;
 
 import fi.nls.oskari.util.XmlHelper;
 
-public class ExceptionReportParser {
+public class OWSExceptionReportParser {
 
     public static OWSException parse(InputStream in) throws Exception {
         DocumentBuilderFactory dbf = XmlHelper.newDocumentBuilderFactory();

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS110Client.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS110Client.java
@@ -74,8 +74,13 @@ public class OskariWFS110Client {
 
         String contentType = conn.getContentType();
         if (contentType != null && !contentType.contains("json")) {
-            // TODO: Handle WFS Error responses
-            throw new Exception("Unexpected content type " + contentType);
+            if (contentType.contains("xml")) {
+                try (InputStream in = new BufferedInputStream(conn.getInputStream())) {
+                    
+                }
+            } else {
+                throw new Exception("Unexpected content type " + contentType);
+            }
         }
 
         Map<String, Object> geojson = readMap(conn);

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS110Client.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS110Client.java
@@ -46,63 +46,77 @@ public class OskariWFS110Client {
     public static SimpleFeatureCollection getFeatures(String endPoint, String user, String pass,
             String typeName, ReferencedEnvelope bbox, CoordinateReferenceSystem crs, int maxFeatures, Filter filter) {
         // First try GeoJSON
+        Map<String, String> query = getQueryParams(typeName, bbox, crs, maxFeatures, filter);
+
+        query.put("OUTPUTFORMAT", "application/json");
+        HttpURLConnection conn;
         try {
-            return getFeaturesGeoJSON(endPoint, user, pass, typeName, bbox, crs, maxFeatures, filter);
+            conn = getConnection(endPoint, user, pass, query);
         } catch (Exception e) {
-            LOG.warn(e, "Failed to read WFS response as GeoJSON");
+            LOG.debug(e);
+            throw new ServiceRuntimeException("Unable to get features");
         }
 
-        // Fallback to GML
-        try {
-            return getFeaturesGML(endPoint, user, pass, typeName, bbox, crs, maxFeatures, filter);
-        } catch (Exception e) {
-            LOG.warn(e, "Failed to read WFS response as GML");
+        Map<String, Object> geojson = null;
+        try (InputStream in = new BufferedInputStream(conn.getInputStream())) {
+            try {
+                in.mark(8192);
+                geojson = OM.readValue(in, TYPE_REF);
+            } catch (Exception e) {
+                in.reset();
+                if (!isOutputFormatInvalid(in)) {
+                    throw new ServiceRuntimeException("Unable to get features");
+                }
+            }
+        } catch (IOException e) {
+            LOG.debug(e);
         }
 
-        throw new ServiceRuntimeException("Unable to get features");
+        if (geojson != null) {
+            try {
+                SimpleFeatureType schema = GeoJSONSchemaDetector.getSchema(geojson, crs);
+                return GeoJSONReader2.toFeatureCollection(geojson, schema);
+            } catch (Exception e) {
+                LOG.debug(e);
+            }
+        }
+
+        query.remove("OUTPUTFORMAT");
+        try {
+            conn = getConnection(endPoint, user, pass, query);
+        } catch (Exception e) {
+            LOG.debug(e);
+            throw new ServiceRuntimeException("Unable to get features");
+        }
+
+        try (InputStream in = new BufferedInputStream(conn.getInputStream())) {
+            return OSKARI_GML.decodeFeatureCollection(in, user, pass);
+        } catch (Exception e) {
+            throw new ServiceRuntimeException("Unable to get features");
+        }
     }
 
     public static SimpleFeatureCollection getFeaturesGeoJSON(String endPoint, String user, String pass,
             String typeName, ReferencedEnvelope bbox, CoordinateReferenceSystem crs, int maxFeatures, Filter filter) throws Exception {
         Map<String, String> query = getQueryParams(typeName, bbox, crs, maxFeatures, filter);
         query.put("OUTPUTFORMAT", "application/json");
-        HttpURLConnection conn = IOHelper.getConnection(endPoint, user, pass, query);
-        conn = IOHelper.followRedirect(conn, user, pass, query, MAX_REDIRECTS);
-        if (conn.getResponseCode() != 200) {
-            throw new Exception("Unexpected status code " + conn.getResponseCode());
-        }
-
+        HttpURLConnection conn = getConnection(endPoint, user, pass, query);
         String contentType = conn.getContentType();
         if (contentType != null && !contentType.contains("json")) {
-            if (contentType.contains("xml")) {
-                try (InputStream in = new BufferedInputStream(conn.getInputStream())) {
-                    
-                }
-            } else {
-                throw new Exception("Unexpected content type " + contentType);
-            }
+            throw new Exception("Unexpected content type " + contentType);
         }
-
-        Map<String, Object> geojson = readMap(conn);
+        Map<String, Object> geojson;
+        try (InputStream in = new BufferedInputStream(conn.getInputStream())) {
+            geojson = OM.readValue(in, TYPE_REF);
+        }
         SimpleFeatureType schema = GeoJSONSchemaDetector.getSchema(geojson, crs);
         return GeoJSONReader2.toFeatureCollection(geojson, schema);
-    }
-
-    private static Map<String, Object> readMap(HttpURLConnection conn) throws IOException {
-        try (InputStream in = conn.getInputStream()) {
-            return OM.readValue(in, TYPE_REF);
-        }
     }
 
     public static SimpleFeatureCollection getFeaturesGML(String endPoint, String user, String pass, String typeName,
             ReferencedEnvelope bbox, CoordinateReferenceSystem crs, int maxFeatures, Filter filter) throws Exception {
         Map<String, String> query = getQueryParams(typeName, bbox, crs, maxFeatures, filter);
-        HttpURLConnection conn = IOHelper.getConnection(endPoint, user, pass, query);
-        conn = IOHelper.followRedirect(conn, user, pass, query, MAX_REDIRECTS);
-        if (conn.getResponseCode() != 200) {
-            throw new Exception("Unexpected status code " + conn.getResponseCode());
-        }
-
+        HttpURLConnection conn = getConnection(endPoint, user, pass, query);
         try (InputStream in = new BufferedInputStream(conn.getInputStream())) {
             return OSKARI_GML.decodeFeatureCollection(in, user, pass);
         }
@@ -123,6 +137,16 @@ public class OskariWFS110Client {
         }
         parameters.put("MAXFEATURES", Integer.toString(maxFeatures));
         return parameters;
+    }
+
+    protected static HttpURLConnection getConnection(String endPoint,
+            String user, String pass, Map<String, String> query) throws Exception {
+        HttpURLConnection conn = IOHelper.getConnection(endPoint, user, pass, query);
+        conn = IOHelper.followRedirect(conn, user, pass, query, MAX_REDIRECTS);
+        if (conn.getResponseCode() != 200) {
+            throw new Exception("Unexpected status code " + conn.getResponseCode());
+        }
+        return conn;
     }
 
     protected static String getBBOX(ReferencedEnvelope bbox) {
@@ -152,6 +176,24 @@ public class OskariWFS110Client {
             LOG.warn("Failed to encode filter!");
         }
         return null;
+    }
+
+    protected static boolean isOutputFormatInvalid(InputStream in) {
+        try {
+            OWSException ex = OWSExceptionReportParser.parse(in);
+            return isExceptionDueToInvalidOutputFormat(ex);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    protected static boolean isExceptionDueToInvalidOutputFormat(OWSException ex) {
+        if (ex.getExceptionCode().equalsIgnoreCase("InvalidParameterValue")) {
+            if (ex.getLocator() != null && ex.getLocator().equalsIgnoreCase("outputFormat")) {
+                return true;
+            }
+        }
+        return false;
     }
 
 }

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS110Client.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS110Client.java
@@ -91,7 +91,6 @@ public class OskariWFS110Client {
     private static SimpleFeatureCollection parseGeoJSON(InputStream in,
             CoordinateReferenceSystem crs) throws IOException {
         Map<String, Object> geojson = OM.readValue(in, TYPE_REF);
-        in.close();
         SimpleFeatureType schema = GeoJSONSchemaDetector.getSchema(geojson, crs);
         return GeoJSONReader2.toFeatureCollection(geojson, schema);
     }

--- a/service-wfs-client/src/test/java/org/oskari/service/wfs/client/ExceptionReportParserTest.java
+++ b/service-wfs-client/src/test/java/org/oskari/service/wfs/client/ExceptionReportParserTest.java
@@ -1,0 +1,21 @@
+package org.oskari.service.wfs.client;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.InputStream;
+
+import org.junit.Test;
+
+public class ExceptionReportParserTest {
+
+    @Test
+    public void happyCase() throws Exception {
+        try (InputStream in = getClass().getClassLoader().getResourceAsStream("exceptionReport.xml")) {
+            OWSException exception = ExceptionReportParser.parse(in);
+            assertEquals("InvalidParameterValue", exception.getExceptionCode());
+            assertEquals("outputFormat", exception.getLocator());
+            assertEquals("Failed to find response for output format application/json11", exception.getExceptionText());
+        }
+    }
+
+}

--- a/service-wfs-client/src/test/java/org/oskari/service/wfs/client/ExceptionReportParserTest.java
+++ b/service-wfs-client/src/test/java/org/oskari/service/wfs/client/ExceptionReportParserTest.java
@@ -11,7 +11,7 @@ public class ExceptionReportParserTest {
     @Test
     public void happyCase() throws Exception {
         try (InputStream in = getClass().getClassLoader().getResourceAsStream("exceptionReport.xml")) {
-            OWSException exception = ExceptionReportParser.parse(in);
+            OWSException exception = OWSExceptionReportParser.parse(in);
             assertEquals("InvalidParameterValue", exception.getExceptionCode());
             assertEquals("outputFormat", exception.getLocator());
             assertEquals("Failed to find response for output format application/json11", exception.getExceptionText());

--- a/service-wfs-client/src/test/resources/exceptionReport.xml
+++ b/service-wfs-client/src/test/resources/exceptionReport.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?><ows:ExceptionReport xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ows="http://www.opengis.net/ows" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" xsi:schemaLocation="http://www.opengis.net/ows http://visukartta01.nls.fi:8080/geoserver/schemas/ows/1.0.0/owsExceptionReport.xsd">
+  <ows:Exception exceptionCode="InvalidParameterValue" locator="outputFormat">
+    <ows:ExceptionText>Failed to find response for output format application/json11</ows:ExceptionText>
+  </ows:Exception>
+</ows:ExceptionReport>

--- a/service-wfs-client/src/test/resources/exceptionReport.xml
+++ b/service-wfs-client/src/test/resources/exceptionReport.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><ows:ExceptionReport xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ows="http://www.opengis.net/ows" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" xsi:schemaLocation="http://www.opengis.net/ows http://visukartta01.nls.fi:8080/geoserver/schemas/ows/1.0.0/owsExceptionReport.xsd">
+<?xml version="1.0" encoding="UTF-8"?><ows:ExceptionReport xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ows="http://www.opengis.net/ows" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" xsi:schemaLocation="http://www.opengis.net/ows http://schemas.opengis.net/ows/1.0.0/owsExceptionReport.xsd">
   <ows:Exception exceptionCode="InvalidParameterValue" locator="outputFormat">
     <ows:ExceptionText>Failed to find response for output format application/json11</ows:ExceptionText>
   </ows:Exception>


### PR DESCRIPTION
Add support for parsing OWSExceptions in service-wfs-client.
`OskariWFS110Client#getFeatures` now checks if the error was due to bad outputFormat parameter. If it wasn't then it doesn't fallback to GML.