### PR TITLE
Use layer ID instead of search channel ID for permission

### DIFF
--- a/service-search-wfs/src/main/java/fi/nls/oskari/search/channel/WFSSearchChannel.java
+++ b/service-search-wfs/src/main/java/fi/nls/oskari/search/channel/WFSSearchChannel.java
@@ -65,14 +65,20 @@ public class WFSSearchChannel extends SearchChannel {
         return config.getLocale();
     }
 
+    /**
+     * USing WFS search channel is permitted if the user has the VIEW_LAYER permission for the
+     * WFS-layer that is used for searching.
+     * @param user
+     * @return
+     */
     public boolean hasPermission(User user) {
         // check if user roles have VIEW_LAYER permission to wfslayer
         Cache<Resource> cache = CacheManager.getCache(this.getClass().getName());
-        final String cacheKey = config.getUrl() + config.getLayerName();
+        final String cacheKey = Integer.toString(config.getWFSLayerId());
         Resource resource = cache.get(cacheKey);
         if(resource == null) {
             Optional<Resource> maybeResource =
-                    getPermissionService().findResource(ResourceType.maplayer, Integer.toString(config.getId()));
+                    getPermissionService().findResource(ResourceType.maplayer, cacheKey);
             if(!maybeResource.isPresent()) {
                 return false;
             }


### PR DESCRIPTION
While refactoring the permissions to use layer id instead of type+url+name combo this broke. The hasPermission tried to get a layer permission using search channel id instead of layer id. This resulted in no user having permission to any wfs backed search channel. (Or in worst case permissions were used from a wrong layer if search channel id happened to match some layer id)