### PR TITLE
Fix npe on empty feature collection for userlayer

### DIFF
--- a/control-userlayer/src/main/java/org/oskari/control/userlayer/UserLayerWFSHelper.java
+++ b/control-userlayer/src/main/java/org/oskari/control/userlayer/UserLayerWFSHelper.java
@@ -86,15 +86,16 @@ public class UserLayerWFSHelper extends UserLayerService {
 
     @SuppressWarnings("unchecked")
     public SimpleFeatureCollection postProcess(SimpleFeatureCollection sfc) throws Exception {
+        if (sfc.isEmpty()) {
+            // return early as no need for processing and getSchema() throws npe if we move forward
+            return sfc;
+        }
         List<SimpleFeature> fc = new ArrayList<>();
         SimpleFeatureType schema;
 
         String geomAttrName = sfc.getSchema().getGeometryDescriptor().getLocalName();
 
         try (SimpleFeatureIterator it = sfc.features()) {
-            if (!it.hasNext()) {
-                return sfc;
-            }
             SimpleFeature f = it.next();
 
             String property_json = (String) f.getAttribute(USERLAYER_ATTR_PROPERTY_JSON);


### PR DESCRIPTION
Postprocessing for userlayers (user imported content) fails if the featurecollection is empty (schema is null for empty sets). This fixes the issue.