### PR TITLE
Skip regions that fail on reprojecting coordinates

### DIFF
--- a/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/RegionSetHelper.java
+++ b/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/RegionSetHelper.java
@@ -94,8 +94,12 @@ public class RegionSetHelper {
             try (FeatureIterator<SimpleFeature> it = FJ.streamFeatureCollection(utf8Reader)) {
                 while (it.hasNext()) {
                     SimpleFeature f = it.next();
-                    transform(f, transform);
-                    fc.add(f);
+                    try {
+                        transform(f, transform);
+                        fc.add(f);
+                    } catch (Exception e) {
+                        LOG.debug(e, "Invalid region", f);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Some regions like ones in https://github.com/oskariorg/sample-server-extension/blob/master/app-resources/src/main/resources/regionsets/ne_110m_admin_0_countries.json break in transforms saying errors like "too close to pole" etc. This change makes the code to skip those and return set of regions that were successfully reprojected instead of rejecting the whole set.