### PR TITLE
Fix issue with null and integer id fields in GeoJSONReader2

### DIFF
--- a/oskari-geojson/src/main/java/org/oskari/geojson/GeoJSONReader2.java
+++ b/oskari-geojson/src/main/java/org/oskari/geojson/GeoJSONReader2.java
@@ -161,7 +161,9 @@ public class GeoJSONReader2 {
 
         builder.reset();
 
-        String id = GeoJSONUtil.getString(json, GeoJSON.ID);
+        Object _id = json.get(GeoJSON.ID);
+        // If id is null SimpleFeatureBuilder will create one
+        String id = _id != null ? _id.toString() : null;
 
         Object geom = json.get(GeoJSON.GEOMETRY);
         if (geom != null) {

--- a/oskari-geojson/src/test/java/org/oskari/geojson/GeoJSONReader2Test.java
+++ b/oskari-geojson/src/test/java/org/oskari/geojson/GeoJSONReader2Test.java
@@ -305,4 +305,32 @@ public class GeoJSONReader2Test {
         }
     }
 
+    @Test
+    public void testDifferentIdTypes() throws Exception {
+        Map<String, Object> json = loadJSONResource("featureCollectionDifferentId.json");
+        CoordinateReferenceSystem crs84 = CRS.decode("EPSG:4326", true);
+        SimpleFeatureType schema = GeoJSONSchemaDetector.getSchema(json, crs84);
+        assertNotNull(schema);
+        SimpleFeatureCollection fc = GeoJSONReader2.toFeatureCollection(json, schema);
+        try (SimpleFeatureIterator it = fc.features()) {
+            it.hasNext();
+            SimpleFeature f1 = it.next();
+            it.hasNext();
+            SimpleFeature f2 = it.next();
+            it.hasNext();
+            SimpleFeature f3 = it.next();
+            it.hasNext();
+            SimpleFeature f4 = it.next();
+
+            assertNotNull(f1.getID());
+            assertEquals(10000001, f1.getAttribute("placeId"));
+            assertNotNull(f2.getID());
+            assertEquals(10000002, f2.getAttribute("placeId"));
+            assertEquals("123", f3.getID());
+            assertEquals(10000003, f3.getAttribute("placeId"));
+            assertEquals("ABC_321", f4.getID());
+            assertEquals(10000004, f4.getAttribute("placeId"));
+        }
+    }
+
 }

--- a/oskari-geojson/src/test/resources/org/oskari/geojson/featureCollectionDifferentId.json
+++ b/oskari-geojson/src/test/resources/org/oskari/geojson/featureCollectionDifferentId.json
@@ -1,0 +1,49 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "placeId": 10000001
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [ 0, 0 ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": null,
+      "properties": {
+        "placeId": 10000002
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [ 1, 1 ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 123,
+      "properties": {
+        "placeId": 10000003
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [ 2, 2 ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "ABC_321",
+      "properties": {
+        "placeId": 10000004
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [ 3, 3 ]
+      }
+    }
+  ],
+  "timeStamp": "2019-02-13T06:57:56.906Z"
+}


### PR DESCRIPTION
If feature.id is null or integer current code throws an exception. This fixes the issue.