### PR TITLE
wfs-client parse outputformat and refactor get Oskari layer's capabilities json

### DIFF
--- a/service-map/src/main/java/fi/nls/oskari/service/capabilities/OskariLayerCapabilitiesHelper.java
+++ b/service-map/src/main/java/fi/nls/oskari/service/capabilities/OskariLayerCapabilitiesHelper.java
@@ -10,6 +10,7 @@ import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.map.layer.formatters.LayerJSONFormatter;
 import fi.nls.oskari.map.layer.formatters.LayerJSONFormatterWMS;
 import fi.nls.oskari.map.layer.formatters.LayerJSONFormatterWMTS;
+import fi.nls.oskari.service.ServiceException;
 import fi.nls.oskari.util.JSONHelper;
 import fi.nls.oskari.wfs.GetGtWFSCapabilities;
 import fi.nls.oskari.wmts.domain.ResourceUrl;
@@ -123,15 +124,15 @@ public class OskariLayerCapabilitiesHelper {
 
     public static void setPropertiesFromCapabilitiesWFS(OskariLayer ml,
             Set<String> systemCRSs) {
-        Map<String, Object> capa = GetGtWFSCapabilities.getGtDataStoreCapabilities(
-                ml.getUrl(), ml.getVersion(),
-                ml.getUsername(), ml.getPassword(), ml.getSrs_name());
-        Set<String> capabilitiesCRSs = GetGtWFSCapabilities.parseProjections(capa, ml.getName());
-        Set<String> crss = LayerJSONFormatter.getCRSsToStore(systemCRSs, capabilitiesCRSs);
-
-        JSONObject capabilities = new JSONObject();
-        JSONHelper.put(capabilities, LayerJSONFormatter.KEY_SRS, new JSONArray(crss));
-        ml.setCapabilities(capabilities);
+        try {
+            if ("3.0.0".equals(ml.getVersion())){
+                // TODO WFS3
+            } else {
+                ml.setCapabilities(GetGtWFSCapabilities.getLayerCapabilities(ml));
+            }
+        } catch (ServiceException e) {
+            LOG.warn("Failed to get capabilities for layer: " + ml.getName());
+        }
         ml.setCapabilitiesLastUpdated(new Date());
     }
 }

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/CachingOskariWFSClient.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/CachingOskariWFSClient.java
@@ -1,5 +1,6 @@
 package org.oskari.service.wfs.client;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.geotools.data.simple.SimpleFeatureCollection;
@@ -30,16 +31,16 @@ public class CachingOskariWFSClient extends OskariWFSClient {
     public SimpleFeatureCollection getFeatures(String endPoint, String version,
             String user, String pass, String typeName,
             ReferencedEnvelope bbox, CoordinateReferenceSystem crs,
-            int maxFeatures, Filter filter) {
+            int maxFeatures, Filter filter, List<String> formats) {
         if (filter != null) {
             // Don't cache requests with a Filter
             return super.getFeatures(endPoint, version, user, pass,
-                    typeName, bbox, crs, maxFeatures, filter);
+                    typeName, bbox, crs, maxFeatures, filter,  formats);
         }
         String key = getCacheKey(endPoint, typeName, bbox, crs, maxFeatures);
         return cache.get(key,
                 __ -> super.getFeatures(endPoint, version, user, pass,
-                        typeName, bbox, crs, maxFeatures, filter));
+                        typeName, bbox, crs, maxFeatures, filter, formats));
     }
 
     private String getCacheKey(String endPoint, String typeName, Envelope bbox,

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFSClient.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFSClient.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -34,9 +35,9 @@ public class OskariWFSClient {
             String user, String pass,
             String typeName, ReferencedEnvelope bbox,
             CoordinateReferenceSystem crs, int maxFeatures,
-            Filter filter) throws ServiceRuntimeException {
+            Filter filter, List<String> formats) throws ServiceRuntimeException {
         return new OskariWFSLoadCommand(endPoint, version, user, pass,
-                typeName, bbox, crs, maxFeatures, filter).execute();
+                typeName, bbox, crs, maxFeatures, filter, formats).execute();
     }
 
     // Common methods for WFS 1.1.0 and 2.0.0 clients

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFSLoadCommand.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFSLoadCommand.java
@@ -17,6 +17,8 @@ import com.netflix.hystrix.HystrixThreadPoolProperties;
 
 import fi.nls.oskari.util.PropertyUtil;
 
+import java.util.List;
+
 public class OskariWFSLoadCommand extends HystrixCommand<SimpleFeatureCollection> {
 
     private static final Logger LOG = LogFactory.getLogger(OskariWFSLoadCommand.class);
@@ -33,11 +35,12 @@ public class OskariWFSLoadCommand extends HystrixCommand<SimpleFeatureCollection
     private final CoordinateReferenceSystem crs;
     private final int maxFeatures;
     private final Filter filter;
+    private final List<String> formats;
 
     public OskariWFSLoadCommand(String endPoint, String version, String user, String pass,
             String typeName, ReferencedEnvelope bbox, CoordinateReferenceSystem crs,
-            int maxFeatures, Filter filter) {
-        this(endPoint, version, user, pass, typeName, bbox, crs, maxFeatures, filter, Setter
+            int maxFeatures, Filter filter, List<String> formats ) {
+        this(endPoint, version, user, pass, typeName, bbox, crs, maxFeatures, filter, formats, Setter
                 .withGroupKey(HystrixCommandGroupKey.Factory.asKey(GROUP_KEY))
                 .andCommandKey(HystrixCommandKey.Factory.asKey(endPoint))
                 .andThreadPoolPropertiesDefaults(
@@ -55,7 +58,7 @@ public class OskariWFSLoadCommand extends HystrixCommand<SimpleFeatureCollection
 
     public OskariWFSLoadCommand(String endPoint, String version, String user, String pass,
             String typeName, ReferencedEnvelope bbox, CoordinateReferenceSystem crs,
-            int maxFeatures, Filter filter, Setter setter) {
+            int maxFeatures, Filter filter, List<String> formats, Setter setter) {
         super(setter);
         this.endPoint = endPoint;
         this.version = version;
@@ -66,6 +69,7 @@ public class OskariWFSLoadCommand extends HystrixCommand<SimpleFeatureCollection
         this.crs = crs;
         this.maxFeatures = maxFeatures;
         this.filter = filter;
+        this.formats = formats;
     }
 
     @Override
@@ -74,9 +78,9 @@ public class OskariWFSLoadCommand extends HystrixCommand<SimpleFeatureCollection
         case WFS_3_VERSION:
             return OskariWFS3Client.getFeatures(endPoint, user, pass, typeName, bbox, crs, maxFeatures);
         case WFS_2_VERSION:
-            return OskariWFS2Client.getFeatures(endPoint, user, pass, typeName, bbox, crs, maxFeatures, filter);
+            return OskariWFS2Client.getFeatures(endPoint, user, pass, typeName, bbox, crs, maxFeatures, filter, formats);
         default:
-            return OskariWFS110Client.getFeatures(endPoint, user, pass, typeName, bbox, crs, maxFeatures, filter);
+            return OskariWFS110Client.getFeatures(endPoint, user, pass, typeName, bbox, crs, maxFeatures, filter, formats);
         }
     }
 

--- a/service-wfs3/pom.xml
+++ b/service-wfs3/pom.xml
@@ -16,6 +16,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>fi.nls.oskari.service</groupId>
+            <artifactId>oskari-map</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.oskari</groupId>
             <artifactId>oskari-geojson</artifactId>
         </dependency>

--- a/service-wfs3/src/main/java/org/oskari/service/wfs3/WFS3Capabilities.java
+++ b/service-wfs3/src/main/java/org/oskari/service/wfs3/WFS3Capabilities.java
@@ -1,0 +1,110 @@
+package org.oskari.service.wfs3;
+
+import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.domain.map.wfs.WFSLayerConfiguration;
+import fi.mml.map.mapwindow.util.OskariLayerWorker;
+import fi.nls.oskari.util.JSONHelper;
+import fi.nls.oskari.util.PropertyUtil;
+import fi.nls.oskari.map.layer.formatters.LayerJSONFormatterWFS;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.oskari.service.wfs3.model.WFS3CollectionInfo;
+import org.oskari.service.wfs3.model.WFS3Exception;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class WFS3Capabilities {
+    public static final String VERSION_WFS3 = "3.0.0";
+
+    public static JSONObject getWFSCapabilities(String url, String user, String pw, String currentCrs) throws WFS3Exception, IOException {
+        WFS3Service service = WFS3Service.fromURL(url, user, pw);
+        List<JSONObject> layers = service.getCollections().stream()
+                .map(collectionInfo -> toOskariLayer(url, collectionInfo))
+                .map(layer -> wfsLayerToJSON(layer, currentCrs, user, pw))
+                .collect(Collectors.toList());
+        return JSONHelper.createJSONObject("layers", new JSONArray(layers));
+    }
+
+    public static JSONObject getLayerCapabilities (OskariLayer ml) throws WFS3Exception, IOException, NoSuchElementException {
+        WFS3Service service = WFS3Service.fromURL(ml.getUrl(), ml.getUsername(), ml.getPassword());
+        WFS3CollectionInfo collection = service.getCollection(ml.getName()).get();
+        return getLayerCapabilities(collection);
+    }
+
+    public static JSONObject getLayerCapabilities (WFS3CollectionInfo collection) {
+        JSONObject capabilities = new JSONObject(); // override
+        Set<String> epsgs = collection.getCrs()
+                .stream()
+                .map(WFS3Service::convertCrsToEpsg)
+                .filter(epsg -> epsg != null)
+                .collect(Collectors.toSet());
+        List<String> types = collection.getLinks()
+                .stream()
+                .filter (link -> "item".equals(link.getRel()))
+                .map(link -> link.getType())
+                .filter (type -> type != null)
+                .collect(Collectors.toList());
+        JSONHelper.put(capabilities, "srs", new JSONArray(epsgs));
+        JSONObject formats = JSONHelper.createJSONObject("available", new JSONArray(types));
+        JSONHelper.put(capabilities, "srs", new JSONArray(epsgs));
+        JSONHelper.putValue(capabilities, "formats", formats);
+        return capabilities;
+    }
+
+    private static OskariLayer toOskariLayer(String url, WFS3CollectionInfo collection) {
+        OskariLayer layer = new OskariLayer();
+        layer.setType(OskariLayer.TYPE_WFS);
+        layer.setVersion(VERSION_WFS3);
+        layer.setUrl(url);
+        layer.setName(collection.getId());
+        layer.setMaxScale(1d);
+        layer.setMinScale(1500000d);
+        layer.setCapabilities(getLayerCapabilities(collection));
+        String title = collection.getTitle() != null ? collection.getTitle() : collection.getId();
+        for (String lang : PropertyUtil.getSupportedLanguages()) {
+            layer.setName(lang, title);
+        }
+
+        return layer;
+    }
+
+    private static JSONObject wfsLayerToJSON(OskariLayer layer, String crs, String user, String pw) {
+        LayerJSONFormatterWFS formatter = new LayerJSONFormatterWFS();
+        String lang = PropertyUtil.getDefaultLanguage();
+        JSONObject obj = formatter.getJSON(layer, lang, false, crs);
+        OskariLayerWorker.modifyCommonFieldsForEditing(obj, layer);
+        WFSLayerConfiguration lc = layerToWfs30LayerConfiguration(layer, crs, user, pw);
+        JSONObject admin = JSONHelper.getJSONObject(obj, "admin");
+        JSONHelper.putValue(admin, "passthrough", JSONHelper.createJSONObject(lc.getAsJSON()));
+        // NOTE! Important to remove id since this is at template
+        obj.remove("id");
+        // Admin layer tools needs for listing layers
+        JSONHelper.putValue(obj, "title", layer.getName());
+        return obj;
+    }
+
+    private static WFSLayerConfiguration layerToWfs30LayerConfiguration (OskariLayer layer, String crs, String user, String pw) {
+        final WFSLayerConfiguration lc = new WFSLayerConfiguration();
+        // Use defaults for now, modify if needed
+        String name = layer.getName();
+        lc.setDefaults();
+        lc.setURL(layer.getUrl());
+        lc.setUsername(user);
+        lc.setPassword(pw);
+        lc.setLayerName(name); // or WFS3CollectionInfo getTitle()
+        lc.setLayerId("layer_" + name);
+        lc.setSRSName(crs);
+        lc.setGMLGeometryProperty("geometry");
+        lc.setWFSVersion(VERSION_WFS3);
+        lc.setFeatureElement(name);
+        lc.setFeatureNamespace("");
+        lc.setFeatureNamespaceURI("");
+        lc.setJobType("default");
+        return lc;
+
+    }
+}

--- a/service-wfs3/src/main/java/org/oskari/service/wfs3/WFS3Service.java
+++ b/service-wfs3/src/main/java/org/oskari/service/wfs3/WFS3Service.java
@@ -115,17 +115,6 @@ public class WFS3Service {
                 .filter(c -> c.getId().equals(id))
                 .findAny();
     }
-    public Set<String> getSupportedEpsgCodes (String collectionId) throws NoSuchElementException {
-        Set<String> epsgs = new HashSet<>();
-        WFS3CollectionInfo collection = getCollection(collectionId).get();
-        for (String crs : collection.getCrs()) {
-            String epsg = convertCrsToEpsg(crs);
-            if (epsg != null) {
-                epsgs.add(epsg);
-            }
-        }
-        return epsgs;
-    }
 
     public static String convertCrsToEpsg (String crs) {
         if (crs.toUpperCase().contains("CRS84")){


### PR DESCRIPTION
Moved WFS3 capabilities to own file.
Added allowed formats parsing for GetFeature request.
Added getLayerCapabilities to get jsonobject for Oskari layer. To keep sure that get wsscapabilties, save layer and update capabilties creates similar objects.
Some refactoring GetGTWSCapabilities exception handling to pass exceptions instead of overriding them with more generic error message.

