### PR TITLE
Use map view specific publishing templates

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/view/AppSetupHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/view/AppSetupHandler.java
@@ -224,8 +224,7 @@ public class AppSetupHandler extends RestActionHandler {
         }
 
         // setup map state
-        setupMapState(view, user, viewdata.optJSONObject(ViewModifier.BUNDLE_MAPFULL),
-                params.getRequiredParam(PARAM_PUBLISHER_VIEW_UUID));
+        setupMapState(view, user, viewdata.optJSONObject(ViewModifier.BUNDLE_MAPFULL), publishedFromUuid);
 
         // check if we need to add divmanazer
         for(String bundleid : BUNDLE_REQUIRES_DIVMANAZER) {

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/view/View.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/view/View.java
@@ -264,6 +264,7 @@ public class View implements Serializable {
         view.setPage(getPage());
         view.setPubDomain(getPubDomain());
         view.setIsDefault(isDefault());
+        view.setMetadata(getMetadata());
         for(Bundle bundle : getBundles()) {
             view.addBundle(bundle.clone());
         }


### PR DESCRIPTION
Setting `publishTemplateUuid` to map view's metadata enables view specific publishing template.