### PR TITLE
Fixes to class scanned from multiple locations problems

### DIFF
--- a/control-users/pom.xml
+++ b/control-users/pom.xml
@@ -66,11 +66,5 @@
             <artifactId>spring-webmvc</artifactId>
         </dependency>
 
-        <dependency>
-			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-crypto</artifactId>
-			<version>4.0.3.RELEASE</version>
-		</dependency>
-
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -482,11 +482,10 @@
                 <version>${spring-security.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.springframework.security</groupId>
-                <artifactId>spring-security-crypto</artifactId>
-                <version>${spring-security.version}</version>
-            </dependency>
-
+								<groupId>org.springframework.security</groupId>
+								<artifactId>spring-security-core</artifactId>
+								<version>${spring-security.version}</version>
+						</dependency>
             <dependency>
                 <groupId>xerces</groupId>
                 <artifactId>xercesImpl</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -475,16 +475,43 @@
                 <groupId>org.springframework.security</groupId>
                 <artifactId>spring-security-web</artifactId>
                 <version>${spring-security.version}</version>
+                <exclusions>
+                    <!-- exclude aopalliance
+                    Reason: Same classes are included in spring-aop (causing conflict if we have both)
+                    -->
+                    <exclusion>
+                        <groupId>aopalliance</groupId>
+                        <artifactId>aopalliance</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.springframework.security</groupId>
                 <artifactId>spring-security-config</artifactId>
                 <version>${spring-security.version}</version>
+                 <exclusions>
+                    <!-- exclude aopalliance
+                    Reason: Same classes are included in spring-aop (causing conflict if we have both)
+                    -->
+                    <exclusion>
+                        <groupId>aopalliance</groupId>
+                        <artifactId>aopalliance</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
 								<groupId>org.springframework.security</groupId>
 								<artifactId>spring-security-core</artifactId>
 								<version>${spring-security.version}</version>
+								<exclusions>
+                    <!-- exclude aopalliance
+                    Reason: Same classes are included in spring-aop (causing conflict if we have both)
+                    -->
+                    <exclusion>
+                        <groupId>aopalliance</groupId>
+                        <artifactId>aopalliance</artifactId>
+                    </exclusion>
+                </exclusions>
 						</dependency>
             <dependency>
                 <groupId>xerces</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -728,6 +728,10 @@
                         <groupId>org.apache.james</groupId>
                         <artifactId>apache-mime4j-core</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.geronimo.specs</groupId>
+                        <artifactId>geronimo-activation_1.1_spec</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>

--- a/service-users/pom.xml
+++ b/service-users/pom.xml
@@ -19,18 +19,18 @@
             <groupId>fi.nls.oskari.service</groupId>
             <artifactId>oskari-base</artifactId>
         </dependency>
-		<dependency>
-			<groupId>fi.nls.oskari.service</groupId>
-			<artifactId>oskari-map</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>fi.nls.oskari.service</groupId>
-			<artifactId>oskari-myplaces</artifactId>
-		</dependency>
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-crypto</artifactId>
-        </dependency>
+				<dependency>
+					<groupId>fi.nls.oskari.service</groupId>
+					<artifactId>oskari-map</artifactId>
+				</dependency>
+				<dependency>
+					<groupId>fi.nls.oskari.service</groupId>
+					<artifactId>oskari-myplaces</artifactId>
+				</dependency>
+				<dependency>
+					<groupId>org.springframework.security</groupId>
+					<artifactId>spring-security-core</artifactId>
+				</dependency>
     </dependencies>
     <build>
     	<pluginManagement>


### PR DESCRIPTION
This PR contains fixes to resolve some (but not all) _class scanned from multiple locations_ warnings logged during oskari-server startup.

- Reguired dependencies spring-security-web and spring-security-config declared in oskari-server pom.xml are dependent of spring-security-core which contains same classes and more than spring-security-crypto . Because both mentioned jars were included in classpath, class scanned from multiple locations - warnings were logged during oskari-server application startup for classes contained in both 
spring-security-core and spring-security-crypto. Provided fix for mentioned problem in this PR is to replace spring-security-crypto dependency with spring-security-core dependency. With this solution only one versions of mentioned crypto classes are in classpath got from spring-security-core jar which is needed in classpath.

-  spring-security-config, spring-security-core and spring-security-web all have aopalliance dependency with scope compile and this causes aopalliance jar to be included in oskari-server application. These aopalliance classes are also included in spring-aop jar which caused class scanned from multiple locations- warnings. This PR contains changes to use aopalliance classes contained in spring-aop dependency jar by excluding aopalliance artifact from other mentioned dependencies and with this change aopalliance jar is not pulled to oskari-server application.  

- geronimo-activation dependency which is dependency of axiom-api uses maven-bundle-plugin to include javax.activation* version 1.1 classes to geronimo-activation jar package. javax.activation-api also contains these classes with newer 1.2.0 version and it is dependency of jaxb-api causing scanned from multiple locations- warnings during oskari-server startup. This PR contains changes to include only javax.activation* classes from javax.activation-api:jar:1.2.0 to classpath. This is achieved by excluding artifact geronimo-activation_1.1_spec from axiom-api dependency definition. Excluded geronimo-activation jar also contained some other than javax.activation* classes but this change feels safe since code compiles without issues and unit tests pass. 