### PR TITLE
Ignore property geometries from GeoJSON WFS responses

### DIFF
--- a/oskari-geojson/src/main/java/org/oskari/geojson/GeoJSONSchemaDetector.java
+++ b/oskari-geojson/src/main/java/org/oskari/geojson/GeoJSONSchemaDetector.java
@@ -31,26 +31,19 @@ public class GeoJSONSchemaDetector {
 
         // Map feature.geometry fields to JTS Geometries
         replaceGeometry(json, GeoJSONReader2::toGeometry);
-        if (ignoreGeometryProperties) {
-            // Remove properties of type Map<String, Object> that were mappable to JTS geometries, otherwise leave as is
-            replaceMapProperties(json, it -> {
-                try {
-                    GeoJSONReader2.toGeometry(it);
-                    return null;
-                } catch (Exception e) {
-                    return it;
-                }
-            });
-        } else {
+        replaceMapProperties(json, it -> {
             // Map properties of type Map<String, Object> to JTS geometries if possible, otherwise leave as is
-            replaceMapProperties(json, it -> {
-                try {
-                    return GeoJSONReader2.toGeometry(it);
-                } catch (Exception e) {
-                    return it;
+            try {
+                Geometry g = GeoJSONReader2.toGeometry(it);
+                if (ignoreGeometryProperties) {
+                    // If we want to ignore them return null to remove them from the properties map
+                    return null;
                 }
-            });
-        }
+                return g;
+            } catch (Exception e) {
+                return it;
+            }
+        });
 
         Map<String, Class<?>> bindings = new HashMap<>();
         String type = GeoJSONUtil.getString(json, GeoJSON.TYPE);

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFSClient.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFSClient.java
@@ -79,7 +79,8 @@ public class OskariWFSClient {
     protected static SimpleFeatureCollection parseGeoJSON(InputStream in,
                                                         CoordinateReferenceSystem crs) throws IOException {
         Map<String, Object> geojson = OM.readValue(in, TYPE_REF);
-        SimpleFeatureType schema = GeoJSONSchemaDetector.getSchema(geojson, crs);
+        boolean ignoreGeometryProperties = true;
+        SimpleFeatureType schema = GeoJSONSchemaDetector.getSchema(geojson, crs, ignoreGeometryProperties);
         return GeoJSONReader2.toFeatureCollection(geojson, schema);
     }
 

--- a/service-wfs3/src/main/java/org/oskari/service/wfs3/OskariWFS3Client.java
+++ b/service-wfs3/src/main/java/org/oskari/service/wfs3/OskariWFS3Client.java
@@ -87,7 +87,8 @@ public class OskariWFS3Client {
 
             validateResponse(conn, CONTENT_TYPE_GEOJSON);
             Map<String, Object> geojson = readMap(conn);
-            schema = GeoJSONSchemaDetector.getSchema(geojson, crs);
+            boolean ignoreGeometryProperties = true;
+            schema = GeoJSONSchemaDetector.getSchema(geojson, crs, ignoreGeometryProperties);
             SimpleFeatureCollection sfc = GeoJSONReader2.toFeatureCollection(geojson, schema, transform);
             numFeatures += sfc.size();
             pages.add(sfc);

--- a/service-wfs3/src/test/java/org/oskari/service/wfs3/OskariWFS3ClientTest.java
+++ b/service-wfs3/src/test/java/org/oskari/service/wfs3/OskariWFS3ClientTest.java
@@ -25,7 +25,7 @@ public class OskariWFS3ClientTest {
     @Ignore("Depends on outside service, results might vary")
     @Test
     public void testGetFeaturesHardLimit() throws ServiceException, IOException {
-        String endPoint = "https://dev-paikkatieto.maanmittauslaitos.fi/geographic-names/wfs3/v1/";
+        String endPoint = "https://beta-paikkatieto.maanmittauslaitos.fi/geographic-names/wfs3/v1/";
         String user = null;
         String pass = null;
         String collectionId = "places";
@@ -61,7 +61,7 @@ public class OskariWFS3ClientTest {
     @Ignore("Depends on outside service, results might vary")
     @Test
     public void testGetFeaturesHardLimitPaging() throws ServiceException, IOException {
-        String endPoint = "https://dev-paikkatieto.maanmittauslaitos.fi/geographic-names/wfs3/v1/";
+        String endPoint = "https://beta-paikkatieto.maanmittauslaitos.fi/geographic-names/wfs3/v1/";
         String user = null;
         String pass = null;
         String collectionId = "places";
@@ -82,7 +82,7 @@ public class OskariWFS3ClientTest {
     @Ignore("Depends on outside service, results might vary")
     @Test
     public void testGetFeaturesTransformingToEPSG3067() throws Exception {
-        String endPoint = "https://dev-paikkatieto.maanmittauslaitos.fi/geographic-names/wfs3/v1/";
+        String endPoint = "https://beta-paikkatieto.maanmittauslaitos.fi/geographic-names/wfs3/v1/";
         String user = null;
         String pass = null;
         String collectionId = "places";


### PR DESCRIPTION
For whatever reason sometimes secondary geometries take over in the process when GetWFSFeatures gets called. Solve the issue by ignoring the secondary geometries for now.