### PR TITLE
Fix user content loading in 3D

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandler.java
@@ -65,7 +65,15 @@ public class GetWFSFeaturesHandler extends AbstractWFSFeaturesHandler {
 
         SimpleFeatureCollection fc;
         try {
-            fc = featureClient.getFeatures(id, layer, bbox, targetCRS, contentProcessor);
+            if (contentProcessor.isPresent()) {
+                // User content layer. Make the search in native crs.
+                // Geoserver BBOX filter doesn't work for other projections.
+                CoordinateReferenceSystem nativeCRS = featureClient.getNativeCRS();
+                fc = featureClient.getFeatures(id, layer, bbox, nativeCRS, targetCRS, contentProcessor);
+            }
+            else {
+                fc = featureClient.getFeatures(id, layer, bbox, targetCRS, null);
+            }
         } catch (ServiceRuntimeException e) {
             throw new ActionCommonException(ERR_FAILED_TO_RETRIEVE_FEATURES, e);
         }

--- a/control-base/src/main/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandler.java
@@ -72,7 +72,7 @@ public class GetWFSFeaturesHandler extends AbstractWFSFeaturesHandler {
                 fc = featureClient.getFeatures(id, layer, bbox, nativeCRS, targetCRS, contentProcessor);
             }
             else {
-                fc = featureClient.getFeatures(id, layer, bbox, targetCRS, null);
+                fc = featureClient.getFeatures(id, layer, bbox, targetCRS, contentProcessor);
             }
         } catch (ServiceRuntimeException e) {
             throw new ActionCommonException(ERR_FAILED_TO_RETRIEVE_FEATURES, e);

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariFeatureClient.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariFeatureClient.java
@@ -29,7 +29,7 @@ public class OskariFeatureClient {
         this.wfsClient = Objects.requireNonNull(wfsClient);
     }
 
-    protected CoordinateReferenceSystem getNativeCRS() {
+    public CoordinateReferenceSystem getNativeCRS() {
         if (nativeCRS == null) {
             try {
                 String nativeSrs = PropertyUtil.get(PROPERTY_NATIVE_SRS, "EPSG:4326");
@@ -43,7 +43,7 @@ public class OskariFeatureClient {
 
     public SimpleFeatureCollection getFeatures(String id, OskariLayer layer, ReferencedEnvelope bbox,
             CoordinateReferenceSystem nativeCRS, CoordinateReferenceSystem targetCRS,
-            Optional<UserLayerService> processor) throws ServiceException {
+            Optional<UserLayerService> processor) throws ServiceRuntimeException {
         boolean needsTransform = !CRS.equalsIgnoreMetadata(nativeCRS, targetCRS);
 
         // Request features in nativeCRS (of the installation)
@@ -53,7 +53,7 @@ public class OskariFeatureClient {
             try {
                 requestBbox = bbox.transform(nativeCRS, true);
             } catch (Exception e) {
-                throw new ServiceException(ERR_REPOJECTION_FAIL, e);
+                throw new ServiceRuntimeException(ERR_REPOJECTION_FAIL, e);
             }
         }
 
@@ -67,7 +67,7 @@ public class OskariFeatureClient {
             CoordinateTransformer transformer = new CoordinateTransformer(nativeCRS, targetCRS);
             return transformer.transform(features);
         } catch (Exception e) {
-            throw new ServiceException(ERR_REPOJECTION_FAIL, e);
+            throw new ServiceRuntimeException(ERR_REPOJECTION_FAIL, e);
         }
     }
 


### PR DESCRIPTION
Workaround for Geoserver `FILTER BBOX gml:Box srsName` which didn't work.

Convert bbox to native srs before searching for features.