### PR TITLE
Move supported SRS metadata from WMS to all layers

### DIFF
--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
@@ -7,12 +7,14 @@ import fi.nls.oskari.map.geometry.WKTHelper;
 import fi.nls.oskari.util.IOHelper;
 import fi.nls.oskari.util.JSONHelper;
 import fi.nls.oskari.util.PropertyUtil;
+import org.apache.commons.lang.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.oskari.utils.common.Sets;
 
 import java.net.URL;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -148,6 +150,12 @@ public class LayerJSONFormatter {
         JSONHelper.putValue(layerJson, "dataUrl_uuid", getFixedDataUrl(layer));
         JSONHelper.putValue(layerJson, "style", layer.getStyle());
 
+        // setup supported projections
+        Set<String> srs = getSRSs(layer.getAttributes(), layer.getCapabilities());
+        if (srs != null) {
+            JSONHelper.putValue(layerJson, KEY_SRS, new JSONArray(srs));
+        }
+
         // sublayer handling
         if(layer.getSublayers() != null && !layer.getSublayers().isEmpty()) {
             JSONArray sublayers = new JSONArray();
@@ -234,6 +242,28 @@ public class LayerJSONFormatter {
             return null;
         }
         return metadataId;
+    }
+
+    /**
+     * Merge forced SRSs from attributes and the ones parsed from
+     * GetCapabilities response into one Set of unique values
+     * @param attributes of OskariLayer in question, can be null
+     * @param capabilities of OskariLayer in question, can be null
+     * @return null iff attributes.forcedSRS and capabilities.srs are both null
+     *         otherwise a Set containing both (can be empty)
+     */
+    protected static Set<String> getSRSs(JSONObject attributes, JSONObject capabilities) {
+        JSONArray jsonForcedSRS = attributes != null ? attributes.optJSONArray(KEY_ATTRIBUTE_FORCED_SRS): null;
+        JSONArray jsonCapabilitiesSRS = capabilities != null ? capabilities.optJSONArray(KEY_SRS): null;
+        if (jsonForcedSRS == null && jsonCapabilitiesSRS == null) {
+            log.debug("No SRS information found from either attributes or capabilities");
+            return null;
+        }
+        Set<String> srs = new HashSet<>();
+        srs.addAll(JSONHelper.getArrayAsList(jsonForcedSRS));
+        srs.addAll(JSONHelper.getArrayAsList(jsonCapabilitiesSRS));
+        log.debug("SRSs from attributes and capabilities:", StringUtils.join(srs, ','));
+        return srs;
     }
 
     public static Set<String> getCRSsToStore(Set<String> systemCRSs,

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWMS.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWMS.java
@@ -143,11 +143,6 @@ public class LayerJSONFormatterWMS extends LayerJSONFormatter {
             JSONHelper.putValue(layerJson, KEY_VERSION, JSONHelper.getStringFromJSON(capabilities, KEY_VERSION, null));
         }
 
-        Set<String> srs = getSRSs(attrs, capabilities);
-        if (srs != null) {
-            JSONHelper.putValue(layerJson, KEY_SRS, new JSONArray(srs));
-        }
-
         // copy time from capabilities to attributes
         // timedata is merged into attributes  (times:{start:,end:,interval:}  or times: []
         // only reason for this is that admin can see the values offered by service
@@ -157,28 +152,6 @@ public class LayerJSONFormatterWMS extends LayerJSONFormatter {
                     JSONHelper.createJSONObject(KEY_TIMES, JSONHelper.get(capabilities, KEY_TIMES))));
         }
 
-    }
-
-    /**
-     * Merge forced SRSs from attributes and the ones parsed from
-     * GetCapabilities response into one Set of unique values
-     * @param attributes of OskariLayer in question, can be null
-     * @param capabilities of OskariLayer in question, can be null
-     * @return null iff attributes.forcedSRS and capabilities.srs are both null
-     *         otherwise a Set containing both (can be empty)
-     */
-    protected static Set<String> getSRSs(JSONObject attributes, JSONObject capabilities) {
-        JSONArray jsonForcedSRS = attributes != null ? attributes.optJSONArray(KEY_ATTRIBUTE_FORCED_SRS): null;
-        JSONArray jsonCapabilitiesSRS = capabilities != null ? capabilities.optJSONArray(KEY_SRS): null;
-        if (jsonForcedSRS == null && jsonCapabilitiesSRS == null) {
-            log.debug("No SRS information found from either attributes or capabilities");
-            return null;
-        }
-        Set<String> srs = new HashSet<>();
-        srs.addAll(JSONHelper.getArrayAsList(jsonForcedSRS));
-        srs.addAll(JSONHelper.getArrayAsList(jsonCapabilitiesSRS));
-        log.debug("SRSs from attributes and capabilities:", StringUtils.join(srs, ','));
-        return srs;
     }
 
     /**


### PR DESCRIPTION
So we can restrict for example vector tile layers to single projection in sample-server-extension.