### PR TITLE
Cleanup after permissions changes

### DIFF
--- a/MigrationGuide.md
+++ b/MigrationGuide.md
@@ -22,8 +22,9 @@ Also class packages have been changed a bit so manual updates is required for se
 See https://github.com/nls-oskari/kartta.paikkatietoikkuna.fi/pull/102 for example and
 https://github.com/oskariorg/oskari-server/pull/271 for details about the change.
 
-OskariLayerResource has been deprecated since it now longer serves any purpose. The mapping of layer permissions mapping
- has been changed from type+url+name to use the layer id.
+OskariLayerResource has been deprecated since it no longer serves any purpose. The mapping of layer permissions mapping
+ has been changed from type+url+name to use the layer id. Note that this might break some old migrations that use it
+ if run on an empty database
 
 ## 1.52.0
 

--- a/MigrationGuide.md
+++ b/MigrationGuide.md
@@ -15,12 +15,15 @@ Here's an example how to do this with nginx: https://github.com/oskariorg/sample
 
 Also class packages have been changed a bit so manual updates is required for server-extensions referencing PermissionService.
 
-- fi.nls.oskari.map.data.domain.OskariLayerResource is now org.oskari.permissions.model.OskariLayerResource
 - fi.nls.oskari.permission.domain.Permission is now org.oskari.permissions.model.Permission
 - fi.nls.oskari.permission.domain.Resource is now org.oskari.permissions.model.Resource
+- fi.nls.oskari.map.data.domain.OskariLayerResource is now org.oskari.permissions.model.OskariLayerResource and is now deprecated.
 
 See https://github.com/nls-oskari/kartta.paikkatietoikkuna.fi/pull/102 for example and
 https://github.com/oskariorg/oskari-server/pull/271 for details about the change.
+
+OskariLayerResource has been deprecated since it now longer serves any purpose. The mapping of layer permissions mapping
+ has been changed from type+url+name to use the layer id.
 
 ## 1.52.0
 

--- a/content-resources/src/main/java/fi/nls/oskari/db/LayerHelper.java
+++ b/content-resources/src/main/java/fi/nls/oskari/db/LayerHelper.java
@@ -23,10 +23,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.oskari.permissions.PermissionService;
 import org.oskari.permissions.PermissionServiceMybatisImpl;
-import org.oskari.permissions.model.OskariLayerResource;
-import org.oskari.permissions.model.Permission;
-import org.oskari.permissions.model.PermissionExternalType;
-import org.oskari.permissions.model.Resource;
+import org.oskari.permissions.model.*;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -57,7 +54,7 @@ public class LayerHelper {
             // layer doesn't exist, insert it
             int id = service.insert(layer);
             layer.setId(id);
-            setupLayerPermissions(json.getJSONObject("role_permissions"), layer);
+            setupLayerPermissions(json.getJSONObject("role_permissions"), id);
 
             final String groupName = json.getString("inspiretheme");
             // handle inspiretheme
@@ -143,13 +140,15 @@ public class LayerHelper {
         "Administrator" : ["VIEW_LAYER"]
     }
     */
-    private static void setupLayerPermissions(JSONObject permissions, OskariLayer layer) {
+    private static void setupLayerPermissions(JSONObject permissions, int layerId) {
 
         // setup rights
         if(permissions == null) {
             return;
         }
-        final Resource res = new OskariLayerResource(layer);
+        final Resource res = new Resource();
+        res.setType(ResourceType.maplayer);
+        res.setMapping(Integer.toString(layerId));
 
         final Iterator<String> roleNames = permissions.keys();
         while(roleNames.hasNext()) {

--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/SystemViewsHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/SystemViewsHandler.java
@@ -22,7 +22,6 @@ import fi.nls.oskari.view.modifier.ViewModifier;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.oskari.permissions.PermissionService;
-import org.oskari.permissions.model.OskariLayerResource;
 import org.oskari.permissions.model.PermissionType;
 import org.oskari.permissions.model.ResourceType;
 import org.oskari.service.util.ServiceFactory;
@@ -198,7 +197,7 @@ public class SystemViewsHandler extends RestActionHandler {
         try {
             User guest = UserService.getInstance().getGuestUser();
             for(OskariLayer layer : layers) {
-                boolean notAvailableForGuestUsers = permissionsService.findResource(ResourceType.maplayer, new OskariLayerResource(layer).getMapping())
+                boolean notAvailableForGuestUsers = permissionsService.findResource(ResourceType.maplayer, Integer.toString(layer.getId()))
                         .filter(r -> !r.hasPermission(guest, PermissionType.VIEW_LAYER)).isPresent();
                 if(notAvailableForGuestUsers) {
                     notAvailable.add(Integer.toString(layer.getId()));

--- a/control-base/src/main/java/fi/nls/oskari/control/data/CreateAnalysisLayerHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/data/CreateAnalysisLayerHandler.java
@@ -332,7 +332,7 @@ public class CreateAnalysisLayerHandler extends RestActionHandler {
         }
         final OskariLayer layer = mapLayerService.find(id);
         // copy permissions from source layer to new analysis
-        return permissionsService.findResource(ResourceType.maplayer, new OskariLayerResource(layer).getMapping());
+        return permissionsService.findResource(ResourceType.maplayer, Integer.toString(layer.getId()));
     }
 
 

--- a/control-base/src/main/java/fi/nls/oskari/control/feature/AbstractFeatureHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/feature/AbstractFeatureHandler.java
@@ -43,7 +43,6 @@ import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 import org.oskari.permissions.PermissionService;
-import org.oskari.permissions.model.OskariLayerResource;
 import org.oskari.permissions.model.PermissionType;
 import org.oskari.permissions.model.ResourceType;
 import org.oskari.service.util.ServiceFactory;
@@ -81,7 +80,7 @@ public abstract class AbstractFeatureHandler extends RestActionHandler {
     }
 
     protected boolean canEdit(OskariLayer layer, User user) {
-        return permissionsService.findResource(ResourceType.maplayer, new OskariLayerResource(layer).getMapping())
+        return permissionsService.findResource(ResourceType.maplayer, Integer.toString(layer.getId()))
                 .filter(r -> r.hasPermission(user, PermissionType.EDIT_LAYER_CONTENT)).isPresent();
     }
 

--- a/control-base/src/main/java/fi/nls/oskari/control/layer/AbstractLayerAdminHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/AbstractLayerAdminHandler.java
@@ -5,7 +5,6 @@ import fi.nls.oskari.domain.User;
 import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.service.OskariComponentManager;
 import org.oskari.permissions.PermissionService;
-import org.oskari.permissions.model.OskariLayerResource;
 import org.oskari.permissions.model.PermissionType;
 import org.oskari.permissions.model.ResourceType;
 
@@ -23,7 +22,7 @@ public abstract class AbstractLayerAdminHandler extends RestActionHandler {
     }
 
     protected boolean userHasEditPermission(User user, OskariLayer layer) {
-        return user.isAdmin() || permissionsService.findResource(ResourceType.maplayer, new OskariLayerResource(layer).getMapping())
+        return user.isAdmin() || permissionsService.findResource(ResourceType.maplayer, Integer.toString(layer.getId()))
                 .filter(r -> r.hasPermission(user, PermissionType.EDIT_LAYER)).isPresent();
     }
 

--- a/control-base/src/main/java/fi/nls/oskari/control/layer/GetPermissionsLayerHandlers.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/GetPermissionsLayerHandlers.java
@@ -106,14 +106,13 @@ public class GetPermissionsLayerHandlers extends ActionHandler {
                 continue;
             }
             try {
-                final OskariLayerResource res = new OskariLayerResource(layer);
                 JSONObject realJson = new JSONObject();
                 realJson.put(KEY_ID, layer.getId());
                 realJson.put(KEY_NAME, layer.getName(PropertyUtil.getDefaultLanguage()));
                 realJson.put(JSON_NAMES_SPACE, Integer.toString(layer.getId()));
                 realJson.put(JSON_RESOURCE_NAME, Integer.toString(layer.getId()));
 
-                Optional<Resource> layerResource = permissions.get(ResourceType.maplayer, res.getMapping());
+                Optional<Resource> layerResource = permissions.get(ResourceType.maplayer, Integer.toString(layer.getId()));
                 JSONArray jsonResults = new JSONArray();
                 for (String permission : getAvailablePermissions()) {
                     JSONObject layerJson = new JSONObject();

--- a/control-base/src/main/java/fi/nls/oskari/control/layer/PermissionHelper.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/PermissionHelper.java
@@ -1,7 +1,6 @@
 package fi.nls.oskari.control.layer;
 
 import org.oskari.permissions.PermissionService;
-import org.oskari.permissions.model.OskariLayerResource;
 import org.oskari.permissions.model.PermissionType;
 import org.oskari.permissions.model.Resource;
 

--- a/control-base/src/main/java/fi/nls/oskari/control/layer/SaveLayerHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/SaveLayerHandler.java
@@ -684,8 +684,9 @@ public class SaveLayerHandler extends AbstractLayerAdminHandler {
                                         final Set<Integer> publishRoleIds,
                                         final Set<Integer> downloadRoleIds,
                                         final Set<Integer> viewEmbeddedRoleIds) {
-
-        OskariLayerResource res = new OskariLayerResource(ml);
+        Resource res = new Resource();
+        res.setType(ResourceType.maplayer);
+        res.setMapping(Integer.toString(ml.getId()));
         // insert permissions
         LOG.debug("Adding permission", PermissionType.VIEW_LAYER, "for roles:", externalIds);
         for (int externalId : externalIds) {

--- a/control-base/src/main/java/fi/nls/oskari/control/view/PublishPermissionHelper.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/view/PublishPermissionHelper.java
@@ -235,7 +235,7 @@ public class PublishPermissionHelper {
             LOG.warn("Couldn't find layer with id:", id);
             return false;
         }
-        boolean hasPermission = permissionsService.findResource(ResourceType.maplayer, new OskariLayerResource(layer).getMapping())
+        boolean hasPermission = permissionsService.findResource(ResourceType.maplayer, Integer.toString(layer.getId()))
                 .filter(r -> r.hasPermission(user, PermissionType.PUBLISH)).isPresent();
         if (!hasPermission) {
             LOG.warn("User tried to publish layer with no publish permission. LayerID:", layerId, "- User:", user);

--- a/service-permissions/src/main/java/org/oskari/permissions/model/OskariLayerResource.java
+++ b/service-permissions/src/main/java/org/oskari/permissions/model/OskariLayerResource.java
@@ -4,7 +4,9 @@ import fi.nls.oskari.domain.map.OskariLayer;
 
 /**
  * Convenience mapping of oskari-permission/Resource for OskariLayer
+ * @deprecated Use plain Resource instead as layer id is used as mapping.
  */
+@Deprecated
 public class OskariLayerResource extends Resource {
 
     public OskariLayerResource(OskariLayer layer) {

--- a/service-permissions/src/main/java/org/oskari/permissions/model/OskariLayerResource.java
+++ b/service-permissions/src/main/java/org/oskari/permissions/model/OskariLayerResource.java
@@ -1,10 +1,11 @@
 package org.oskari.permissions.model;
 
 import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.service.ServiceRuntimeException;
 
 /**
  * Convenience mapping of oskari-permission/Resource for OskariLayer
- * @deprecated Use plain Resource instead as layer id is used as mapping.
+ * @deprecated Use Resource instead as layer id is used for mapping this has become unnecessary.
  */
 @Deprecated
 public class OskariLayerResource extends Resource {
@@ -15,6 +16,11 @@ public class OskariLayerResource extends Resource {
 
     public OskariLayerResource(int layerId) {
         this(Integer.toString(layerId));
+    }
+
+    public OskariLayerResource(String type, String url, String name) {
+        // so old code doesn't need to be modified and signals problem on migrations etc
+        throw new ServiceRuntimeException("This is no longer supported. Use layer id as mapping instead");
     }
 
     public OskariLayerResource(String layerId) {

--- a/service-permissions/src/test/java/org/oskari/permissions/PermissionServiceMybatisImplTest.java
+++ b/service-permissions/src/test/java/org/oskari/permissions/PermissionServiceMybatisImplTest.java
@@ -1,6 +1,5 @@
 package org.oskari.permissions;
 
-import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.test.util.ResourceHelper;
 import fi.nls.test.util.TestHelper;
 import org.junit.Before;

--- a/service-search-wfs/src/main/java/fi/nls/oskari/search/channel/WFSSearchChannel.java
+++ b/service-search-wfs/src/main/java/fi/nls/oskari/search/channel/WFSSearchChannel.java
@@ -7,7 +7,6 @@ import fi.nls.oskari.cache.Cache;
 import fi.nls.oskari.cache.CacheManager;
 import fi.nls.oskari.domain.SelectItem;
 import fi.nls.oskari.domain.User;
-import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.map.geometry.WKTHelper;
 import fi.nls.oskari.service.OskariComponentManager;
 import fi.nls.oskari.util.JSONHelper;
@@ -15,7 +14,6 @@ import org.geotools.geojson.geom.GeometryJSON;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.oskari.permissions.PermissionService;
-import org.oskari.permissions.model.OskariLayerResource;
 import org.oskari.permissions.model.PermissionType;
 import org.oskari.permissions.model.Resource;
 import org.oskari.permissions.model.ResourceType;
@@ -73,8 +71,8 @@ public class WFSSearchChannel extends SearchChannel {
         final String cacheKey = config.getUrl() + config.getLayerName();
         Resource resource = cache.get(cacheKey);
         if(resource == null) {
-            Optional<Resource> maybeResource = getPermissionService().findResource(ResourceType.maplayer,
-                    new OskariLayerResource(config.getId()).getMapping());
+            Optional<Resource> maybeResource =
+                    getPermissionService().findResource(ResourceType.maplayer, Integer.toString(config.getId()));
             if(!maybeResource.isPresent()) {
                 return false;
             }

--- a/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/StatisticalDatasourceFactory.java
+++ b/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/StatisticalDatasourceFactory.java
@@ -17,7 +17,6 @@ import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 import org.apache.ibatis.transaction.TransactionFactory;
 import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
 import org.oskari.permissions.PermissionService;
-import org.oskari.permissions.model.OskariLayerResource;
 import org.oskari.permissions.model.Permission;
 import org.oskari.permissions.model.PermissionExternalType;
 import org.oskari.permissions.model.ResourceType;
@@ -53,7 +52,7 @@ public abstract class StatisticalDatasourceFactory extends OskariComponent {
             // layer id -> set of role ids that have permissions
             Map<String, Set<Long>> rolesForLayers = new HashMap<>();
             layers.forEach(layer ->
-                permissionService.findResource(ResourceType.maplayer, new OskariLayerResource(layer).getMapping())
+                permissionService.findResource(ResourceType.maplayer, Integer.toString(layer.getId()))
                         .ifPresent( res ->
                                 rolesForLayers.put(Integer.toString(layer.getId()), getRoleIdsForLayer(res.getPermissions())))
             );


### PR DESCRIPTION
Continues #435 by deprecating OskariLayerResource and restoring the constructor for backwards compatibility (but throwing exception on it so developers know everything didn't go right as it's mostly used in migrations).