### PR TITLE
Add generic resource type for audit log

### DIFF
--- a/service-logging/src/main/java/org/oskari/log/AuditLog.java
+++ b/service-logging/src/main/java/org/oskari/log/AuditLog.java
@@ -15,6 +15,7 @@ import java.util.Map;
 public class AuditLog {
 
     public enum ResourceType {
+        GENERIC,
         MAPLAYER,
         MAPLAYER_GROUP,
         MAPLAYER_PERMISSION,
@@ -98,6 +99,9 @@ public class AuditLog {
     /*
      * Actual logging. Probably write out JSON so it can be parsed easily
      */
+    public void wasDenied(ResourceType type) {
+        wasDenied(type.name());
+    }
     public void wasDenied(String msg) {
         send(Level.WARN, getJSON(msg, Op.UNAUTHORIZED));
     }
@@ -110,6 +114,9 @@ public class AuditLog {
         send(Level.WARN, getJSON(msg, Op.ERROR));
     }
 
+    public void usedInvalidParams(ResourceType type) {
+        usedInvalidParams(type.name());
+    }
     public void usedInvalidParams(String msg) {
         send(Level.INFO, getJSON(msg, Op.INVALID_PARAMS));
     }

--- a/servlet-map/src/main/java/fi/nls/oskari/AjaxController.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/AjaxController.java
@@ -39,7 +39,8 @@ public class AjaxController {
             log.error("Couldn't handle action:", route, ". Message: ", e.getMessage(), ". Parameters: ", params.getRequest().getParameterMap());
             AuditLog.user(params.getClientIp(), params.getUser())
                     .withParams(params.getRequest().getParameterMap())
-                    .usedInvalidParams(e.getMessage());
+                    .withMsg(e.getMessage())
+                    .usedInvalidParams(AuditLog.ResourceType.GENERIC);
             ResponseHelper.writeError(params, e.getMessage(), HttpServletResponse.SC_BAD_REQUEST, e.getOptions());
         } catch (ActionDeniedException e) {
             // User tried to execute action he/she is not authorized to execute or session had expired
@@ -51,7 +52,8 @@ public class AjaxController {
             }
             AuditLog.user(params.getClientIp(), params.getUser())
                     .withParams(params.getRequest().getParameterMap())
-                    .wasDenied(e.getMessage());
+                    .withMsg(e.getMessage())
+                    .wasDenied(AuditLog.ResourceType.GENERIC);
             ResponseHelper.writeError(params, e.getMessage(), HttpServletResponse.SC_FORBIDDEN, e.getOptions());
         } catch (ActionCommonException e) {
             Throwable error = e;
@@ -74,7 +76,8 @@ public class AjaxController {
             log.error(error, "Couldn't handle action:", route, "Message: ", e.getMessage(), ". Parameters: ", params.getRequest().getParameterMap());
             AuditLog.user(params.getClientIp(), params.getUser())
                     .withParams(params.getRequest().getParameterMap())
-                    .errored(error.getMessage());
+                    .withMsg(error.getMessage())
+                    .errored(AuditLog.ResourceType.GENERIC);
             ResponseHelper.writeError(params, e.getMessage());
         }
     }


### PR DESCRIPTION
Changes messages like:
```
{"op":"ERROR","resource":"No content to map due to end-of-input\n at [Source: UNKNOWN; line: 1, column: 0]","params":{...}}
```
to 
```
{"op":"ERROR","resource":"GENERIC", "msg":"No content to map due to end-of-input\n at [Source: UNKNOWN; line: 1, column: 0]","params":{...}}
```
So it's more in line with other audit log entries having a simple resource name and an additional message.