### PR TITLE
Regionset permissions

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/data/CreateAnalysisLayerHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/data/CreateAnalysisLayerHandler.java
@@ -221,7 +221,7 @@ public class CreateAnalysisLayerHandler extends RestActionHandler {
             analysisResource.setMapping("analysis", Long.toString(analysis.getId()));
             for(Permission p : sourceResource.get().getPermissions()) {
                 // check if user has role matching permission?
-                if(p.isOfType(Permissions.PERMISSION_TYPE_PUBLISH) || p.isOfType(Permissions.PERMISSION_TYPE_VIEW_PUBLISHED) || p.isOfType(Permissions.PERMISSION_TYPE_DOWNLOAD)) {
+                if(p.isOfType(PermissionType.PUBLISH) || p.isOfType(PermissionType.VIEW_PUBLISHED) || p.isOfType(PermissionType.DOWNLOAD)) {
                     analysisResource.addPermission(p.clonePermission());
                 }
             }
@@ -302,17 +302,15 @@ public class CreateAnalysisLayerHandler extends RestActionHandler {
             final Resource resource = new Resource();
             // permission to publish for self
             final Permission permPublish = new Permission();
-            permPublish.setExternalType(Permissions.EXTERNAL_TYPE_USER);
-            permPublish.setExternalId("" + user.getId());
-            permPublish.setType(Permissions.PERMISSION_TYPE_PUBLISH);
+            permPublish.setUserId((int) user.getId());
+            permPublish.setType(PermissionType.PUBLISH);
             resource.addPermission(permPublish);
             try {
                 // add VIEW_PUBLISHED for all roles currently in the system
                 for(Role role: UserService.getInstance().getRoles()) {
                     final Permission perm = new Permission();
-                    perm.setExternalType(Permissions.EXTERNAL_TYPE_ROLE);
-                    perm.setExternalId("" + role.getId());
-                    perm.setType(Permissions.PERMISSION_TYPE_VIEW_PUBLISHED);
+                    perm.setRoleId((int) role.getId());
+                    perm.setType(PermissionType.VIEW_PUBLISHED);
                     resource.addPermission(perm);
                 }
             } catch (Exception e) {

--- a/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/StatisticalDatasourceFactory.java
+++ b/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/StatisticalDatasourceFactory.java
@@ -50,16 +50,15 @@ public abstract class StatisticalDatasourceFactory extends OskariComponent {
             PermissionService permissionService = OskariComponentManager.getComponentOfType(PermissionService.class);
             List<OskariLayer> layers = layerService.findByIdList(layerIdList);
 
-            Map<Integer, Set<Long>> rolesForLayers = new HashMap<>();
-            layers.forEach(layer -> {
+            // layer id -> set of role ids that have permissions
+            Map<String, Set<Long>> rolesForLayers = new HashMap<>();
+            layers.forEach(layer ->
                 permissionService.findResource(ResourceType.maplayer, new OskariLayerResource(layer).getMapping())
-                        .ifPresent( res -> {
-                            rolesForLayers.put(layer.getId(), getRoleIdsForLayer(res.getPermissions()));
-                        });
-
-            });
+                        .ifPresent( res ->
+                                rolesForLayers.put(Integer.toString(layer.getId()), getRoleIdsForLayer(res.getPermissions())))
+            );
             //  Adds roles that are permitted to see the regionset for the layer
-            layerRows.forEach( dsLayer -> dsLayer.addRoles(rolesForLayers.getOrDefault(dsLayer.getMaplayerId(), Collections.emptySet())));
+            layerRows.forEach( dsLayer -> dsLayer.addRoles(rolesForLayers.getOrDefault(Long.toString(dsLayer.getMaplayerId()), Collections.emptySet())));
             source.setLayers(layerRows);
         }
     }


### PR DESCRIPTION
Fixes an issue where permissions were mapped by int key but fetched with long resulted in no regionset having any permissions. Now the code makes strings of the numbers to get the correct permissions mapped to layers.

Also includes unrelated change where uses of constants from Permissions clsas is being replaced by the the new PermissionType enum.