### PR TITLE
Mybatis 3.4.6 -> 3.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <!-- gt-xsd-kml.version>9.3</gt-xsd-kml.version -->
         <flexjson.version>2.0</flexjson.version>
 
-        <mybatis.version>3.4.6</mybatis.version>
+        <mybatis.version>3.5.1</mybatis.version>
         <pdfbox.version>2.0.12</pdfbox.version>
         <hystrix.version>1.5.18</hystrix.version>
         <!-- Test deps versions -->


### PR DESCRIPTION
https://github.com/mybatis/mybatis-3/releases/tag/mybatis-3.5.0
https://github.com/mybatis/mybatis-3/releases/tag/mybatis-3.5.1

Mainly because https://github.com/mybatis/mybatis-3/issues/1156 hit us for JDK 11 builds on Travis when building #271 with this logging:
```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.apache.ibatis.reflection.Reflector (file:/home/travis/.m2/repository/org/mybatis/mybatis/3.4.6/mybatis-3.4.6.jar) to method java.lang.Class.checkPackageAccess(java.lang.SecurityManager,java.lang.ClassLoader,boolean)
WARNING: Please consider reporting this to the maintainers of org.apache.ibatis.reflection.Reflector
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```