### PR TITLE
Additions to Flyway helper methods

### DIFF
--- a/content-resources/src/main/java/fi/nls/oskari/db/BundleHelper.java
+++ b/content-resources/src/main/java/fi/nls/oskari/db/BundleHelper.java
@@ -91,14 +91,14 @@ public class BundleHelper {
         }
     }
 
-    public static void removeBundle(final Bundle bundle, Connection conn) throws SQLException {
-        if (isBundleRegistered(bundle.getName(), conn)) {
+    public static void unregisterBundle(final String bundleName, Connection conn) throws SQLException {
+        if (isBundleRegistered(bundleName, conn)) {
             try (PreparedStatement statement = conn.prepareStatement("DELETE FROM portti_bundle WHERE name=?")) {
-                statement.setString(1, bundle.getName());
+                statement.setString(1, bundleName);
                 statement.execute();
             }
         } else {
-            LOG.info("Bundle", bundle.getName(), "not registered - Skipping!");
+            LOG.info("Bundle", bundleName, "not registered - Skipping!");
         }
     }
 }

--- a/content-resources/src/main/java/fi/nls/oskari/db/BundleHelper.java
+++ b/content-resources/src/main/java/fi/nls/oskari/db/BundleHelper.java
@@ -32,8 +32,9 @@ public class BundleHelper {
     public static String getDefaultBundleStartup(final String namespace, final String bundleid, final String title) {
         return null;
     }
+
     public static String getBundleStartup(final String path, final String bundleid, final String title) {
-        if(bundleid == null) {
+        if (bundleid == null) {
             throw new OskariRuntimeException("Missing bundleid");
         }
         return null;
@@ -44,7 +45,7 @@ public class BundleHelper {
     }
 
     public static void registerBundle(final Bundle bundle) {
-        if(isBundleRegistered(bundle.getName())) {
+        if (isBundleRegistered(bundle.getName())) {
             // already registered
             LOG.info("Bundle", bundle.getName(), "already registered - Skipping!");
             return;
@@ -57,27 +58,27 @@ public class BundleHelper {
     }
 
     public static void registerBundle(final Bundle bundle, Connection conn) throws SQLException {
-        if(isBundleRegistered(bundle.getName(), conn)) {
+        if (isBundleRegistered(bundle.getName(), conn)) {
             // already registered
             LOG.info("Bundle", bundle.getName(), "already registered - Skipping!");
             return;
         }
 
-        try(PreparedStatement statement =
-                    conn.prepareStatement("INSERT INTO portti_bundle(name, config, state) VALUES(?,?,?)")) {
-            statement.setString(1,bundle.getName());
-            statement.setString(2,bundle.getConfig());
-            statement.setString(3,bundle.getState());
+        try (PreparedStatement statement = conn
+                .prepareStatement("INSERT INTO portti_bundle(name, config, state) VALUES(?,?,?)")) {
+            statement.setString(1, bundle.getName());
+            statement.setString(2, bundle.getConfig());
+            statement.setString(3, bundle.getState());
             statement.execute();
         }
     }
 
     public static Bundle getRegisteredBundle(final String id, Connection conn) throws SQLException {
-        try(PreparedStatement statement =
-                    conn.prepareStatement("SELECT id, name, config, state FROM portti_bundle WHERE name=?")) {
+        try (PreparedStatement statement = conn
+                .prepareStatement("SELECT id, name, config, state FROM portti_bundle WHERE name=?")) {
             statement.setString(1, id);
             try (ResultSet rs = statement.executeQuery()) {
-                if(!rs.next()) {
+                if (!rs.next()) {
                     return null;
                 }
                 Bundle b = new Bundle();
@@ -87,6 +88,17 @@ public class BundleHelper {
                 b.setState(rs.getString("state"));
                 return b;
             }
+        }
+    }
+
+    public static void removeBundle(final Bundle bundle, Connection conn) throws SQLException {
+        if (isBundleRegistered(bundle.getName(), conn)) {
+            try (PreparedStatement statement = conn.prepareStatement("DELETE FROM portti_bundle WHERE name=?")) {
+                statement.setString(1, bundle.getName());
+                statement.execute();
+            }
+        } else {
+            LOG.info("Bundle", bundle.getName(), "not registered - Skipping!");
         }
     }
 }

--- a/content-resources/src/main/java/fi/nls/oskari/util/FlywayHelper.java
+++ b/content-resources/src/main/java/fi/nls/oskari/util/FlywayHelper.java
@@ -137,4 +137,16 @@ public class FlywayHelper {
             statement.execute();
         }
     }
+    
+    public static void removeBundleFromView(Connection connection, String bundleName, Long viewId)
+            throws SQLException {
+        final String sql ="DELETE FROM portti_view_bundle_seq " +
+                "WHERE bundle_id = (SELECT id FROM portti_bundle WHERE name=?) AND view_id=?";
+        try(final PreparedStatement statement =
+                    connection.prepareStatement(sql)) {
+            statement.setString(1, bundleName);
+            statement.setLong(2, viewId);
+            statement.execute();
+        }
+    }
 }


### PR DESCRIPTION
- Added helper method to remove registered bundle 
- Added helper method to remove bundle from view

Use case for these is situation when bundle is no longer used and there is need to first remove bundle registration from view(s) and after that remove the bundle.