### PR TITLE
Made possible to specify alternative TileMatrixSet to be used in print.

### DIFF
--- a/service-print/src/main/java/org/oskari/print/loader/CommandLoadImageWMTS.java
+++ b/service-print/src/main/java/org/oskari/print/loader/CommandLoadImageWMTS.java
@@ -201,8 +201,9 @@ public class CommandLoadImageWMTS extends CommandLoadImageBase {
         List<TileMatrixSet> possibleTileMatrixSets = new ArrayList<>();
 
         for (TileMatrixSet tms : capabilities.getTileMatrixSets()) {
-            String key = tms.getTileMatrixMap().keySet().iterator().next();
-            possibleTileMatrixSets.add(tms);
+            if (srs.equals(ProjectionHelper.shortSyntaxEpsg(tms.getCrs()))) {
+                possibleTileMatrixSets.add(tms);
+            }
         }
 
         if (possibleTileMatrixSets.isEmpty()) {
@@ -215,7 +216,7 @@ public class CommandLoadImageWMTS extends CommandLoadImageBase {
         return determineTileMatrixSetToUse(possibleTileMatrixSets);
     }
 
-    private TileMatrixSet determineTileMatrixSetToUse(List<TileMatrixSet> possibleTileMatrixSets) {
+    private TileMatrixSet determineTileMatrixSetToUse(List<TileMatrixSet> possibleTileMatrixSets) throws IllegalArgumentException {
         HashMap<String, String> alternativeTileMatrixSets = new HashMap<>();
         JSONObject useThisTileMatrixSetInstead = layerService.find(layer.getId()).getOptions().optJSONObject("useThisAlternativeTileMatrixSet");
 

--- a/service-print/src/main/java/org/oskari/print/loader/CommandLoadImageWMTS.java
+++ b/service-print/src/main/java/org/oskari/print/loader/CommandLoadImageWMTS.java
@@ -23,9 +23,6 @@ import fi.nls.oskari.wmts.domain.TileMatrix;
 import fi.nls.oskari.wmts.domain.TileMatrixSet;
 import fi.nls.oskari.wmts.domain.WMTSCapabilities;
 import fi.nls.oskari.wmts.domain.WMTSCapabilitiesLayer;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
 import org.json.JSONObject;
 
 /**
@@ -217,34 +214,22 @@ public class CommandLoadImageWMTS extends CommandLoadImageBase {
     }
 
     private TileMatrixSet determineTileMatrixSetToUse(List<TileMatrixSet> possibleTileMatrixSets) throws IllegalArgumentException {
-        HashMap<String, String> alternativeTileMatrixSets = new HashMap<>();
         JSONObject useThisTileMatrixSetInstead = layerService.find(layer.getId()).getOptions().optJSONObject("useThisAlternativeTileMatrixSet");
-
         if (useThisTileMatrixSetInstead == null) {
             return possibleTileMatrixSets.get(0);
-        } else if (useThisTileMatrixSetInstead.length() > 0) {
-            Iterator iterator = useThisTileMatrixSetInstead.keys();
-            while (iterator.hasNext()) {
-                String nextKey = (String) iterator.next();
-                alternativeTileMatrixSets.put(nextKey, useThisTileMatrixSetInstead.optString(nextKey));
-            }
-
-        }
-
+        } 
+        
         TileMatrixSet setToReturn = null;
         for (TileMatrixSet tms : possibleTileMatrixSets) {
-            String tileMatrixSetName = tms.getTileMatrixMap().keySet().iterator().next();
-            for (Map.Entry<String, String> entry : alternativeTileMatrixSets.entrySet()) {
-                String key = entry.getKey();
-                String value = entry.getValue();
-                if (tileMatrixSetName.contains(key) || tileMatrixSetName.contains(value)) {
+            String tileMatrixSetName = tms.getTileMatrixMap().keySet().iterator().next();            
+            for (int i = 0; i < useThisTileMatrixSetInstead.length(); i++) {
+                String key = (String) useThisTileMatrixSetInstead.keys().next();
+                if (tileMatrixSetName.contains(useThisTileMatrixSetInstead.optString(key, "Something not in tmsName."))) {
                     setToReturn = tms;
-                    break;
+                    break;                    
                 }
-
             }
         }
-
         if (setToReturn != null) {
             return setToReturn;
         }

--- a/service-print/src/main/java/org/oskari/print/loader/CommandLoadImageWMTS.java
+++ b/service-print/src/main/java/org/oskari/print/loader/CommandLoadImageWMTS.java
@@ -215,6 +215,11 @@ public class CommandLoadImageWMTS extends CommandLoadImageBase {
 
     private TileMatrixSet determineTileMatrixSetToUse(List<TileMatrixSet> possibleTileMatrixSets) throws IllegalArgumentException {
         JSONObject useThisTileMatrixSetInstead = layerService.find(layer.getId()).getAttributes().optJSONObject("preferredTileMatrix");
+        
+        if (useThisTileMatrixSetInstead == null) {
+            return possibleTileMatrixSets.get(0);
+        }
+        
         String id = useThisTileMatrixSetInstead.optString(srs);
         if (id == null) {
             return possibleTileMatrixSets.get(0);

--- a/service-print/src/main/java/org/oskari/print/loader/CommandLoadImageWMTS.java
+++ b/service-print/src/main/java/org/oskari/print/loader/CommandLoadImageWMTS.java
@@ -220,7 +220,7 @@ public class CommandLoadImageWMTS extends CommandLoadImageBase {
         JSONObject useThisTileMatrixSetInstead = layerService.find(layer.getId()).getOptions().optJSONObject("useThisAlternativeTileMatrixSet");
 
         if (useThisTileMatrixSetInstead == null) {
-            alternativeTileMatrixSets.put(srs, srs);
+            return possibleTileMatrixSets.get(0);
         } else if (useThisTileMatrixSetInstead.length() > 0) {
             Iterator iterator = useThisTileMatrixSetInstead.keys();
             while (iterator.hasNext()) {

--- a/service-print/src/main/java/org/oskari/print/loader/CommandLoadImageWMTS.java
+++ b/service-print/src/main/java/org/oskari/print/loader/CommandLoadImageWMTS.java
@@ -212,7 +212,10 @@ public class CommandLoadImageWMTS extends CommandLoadImageBase {
         if (possibleTileMatrixSets.size() == 1) {
             return possibleTileMatrixSets.get(0);
         }
+        return determineTileMatrixSetToUse(possibleTileMatrixSets);
+    }
 
+    private TileMatrixSet determineTileMatrixSetToUse(List<TileMatrixSet> possibleTileMatrixSets) {
         HashMap<String, String> alternativeTileMatrixSets = new HashMap<>();
         JSONObject useThisTileMatrixSetInstead = layerService.find(layer.getId()).getOptions().optJSONObject("useThisAlternativeTileMatrixSet");
 

--- a/service-print/src/main/java/org/oskari/print/loader/CommandLoadImageWMTS.java
+++ b/service-print/src/main/java/org/oskari/print/loader/CommandLoadImageWMTS.java
@@ -215,25 +215,16 @@ public class CommandLoadImageWMTS extends CommandLoadImageBase {
 
     private TileMatrixSet determineTileMatrixSetToUse(List<TileMatrixSet> possibleTileMatrixSets) throws IllegalArgumentException {
         JSONObject useThisTileMatrixSetInstead = layerService.find(layer.getId()).getOptions().optJSONObject("useThisAlternativeTileMatrixSet");
-        if (useThisTileMatrixSetInstead == null) {
+        String id = useThisTileMatrixSetInstead.optString(srs);
+        if (id == null) {
             return possibleTileMatrixSets.get(0);
-        } 
-        
-        TileMatrixSet setToReturn = null;
+        }
         for (TileMatrixSet tms : possibleTileMatrixSets) {
-            String tileMatrixSetName = tms.getTileMatrixMap().keySet().iterator().next();            
-            for (int i = 0; i < useThisTileMatrixSetInstead.length(); i++) {
-                String key = (String) useThisTileMatrixSetInstead.keys().next();
-                if (tileMatrixSetName.contains(useThisTileMatrixSetInstead.optString(key, "Something not in tmsName."))) {
-                    setToReturn = tms;
-                    break;                    
-                }
+            if (tms.getId().equals(id)) {
+                return tms;
             }
         }
-        if (setToReturn != null) {
-            return setToReturn;
-        }
-        throw new IllegalArgumentException("Could not find TileMatrixSet for the requested crs");
+        throw new IllegalArgumentException("Could not find TileMatrixSet with id " + id + " for layer " + layer.getId());
     }
 
     private GetTileRequestBuilder getTileRequestBuilderREST(String tileMatrixSetId, String tileMatrixId, ResourceUrl tileResourceUrl) {

--- a/service-print/src/main/java/org/oskari/print/loader/CommandLoadImageWMTS.java
+++ b/service-print/src/main/java/org/oskari/print/loader/CommandLoadImageWMTS.java
@@ -206,7 +206,7 @@ public class CommandLoadImageWMTS extends CommandLoadImageBase {
         }
 
         if (possibleTileMatrixSets.isEmpty()) {
-            throw new NullPointerException("Could not find any TileMatrixSets");
+            throw new IllegalArgumentException("Could not find TileMatrixSet for the requested crs");
         }
 
         if (possibleTileMatrixSets.size() == 1) {

--- a/service-print/src/main/java/org/oskari/print/loader/CommandLoadImageWMTS.java
+++ b/service-print/src/main/java/org/oskari/print/loader/CommandLoadImageWMTS.java
@@ -214,7 +214,7 @@ public class CommandLoadImageWMTS extends CommandLoadImageBase {
     }
 
     private TileMatrixSet determineTileMatrixSetToUse(List<TileMatrixSet> possibleTileMatrixSets) throws IllegalArgumentException {
-        JSONObject useThisTileMatrixSetInstead = layerService.find(layer.getId()).getOptions().optJSONObject("useThisAlternativeTileMatrixSet");
+        JSONObject useThisTileMatrixSetInstead = layerService.find(layer.getId()).getAttributes().optJSONObject("preferredTileMatrix");
         String id = useThisTileMatrixSetInstead.optString(srs);
         if (id == null) {
             return possibleTileMatrixSets.get(0);

--- a/service-print/src/main/java/org/oskari/print/loader/CommandLoadImageWMTS.java
+++ b/service-print/src/main/java/org/oskari/print/loader/CommandLoadImageWMTS.java
@@ -201,7 +201,15 @@ public class CommandLoadImageWMTS extends CommandLoadImageBase {
             String key = tms.getTileMatrixMap().keySet().iterator().next();
             possibleTileMatrixSets.put(key, tms);
         }
+        
+        if (possibleTileMatrixSets.size() <= 0) {
+            throw new NullPointerException("Could not find any TileMatrixSets");
+        }
 
+        if (possibleTileMatrixSets.size() == 1) {
+            return possibleTileMatrixSets.entrySet().iterator().next().getValue();
+        }
+        
         String alternativeTileMatrixSet = layerService.find(layer.getId()).getOptions().optString("useThisAlternativeTileMatrixSet", null);
         String tileMatrixSetToUse = srs;
         if (alternativeTileMatrixSet != null && !alternativeTileMatrixSet.isEmpty()) {


### PR DESCRIPTION
If one desires, now one can specify alternative TileMatrixSet to be used in print.
This can be done by adding "useThisAlternativeTileMatrixSet" to the oskari_maplayer table in options column.

Example:
UPDATE public.oskari_maplayer 
SET attributes='{"preferredTileMatrix": {"EPSG:3879":"ETRS-GK25"}}' WHERE id =20;
After that query printing layer, which id is 20, will use ETRS-GK25 instead of first available one.