### PR TITLE
Fixes to classes scanned from multiple locations problems part 2

### DIFF
--- a/control-users/pom.xml
+++ b/control-users/pom.xml
@@ -59,6 +59,13 @@
 			<groupId>javax.mail</groupId>
 			<artifactId>javax.mail-api</artifactId>
 			<version>1.5.4</version>
+			<exclusions>
+				<!-- Exclude activation to use newer classes from javax.activation-api (causing conflict if we have both) -->
+				<exclusion>
+					<groupId>javax.activation</groupId>
+					<artifactId>activation</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		 <dependency>

--- a/download-basket/pom.xml
+++ b/download-basket/pom.xml
@@ -42,11 +42,25 @@
 			<groupId>javax.mail</groupId>
 			<artifactId>mail</artifactId>
 			<version>${javax.mail.version}</version>
+			<!-- Exclude activation to use newer classes from javax.activation-api (causing conflict if we have both) -->
+			<exclusions>
+				<exclusion>
+					<groupId>javax.activation</groupId>
+					<artifactId>activation</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-email</artifactId>
 			<version>${commons-email.version}</version>
+			<exclusions>
+				<!-- Exclude activation to use newer classes from javax.activation-api (causing conflict if we have both) -->
+				<exclusion>
+					<groupId>javax.activation</groupId>
+					<artifactId>activation</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -497,6 +497,15 @@
                 <groupId>org.apache.xmlbeans</groupId>
                 <artifactId>xmlbeans</artifactId>
                 <version>${xmlbeans.version}</version>
+                <exclusions>
+                    <!-- exclude stax-api
+                    	Reason: xml-apis lib provide newer version of classes which are used (causing conflict if we have both)
+                    -->
+                    <exclusion>
+                        <groupId>stax</groupId>
+                        <artifactId>stax-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -701,6 +710,13 @@
                     <exclusion>
                         <groupId>org.apache.james</groupId>
                         <artifactId>apache-mime4j-core</artifactId>
+                    </exclusion>
+                    <!-- exclude stax-api
+                    	Reason: xml-apis lib provide newer version of classes which are used (causing conflict if we have both)
+                    -->
+                    <exclusion>
+                        <groupId>org.apache.geronimo.specs</groupId>
+                        <artifactId>geronimo-stax-api_1.0_spec</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
         <slf4j.version>1.7.12</slf4j.version>
         <metrics.version>4.0.3</metrics.version>
         <h2database.version>1.4.199</h2database.version>
-
+        <xom.version>1.2.5</xom.version>
     </properties>
 
     <dependencies>
@@ -928,6 +928,12 @@
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-core</artifactId>
                 <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+		<groupId>xom</groupId>
+		<artifactId>xom</artifactId>
+		<version>${xom.version}</version>
+		<scope>provided</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
This PR contains following fixes to _class scanned from multiple locations_ warnings logged during oskari-server startup.

- Exclude geronimo-stax-api and stax-api transitive dependencies. With these changes newer classes from xml-apis dependency are used. 
- Add xom as direct dependency with scope provided to exclude xom jar from classpath. _mvn dependency:tree -Dverbose_ command did not list this dependency but jar was included to classpath path. For this reason excluded with mentioned way instead of exclusion tag.
- Exclude activation transitive dependency. With this change newer classes from javax.activation-api dependency are used.