### PR TITLE
WFS2 client

### DIFF
--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariGML.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariGML.java
@@ -95,7 +95,7 @@ public class OskariGML extends GML {
                     return collection;
                 }
             }
-            return null; // nothing found
+            return new DefaultFeatureCollection(); // nothing found, return empty collection
         } else {
             throw new ClassCastException(
                     obj.getClass()

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariGML32.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariGML32.java
@@ -1,0 +1,51 @@
+package org.oskari.service.wfs.client;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.feature.DefaultFeatureCollection;
+
+import org.geotools.xml.DOMParser;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
+import fi.nls.oskari.util.XmlHelper;
+import net.opengis.wfs20.FeatureCollectionType;
+
+public class OskariGML32 {
+
+    public SimpleFeatureCollection decodeFeatureCollection(InputStream in, String username, String password)
+            throws IOException, SAXException, ParserConfigurationException {
+        DocumentBuilderFactory dbf = XmlHelper.newDocumentBuilderFactory();
+        dbf.setNamespaceAware(true);
+        DocumentBuilder db = dbf.newDocumentBuilder();
+        Document doc = db.parse(in);
+        in.close();
+
+        DOMParser parser = new DOMParser(new OskariWFS2Configuration(username, password), doc);
+        Object obj = parser.parse();
+        return toFeatureCollection(obj);
+    }
+
+    private SimpleFeatureCollection toFeatureCollection(Object obj) {
+        if (obj == null) {
+            return null; // not available?
+        }
+        if (obj instanceof FeatureCollectionType) {
+            FeatureCollectionType collectionType = (FeatureCollectionType) obj;
+            List fc = collectionType.getMember();
+            return fc.isEmpty() ? new DefaultFeatureCollection() : (SimpleFeatureCollection) fc.get(0);
+        } else {
+            throw new ClassCastException(
+                    obj.getClass()
+                            + " produced when FeatureCollection expected"
+                            + " check schema use of AbstractFeatureCollection");
+        }
+    }
+}

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS110Client.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS110Client.java
@@ -45,7 +45,6 @@ public class OskariWFS110Client {
         try {
             return OskariWFSClient.parseGeoJSON(new ByteArrayInputStream(response), crs);
         } catch (IOException e) {
-            //TODO kannattaako siirtää endpoint, query
             if (!OskariWFSClient.isOutputFormatInvalid(new ByteArrayInputStream(response))) {
                 // If we can not determine that the exception was due to bad
                 // outputFormat parameter then don't bother trying GML

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS110Client.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS110Client.java
@@ -6,23 +6,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.Locale;
 import java.util.Map;
 
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.filter.v1_0.OGCConfiguration;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.xml.Encoder;
-import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.filter.Filter;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
-import org.oskari.geojson.GeoJSONReader2;
-import org.oskari.geojson.GeoJSONSchemaDetector;
-
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
@@ -36,10 +28,6 @@ public class OskariWFS110Client {
 
     private static final Logger LOG = LogFactory.getLogger(OskariWFS110Client.class);
     private static final OskariGML OSKARI_GML = new OskariGML();
-    private static final int MAX_REDIRECTS = 5;
-    private static final ObjectMapper OM = new ObjectMapper();
-    private static final TypeReference<HashMap<String, Object>> TYPE_REF = new TypeReference<HashMap<String, Object>>() {};
-    private static final String EXC_HANDLING_OUTPUTFORMAT = "outputformat";
 
     private OskariWFS110Client() {}
 
@@ -53,11 +41,12 @@ public class OskariWFS110Client {
         Map<String, String> query = getQueryParams(typeName, bbox, crs, maxFeatures, filter);
         query.put("OUTPUTFORMAT", "application/json");
 
-        byte[] response = getResponse(endPoint, user, pass, query);
+        byte[] response = OskariWFSClient.getResponse(endPoint, user, pass, query);
         try {
-            return parseGeoJSON(new ByteArrayInputStream(response), crs);
+            return OskariWFSClient.parseGeoJSON(new ByteArrayInputStream(response), crs);
         } catch (IOException e) {
-            if (!isOutputFormatInvalid(new ByteArrayInputStream(response))) {
+            //TODO kannattaako siirtää endpoint, query
+            if (!OskariWFSClient.isOutputFormatInvalid(new ByteArrayInputStream(response))) {
                 // If we can not determine that the exception was due to bad
                 // outputFormat parameter then don't bother trying GML
                 final String url = IOHelper.constructUrl(endPoint, query);
@@ -68,7 +57,7 @@ public class OskariWFS110Client {
 
         // Fallback to GML
         query.remove("OUTPUTFORMAT");
-        response = getResponse(endPoint, user, pass, query);
+        response = OskariWFSClient.getResponse(endPoint, user, pass, query);
 
         try {
             return OSKARI_GML.decodeFeatureCollection(new ByteArrayInputStream(response), user, pass);
@@ -84,28 +73,21 @@ public class OskariWFS110Client {
             int maxFeatures, Filter filter) throws IOException {
         Map<String, String> query = getQueryParams(typeName, bbox, crs, maxFeatures, filter);
         query.put("OUTPUTFORMAT", "application/json");
-        HttpURLConnection conn = getConnection(endPoint, user, pass, query);
+        HttpURLConnection conn = OskariWFSClient.getConnection(endPoint, user, pass, query);
         String contentType = conn.getContentType();
         if (contentType != null && !contentType.contains("json")) {
             throw new ServiceRuntimeException("Unexpected content type " + contentType);
         }
         try (InputStream in = new BufferedInputStream(conn.getInputStream())) {
-            return parseGeoJSON(in, crs);
+            return OskariWFSClient.parseGeoJSON(in, crs);
         }
-    }
-
-    private static SimpleFeatureCollection parseGeoJSON(InputStream in,
-            CoordinateReferenceSystem crs) throws IOException {
-        Map<String, Object> geojson = OM.readValue(in, TYPE_REF);
-        SimpleFeatureType schema = GeoJSONSchemaDetector.getSchema(geojson, crs);
-        return GeoJSONReader2.toFeatureCollection(geojson, schema);
     }
 
     public static SimpleFeatureCollection getFeaturesGML(String endPoint, String user, String pass,
             String typeName, ReferencedEnvelope bbox, CoordinateReferenceSystem crs,
             int maxFeatures, Filter filter) throws Exception {
         Map<String, String> query = getQueryParams(typeName, bbox, crs, maxFeatures, filter);
-        HttpURLConnection conn = getConnection(endPoint, user, pass, query);
+        HttpURLConnection conn = OskariWFSClient.getConnection(endPoint, user, pass, query);
         try (InputStream in = new BufferedInputStream(conn.getInputStream())) {
             return OSKARI_GML.decodeFeatureCollection(in, user, pass);
         }
@@ -120,48 +102,12 @@ public class OskariWFS110Client {
         parameters.put("TYPENAME", typeName);
         parameters.put("SRSNAME", crs.getIdentifiers().iterator().next().toString());
         if (filter == null) {
-            parameters.put("BBOX", getBBOX(bbox));
+            parameters.put("BBOX", OskariWFSClient.getBBOX(bbox));
         } else {
             parameters.put("FILTER", getFilter(filter));
         }
         parameters.put("MAXFEATURES", Integer.toString(maxFeatures));
         return parameters;
-    }
-
-    protected static byte[] getResponse(String endPoint,
-            String user, String pass, Map<String, String> query) {
-        try {
-            HttpURLConnection conn = getConnection(endPoint, user, pass, query);
-            return IOHelper.readBytes(conn);
-        } catch (IOException e) {
-            throw new ServiceRuntimeException("Unable to read response", e);
-        }
-    }
-
-    protected static HttpURLConnection getConnection(String endPoint,
-            String user, String pass, Map<String, String> query) throws IOException {
-        HttpURLConnection conn = IOHelper.getConnection(endPoint, user, pass, query);
-        conn = IOHelper.followRedirect(conn, user, pass, query, MAX_REDIRECTS);
-        int sc = conn.getResponseCode();
-        if (sc != 200) {
-            throw new ServiceRuntimeException("Unexpected status code " + sc);
-        }
-        return conn;
-    }
-
-    protected static String getBBOX(ReferencedEnvelope bbox) {
-        if (bbox == null) {
-            return null;
-        }
-        String srsName = bbox.getCoordinateReferenceSystem()
-                .getIdentifiers()
-                .iterator()
-                .next()
-                .toString();
-        return String.format(Locale.US, "%f,%f,%f,%f,%s",
-                bbox.getMinX(), bbox.getMinY(),
-                bbox.getMaxX(), bbox.getMaxY(),
-                srsName);
     }
 
     protected static String getFilter(Filter filter) {
@@ -176,40 +122,4 @@ public class OskariWFS110Client {
             throw new ServiceRuntimeException("Failed to encode filter!", e);
         }
     }
-
-    protected static boolean isOutputFormatInvalid(InputStream in) {
-        try {
-            OWSException ex = OWSExceptionReportParser.parse(in);
-            return isExceptionDueToInvalidOutputFormat(ex);
-        } catch (Exception e) {
-            LOG.debug(e);
-            return false;
-        }
-    }
-
-    /**
-     * We might get:
-     * <ows:ExceptionReport xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ows="http://www.opengis.net/ows" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ows http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd" version="1.1.0">
-     * <ows:Exception exceptionCode="InvalidParameterValue" locator="Unknown">
-     * <ows:ExceptionText>
-     * <![CDATA[ OutputFormat 'application/json' not supported. ]]>
-     * </ows:ExceptionText>
-     * </ows:Exception>
-     * </ows:ExceptionReport>
-     * @param ex
-     * @return
-     */
-    protected static boolean isExceptionDueToInvalidOutputFormat(OWSException ex) {
-        if (ex.getExceptionCode().equalsIgnoreCase("InvalidParameterValue")) {
-            if (EXC_HANDLING_OUTPUTFORMAT.equalsIgnoreCase(ex.getLocator())) {
-                return true;
-            }
-            if (ex.getExceptionText() != null &&
-                    ex.getExceptionText().toLowerCase().contains(EXC_HANDLING_OUTPUTFORMAT)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
 }

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS2Client.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS2Client.java
@@ -1,0 +1,100 @@
+package org.oskari.service.wfs.client;
+
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.service.ServiceRuntimeException;
+import fi.nls.oskari.util.IOHelper;
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.filter.v2_0.FESConfiguration;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.xml.Encoder;
+import org.opengis.filter.Filter;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Client code for WFS 2.0.0 services
+ */
+public class OskariWFS2Client {
+
+    private static final Logger LOG = LogFactory.getLogger(OskariWFS2Client.class);
+    private static final OskariGML32 OSKARI_GML32 = new OskariGML32();
+
+    private OskariWFS2Client() {}
+
+    /**
+     * @return SimpleFeatureCollection containing the parsed Features, or null if all fails
+     */
+    public static SimpleFeatureCollection getFeatures(String endPoint, String user, String pass,
+                                                      String typeName, ReferencedEnvelope bbox, CoordinateReferenceSystem crs,
+                                                      int maxFeatures, Filter filter) {
+        // First try GeoJSON
+        Map<String, String> query = getQueryParams(typeName, bbox, crs, maxFeatures, filter);
+        query.put("OUTPUTFORMAT", "application/json");
+        byte[] response = new byte[]{};
+        try {
+            response = OskariWFSClient.getResponse(endPoint, user, pass, query);
+            return OskariWFSClient.parseGeoJSON(new ByteArrayInputStream(response), crs);
+        } catch (ServiceRuntimeException e) {
+            if (!"400".equals(e.getMessageKey())) throw e;
+            // fallback to gml
+        } catch (IOException e) {
+            if (!OskariWFSClient.isOutputFormatInvalid(new ByteArrayInputStream(response))) {
+                // If we can not determine that the exception was due to bad
+                // outputFormat parameter then don't bother trying GML
+                final String url = IOHelper.constructUrl(endPoint, query);
+                LOG.debug("Response from", url, "was:\n", new String(response, StandardCharsets.UTF_8));
+                throw new ServiceRuntimeException("Unable to parse GeoJSON from " + url, e);
+            }
+        }
+
+        // Fallback to GML
+        query.remove("OUTPUTFORMAT");
+        response = OskariWFSClient.getResponse(endPoint, user, pass, query);
+
+        try {
+            return OSKARI_GML32.decodeFeatureCollection(new ByteArrayInputStream(response), user, pass);
+        } catch (Exception e) {
+            final String url = IOHelper.constructUrl(endPoint, query);
+            LOG.debug("Response from", url, "was:\n", new String(response, StandardCharsets.UTF_8));
+            throw new ServiceRuntimeException("Unable to parse GML from " + url, e);
+        }
+    }
+
+    protected static Map<String, String> getQueryParams(String typeName, ReferencedEnvelope bbox,
+                                                        CoordinateReferenceSystem crs, int maxFeatures, Filter filter) {
+        Map<String, String> parameters = new LinkedHashMap<>();
+        parameters.put("SERVICE", "WFS");
+        parameters.put("VERSION", "2.0.0");
+        parameters.put("REQUEST", "GetFeature");
+        parameters.put("TYPENAMES", typeName);
+        parameters.put("SRSNAME", crs.getIdentifiers().iterator().next().toString());
+        if (filter == null) {
+            parameters.put("BBOX", OskariWFSClient.getBBOX(bbox));
+        } else {
+            parameters.put("FILTER", getFilter(filter));
+        }
+        parameters.put("COUNT", Integer.toString(maxFeatures));
+        return parameters;
+    }
+
+
+    protected static String getFilter(Filter filter) {
+        if (filter == null) {
+            return null;
+        }
+        try {
+            Encoder encoder = new Encoder(new FESConfiguration());
+            encoder.setOmitXMLDeclaration(true);
+            return encoder.encodeAsString(filter, org.geotools.filter.v2_0.FES.Filter);
+        } catch (IOException e) {
+            throw new ServiceRuntimeException("Failed to encode filter!", e);
+        }
+    }
+
+}

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS2Configuration.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS2Configuration.java
@@ -1,0 +1,30 @@
+package org.oskari.service.wfs.client;
+import javax.xml.namespace.QName;
+
+import org.eclipse.xsd.util.XSDSchemaLocator;
+import org.geotools.wfs.v2_0.WFSConfiguration;
+import org.picocontainer.MutablePicoContainer;
+
+public class OskariWFS2Configuration extends WFSConfiguration {
+
+    private final String user;
+    private final String pass;
+
+    public OskariWFS2Configuration() {
+        this(null, null);
+    }
+
+    public OskariWFS2Configuration(String user, String pass) {
+        this.user = user;
+        this.pass = pass;
+    }
+
+    public void configureContext(final MutablePicoContainer container) {
+        super.configureContext(container);
+        XSDSchemaLocator locator = new OskariCachingSchemaLocator(user, pass);
+        // No idea what the key is used for
+        QName key = new QName("mycustom", "schemaLocator");
+        container.registerComponentInstance(key, locator);
+    }
+
+}

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFSClient.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFSClient.java
@@ -1,13 +1,33 @@
 package org.oskari.service.wfs.client;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.util.IOHelper;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.filter.Filter;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 import fi.nls.oskari.service.ServiceRuntimeException;
+import org.oskari.geojson.GeoJSONReader2;
+import org.oskari.geojson.GeoJSONSchemaDetector;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 
 public class OskariWFSClient {
+    private static final Logger LOG = LogFactory.getLogger(OskariWFS110Client.class);
+    private static final String EXC_HANDLING_OUTPUTFORMAT = "outputformat";
+    private static final TypeReference<HashMap<String, Object>> TYPE_REF = new TypeReference<HashMap<String, Object>>() {};
+    private static final ObjectMapper OM = new ObjectMapper();
+    private static final int MAX_REDIRECTS = 5;
 
     public SimpleFeatureCollection getFeatures(
             String endPoint, String version,
@@ -19,4 +39,82 @@ public class OskariWFSClient {
                 typeName, bbox, crs, maxFeatures, filter).execute();
     }
 
+    // Common methods for WFS 1.1.0 and 2.0.0 clients
+    protected static String getBBOX(ReferencedEnvelope bbox) {
+        if (bbox == null) {
+            return null;
+        }
+        String srsName = bbox.getCoordinateReferenceSystem()
+                .getIdentifiers()
+                .iterator()
+                .next()
+                .toString();
+        return String.format(Locale.US, "%f,%f,%f,%f,%s",
+                bbox.getMinX(), bbox.getMinY(),
+                bbox.getMaxX(), bbox.getMaxY(),
+                srsName);
+    }
+
+    protected static byte[] getResponse(String endPoint,
+                                        String user, String pass, Map<String, String> query) {
+        try {
+            HttpURLConnection conn = getConnection(endPoint, user, pass, query);
+            return IOHelper.readBytes(conn);
+        } catch (IOException e) {
+            throw new ServiceRuntimeException("Unable to read response", e);
+        }
+    }
+
+    protected static HttpURLConnection getConnection(String endPoint,
+                                                     String user, String pass, Map<String, String> query) throws IOException {
+        HttpURLConnection conn = IOHelper.getConnection(endPoint, user, pass, query);
+        conn = IOHelper.followRedirect(conn, user, pass, query, MAX_REDIRECTS);
+        int sc = conn.getResponseCode();
+        if (sc != 200) {
+            throw new ServiceRuntimeException("Unexpected status code " + sc, Integer.toString(sc));
+        }
+        return conn;
+    }
+
+    protected static SimpleFeatureCollection parseGeoJSON(InputStream in,
+                                                        CoordinateReferenceSystem crs) throws IOException {
+        Map<String, Object> geojson = OM.readValue(in, TYPE_REF);
+        SimpleFeatureType schema = GeoJSONSchemaDetector.getSchema(geojson, crs);
+        return GeoJSONReader2.toFeatureCollection(geojson, schema);
+    }
+
+    protected static boolean isOutputFormatInvalid(InputStream in) {
+        try {
+            OWSException ex = OWSExceptionReportParser.parse(in);
+            return isExceptionDueToInvalidOutputFormat(ex);
+        } catch (Exception e) {
+            LOG.debug(e);
+            return false;
+        }
+    }
+
+    /**
+     * We might get:
+     * <ows:ExceptionReport xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ows="http://www.opengis.net/ows" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ows http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd" version="1.1.0">
+     * <ows:Exception exceptionCode="InvalidParameterValue" locator="Unknown">
+     * <ows:ExceptionText>
+     * <![CDATA[ OutputFormat 'application/json' not supported. ]]>
+     * </ows:ExceptionText>
+     * </ows:Exception>
+     * </ows:ExceptionReport>
+     * @param ex
+     * @return
+     */
+    protected static boolean isExceptionDueToInvalidOutputFormat(OWSException ex) {
+        if (ex.getExceptionCode().equalsIgnoreCase("InvalidParameterValue")) {
+            if (EXC_HANDLING_OUTPUTFORMAT.equalsIgnoreCase(ex.getLocator())) {
+                return true;
+            }
+            if (ex.getExceptionText() != null &&
+                    ex.getExceptionText().toLowerCase().contains(EXC_HANDLING_OUTPUTFORMAT)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFSLoadCommand.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFSLoadCommand.java
@@ -21,6 +21,7 @@ public class OskariWFSLoadCommand extends HystrixCommand<SimpleFeatureCollection
 
     private static final Logger LOG = LogFactory.getLogger(OskariWFSLoadCommand.class);
     private static final String WFS_3_VERSION = "3.0.0";
+    private static final String WFS_2_VERSION = "2.0.0";
     private static final String GROUP_KEY = "wfs";
 
     private final String endPoint;
@@ -72,6 +73,8 @@ public class OskariWFSLoadCommand extends HystrixCommand<SimpleFeatureCollection
         switch (version) {
         case WFS_3_VERSION:
             return OskariWFS3Client.getFeatures(endPoint, user, pass, typeName, bbox, crs, maxFeatures);
+        case WFS_2_VERSION:
+            return OskariWFS2Client.getFeatures(endPoint, user, pass, typeName, bbox, crs, maxFeatures, filter);
         default:
             return OskariWFS110Client.getFeatures(endPoint, user, pass, typeName, bbox, crs, maxFeatures, filter);
         }


### PR DESCRIPTION
Added client, configuration and gml for wfs version 2.0.0

Skip layer and add to layers with errors if describe feature type parsing fails. Some services have layers which have white space in feature type name which caused request to fail. If it's valid then type name should be url encoded.

OskariGML for WFS 1.1.0 removes numberOfFeatures and schemaLocation before parsing. I don't know if complex gml behind authorization cause problems or does some servers return invalid numberReturned or numberMatched.

