### PR TITLE
Disabled CSRF protection on webapp level

### DIFF
--- a/MigrationGuide.md
+++ b/MigrationGuide.md
@@ -2,6 +2,15 @@
 
 ## 1.53.0
 
+### Disabled CSRF protection on webapp level
+
+The previous cross-site request forgery protection used cookies and http headers to detect if a given request to the server
+was legit. Because certain browsers block 3rd party cookies by default this didn't really work on embedded maps.
+ Java libraries don't yet support adding SameSite-flag on cookies which is the current solution to protect against
+ CSRF attacks. You should configure your reverse-proxy to modify cookies to have SameSite=lax flag.
+
+Here's an example how to do this with nginx: https://github.com/oskariorg/sample-configs/commit/e3802ccd84d866dc1643f7dfc98f80bf6fe5cde9
+
 ### PermissionService migrated to MyBatis
 
 Also class packages have been changed a bit so manual updates is required for server-extensions referencing PermissionService.

--- a/servlet-map/src/main/java/fi/nls/oskari/spring/security/OskariCommonSecurityConfig.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/spring/security/OskariCommonSecurityConfig.java
@@ -28,8 +28,9 @@ public class OskariCommonSecurityConfig extends WebSecurityConfigurerAdapter {
 
         final String logoutUrl = env.getLogoutUrl();
 
-        // CSRF config is needed in this particular config even if it's not otherwise configured here...
-        http.csrf().ignoringAntMatchers(logoutUrl);
+        // 3rd party cookie blockers don't really work with cookie based CSRF protection on embedded maps.
+        // Configure nginx to attach SameSite-flag to cookies instead.
+        http.csrf().disable();
         http
             .headers().frameOptions().disable()
             .and()

--- a/servlet-map/src/main/java/fi/nls/oskari/spring/security/database/OskariDatabaseSecurityConfig.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/spring/security/database/OskariDatabaseSecurityConfig.java
@@ -37,8 +37,9 @@ public class OskariDatabaseSecurityConfig extends WebSecurityConfigurerAdapter {
         http.authenticationProvider( new OskariAuthenticationProvider() );
         http.headers().frameOptions().disable();
 
-        // require form parameter "_csrf" OR "X-XSRF-TOKEN" header with token as value or respond with an error message
-        http.csrf().csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse());
+        // 3rd party cookie blockers don't really work with cookie based CSRF protection on embedded maps.
+        // Configure nginx to attach SameSite-flag to cookies instead.
+        http.csrf().disable();
 
         // IMPORTANT! Only antMatch for processing url, otherwise SAML security filters are passed even if both are active
         http.formLogin()


### PR DESCRIPTION
The previous cross-site request forgery protection used cookies and http headers to detect if a given request to the server was legit. Because certain browsers block 3rd party cookies by default this didn't really work on embedded maps. Java libraries don't yet support adding SameSite-flag on cookies which is the current solution to protect against CSRF attacks. You should configure your reverse-proxy to modify cookies to have SameSite=lax flag.