### PR TITLE
OGC API Features client: support CRS extension

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandler.java
@@ -60,8 +60,6 @@ public class GetWFSFeaturesHandler extends AbstractWFSFeaturesHandler {
             throw new ActionParamsException("Invalid " + ActionConstants.PARAM_SRS);
         }
 
-        // TODO: Figure out if layer supports targetSrsName
-        // If it does let the WFS service do the transformation
         ReferencedEnvelope bbox = parseBbox(bboxStr, targetCRS);
 
         SimpleFeatureCollection fc;

--- a/control-base/src/main/java/fi/nls/oskari/control/layer/GetWSCapabilitiesHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/GetWSCapabilitiesHandler.java
@@ -87,7 +87,7 @@ public class GetWSCapabilitiesHandler extends ActionHandler {
                 if (VERSION_WFS3.equals(version)) {
                     WFS3Service service = WFS3Service.fromURL(url, user, pw);
                     List<JSONObject> layers = service.getCollections().stream()
-                            .map(collectionInfo -> toOskariLayer(url, collectionInfo))
+                            .map(collectionInfo -> toOskariLayer(url, service, collectionInfo))
                             .map(layer -> wfsLayerToJSON(layer, currentCrs, user, pw))
                             .collect(Collectors.toList());
                     return JSONHelper.createJSONObject("layers", new JSONArray(layers));
@@ -112,7 +112,7 @@ public class GetWSCapabilitiesHandler extends ActionHandler {
         }
     }
 
-    private OskariLayer toOskariLayer(String url, WFS3CollectionInfo collection) {
+    private OskariLayer toOskariLayer(String url, WFS3Service service, WFS3CollectionInfo collection) {
         OskariLayer layer = new OskariLayer();
         layer.setType(OskariLayer.TYPE_WFS);
         layer.setVersion(VERSION_WFS3);
@@ -126,11 +126,7 @@ public class GetWSCapabilitiesHandler extends ActionHandler {
             layer.setName(lang, title);
         }
         JSONObject capabilities = layer.getCapabilities();
-        Set<String> epsgs = collection.getCrs()
-                .stream()
-                .map(WFS3Service::convertCrsToEpsg)
-                .filter(epsg -> epsg != null)
-                .collect(Collectors.toSet());
+        Set<String> epsgs = service.getSupportedEpsgCodes(collection.getId());
         JSONHelper.put(capabilities, "srs", new JSONArray(epsgs));
         return layer;
     }

--- a/control-base/src/main/java/fi/nls/oskari/control/layer/SaveLayerHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/SaveLayerHandler.java
@@ -648,12 +648,15 @@ public class SaveLayerHandler extends AbstractLayerAdminHandler {
         }
 
         // Get supported projections
-
+        JSONObject capabilities = new JSONObject();
         Set<String> crss = new HashSet<>();
         if (WFS3_0_0_VERSION.equals(ml.getVersion())) {
             try {
                 WFS3Service service = WFS3Service.fromURL(ml.getUrl(), ml.getUsername(), ml.getPassword());
-                crss = service.getSupportedEpsgCodes(ml.getName());
+                String collectionId = ml.getName();
+                crss = service.getSupportedEpsgCodes(collectionId);
+                Set<String> crsUri = service.getSupportedCrsURIs(collectionId);
+                JSONHelper.put(capabilities, "crs-uri", new JSONArray(crsUri));
             } catch (Exception e) {
                 LOG.warn("Couldn't get supported projections for WFS3 layer:", ml.getName(), e.getMessage());
             }
@@ -662,7 +665,7 @@ public class SaveLayerHandler extends AbstractLayerAdminHandler {
                     ml.getUrl(), ml.getVersion(), ml.getUsername(), ml.getPassword(), ml.getSrs_name());
             crss = GetGtWFSCapabilities.parseProjections(capa, ml.getName());
         }
-        JSONObject capabilities = new JSONObject();
+
         JSONHelper.put(capabilities, "srs", new JSONArray(crss));
         ml.setCapabilities(capabilities);
         ml.setCapabilitiesLastUpdated(new Date());

--- a/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
@@ -1019,6 +1019,9 @@ public class IOHelper {
             if (key == null || key.isEmpty()) {
                 continue;
             }
+            if (value == null) {
+                continue;
+            }
             final String keyEnc = urlEncodePayload(key);
             final String valueEnc = urlEncodePayload(value);
             if (!first) {

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariFeatureClient.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariFeatureClient.java
@@ -20,7 +20,6 @@ public class OskariFeatureClient {
     protected static final String PROPERTY_NATIVE_SRS = "oskari.native.srs";
     protected static final String ERR_REPOJECTION_FAIL = "Reprojection failed";
     protected static final String ERR_NATIVE_SRS_DECODE_FAIL = "Failed to decode Native CRS";
-    protected static final String PROPERTY_FORCE_GML = "forceGML";
 
     private OskariWFSClient wfsClient;
     private CoordinateReferenceSystem nativeCRS;
@@ -76,19 +75,9 @@ public class OskariFeatureClient {
     private SimpleFeatureCollection getFeaturesNoTransform(String id, OskariLayer layer,
             ReferencedEnvelope bbox, CoordinateReferenceSystem crs,
             Optional<UserLayerService> processor) throws ServiceRuntimeException {
-        String endPoint = layer.getUrl();
-        String version = layer.getVersion();
-        String typeName = layer.getName();
-        String user = layer.getUsername();
-        String pass = layer.getPassword();
-        // TODO: Figure out the maxFeatures from the layer
-        int maxFeatures = 10000;
-
         Filter filter = processor.map(proc -> proc.getWFSFilter(id, bbox)).orElse(null);
 
-        boolean forceGML =  layer.getAttributes().optBoolean(PROPERTY_FORCE_GML, false);
-        SimpleFeatureCollection sfc = wfsClient.getFeatures(endPoint, version, user, pass, typeName, bbox, crs, maxFeatures, filter, forceGML);
-
+        SimpleFeatureCollection sfc = wfsClient.getFeatures(layer, bbox, crs, filter);
 
         if (processor.isPresent()) {
             try {

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS110Client.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS110Client.java
@@ -16,6 +16,7 @@ import org.geotools.xml.Encoder;
 import org.opengis.filter.Filter;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
+import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.service.ServiceRuntimeException;
@@ -27,20 +28,30 @@ import fi.nls.oskari.util.IOHelper;
 public class OskariWFS110Client {
 
     private static final Logger LOG = LogFactory.getLogger(OskariWFS110Client.class);
+
     private static final OskariGML OSKARI_GML = new OskariGML();
+    private static final String PROPERTY_FORCE_GML = "forceGML";
 
     private OskariWFS110Client() {}
 
     /**
      * @return SimpleFeatureCollection containing the parsed Features, or null if all fails
      */
-    public static SimpleFeatureCollection getFeatures(String endPoint, String user, String pass,
-            String typeName, ReferencedEnvelope bbox, CoordinateReferenceSystem crs,
-            int maxFeatures, Filter filter, boolean forceGML) {
-        // First try GeoJSON
+    public static SimpleFeatureCollection getFeatures(OskariLayer layer,
+            ReferencedEnvelope bbox, CoordinateReferenceSystem crs, Filter filter) {
+        String endPoint = layer.getUrl();
+        String typeName = layer.getName();
+        String user = layer.getUsername();
+        String pass = layer.getPassword();
+
+        // TODO: FIXME!
+        int maxFeatures = 10000;
+        boolean forceGML = layer.getAttributes().optBoolean(PROPERTY_FORCE_GML, false);
+
         Map<String, String> query = getQueryParams(typeName, bbox, crs, maxFeatures, filter);
         byte[] response;
         if (!forceGML) {
+            // First try GeoJSON
             query.put("OUTPUTFORMAT", "application/json");
             response = OskariWFSClient.getResponse(endPoint, user, pass, query);
             try {

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS2Client.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS2Client.java
@@ -1,5 +1,6 @@
 package org.oskari.service.wfs.client;
 
+import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.service.ServiceRuntimeException;
@@ -23,21 +24,32 @@ import java.util.Map;
 public class OskariWFS2Client {
 
     private static final Logger LOG = LogFactory.getLogger(OskariWFS2Client.class);
+
     private static final OskariGML32 OSKARI_GML32 = new OskariGML32();
+    private static final String PROPERTY_FORCE_GML = "forceGML";
 
     private OskariWFS2Client() {}
 
     /**
      * @return SimpleFeatureCollection containing the parsed Features, or null if all fails
      */
-    public static SimpleFeatureCollection getFeatures(String endPoint, String user, String pass,
-                                                      String typeName, ReferencedEnvelope bbox, CoordinateReferenceSystem crs,
-                                                      int maxFeatures, Filter filter, boolean forceGML) {
-        // First try GeoJSON
+    public static SimpleFeatureCollection getFeatures(OskariLayer layer,
+            ReferencedEnvelope bbox, CoordinateReferenceSystem crs, Filter filter) {
+        String endPoint = layer.getUrl();
+        String typeName = layer.getName();
+        String user = layer.getUsername();
+        String pass = layer.getPassword();
+
+        // TODO: FIXME!
+        int maxFeatures = 10000;
+        boolean forceGML = layer.getAttributes().optBoolean(PROPERTY_FORCE_GML, false);
+
         Map<String, String> query = getQueryParams(typeName, bbox, crs, maxFeatures, filter);
 
-        byte[] response = new byte[]{};
+        byte[] response = new byte[0];
+
         if (!forceGML) {
+            // First try GeoJSON
             query.put("OUTPUTFORMAT", "application/json");
             try {
                 response = OskariWFSClient.getResponse(endPoint, user, pass, query);
@@ -70,7 +82,7 @@ public class OskariWFS2Client {
     }
 
     protected static Map<String, String> getQueryParams(String typeName, ReferencedEnvelope bbox,
-                                                        CoordinateReferenceSystem crs, int maxFeatures, Filter filter) {
+            CoordinateReferenceSystem crs, int maxFeatures, Filter filter) {
         Map<String, String> parameters = new LinkedHashMap<>();
         parameters.put("SERVICE", "WFS");
         parameters.put("VERSION", "2.0.0");

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFSClient.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFSClient.java
@@ -2,6 +2,8 @@ package org.oskari.service.wfs.client;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.util.IOHelper;
@@ -29,14 +31,9 @@ public class OskariWFSClient {
     private static final ObjectMapper OM = new ObjectMapper();
     private static final int MAX_REDIRECTS = 5;
 
-    public SimpleFeatureCollection getFeatures(
-            String endPoint, String version,
-            String user, String pass,
-            String typeName, ReferencedEnvelope bbox,
-            CoordinateReferenceSystem crs, int maxFeatures,
-            Filter filter, boolean forceGML) throws ServiceRuntimeException {
-        return new OskariWFSLoadCommand(endPoint, version, user, pass,
-                typeName, bbox, crs, maxFeatures, filter, forceGML).execute();
+    public SimpleFeatureCollection getFeatures(OskariLayer layer,
+            ReferencedEnvelope bbox, CoordinateReferenceSystem crs, Filter filter) throws ServiceRuntimeException {
+        return new OskariWFSLoadCommand(layer, bbox, crs, filter).execute();
     }
 
     // Common methods for WFS 1.1.0 and 2.0.0 clients

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFSLoadCommand.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFSLoadCommand.java
@@ -1,7 +1,6 @@
 package org.oskari.service.wfs.client;
 
-import fi.nls.oskari.log.LogFactory;
-import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.service.ServiceRuntimeException;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.geometry.jts.ReferencedEnvelope;
@@ -19,28 +18,20 @@ import fi.nls.oskari.util.PropertyUtil;
 
 public class OskariWFSLoadCommand extends HystrixCommand<SimpleFeatureCollection> {
 
-    private static final Logger LOG = LogFactory.getLogger(OskariWFSLoadCommand.class);
     private static final String WFS_3_VERSION = "3.0.0";
     private static final String WFS_2_VERSION = "2.0.0";
     private static final String GROUP_KEY = "wfs";
 
-    private final String endPoint;
-    private final String version;
-    private final String user;
-    private final String pass;
-    private final String typeName;
+    private final OskariLayer layer;
     private final ReferencedEnvelope bbox;
     private final CoordinateReferenceSystem crs;
-    private final int maxFeatures;
     private final Filter filter;
-    private final boolean forceGML;
 
-    public OskariWFSLoadCommand(String endPoint, String version, String user, String pass,
-            String typeName, ReferencedEnvelope bbox, CoordinateReferenceSystem crs,
-            int maxFeatures, Filter filter, boolean forceGML) {
-        this(endPoint, version, user, pass, typeName, bbox, crs, maxFeatures, filter, forceGML, Setter
+    public OskariWFSLoadCommand(OskariLayer layer, ReferencedEnvelope bbox,
+            CoordinateReferenceSystem crs, Filter filter) {
+        this(layer, bbox, crs, filter, Setter
                 .withGroupKey(HystrixCommandGroupKey.Factory.asKey(GROUP_KEY))
-                .andCommandKey(HystrixCommandKey.Factory.asKey(endPoint))
+                .andCommandKey(HystrixCommandKey.Factory.asKey(layer.getUrl()))
                 .andThreadPoolPropertiesDefaults(
                         HystrixThreadPoolProperties.Setter()
                         .withCoreSize(PropertyUtil.getOptional("oskari." + GROUP_KEY + ".job.pool.size", 10))
@@ -54,37 +45,30 @@ public class OskariWFSLoadCommand extends HystrixCommand<SimpleFeatureCollection
                         .withCircuitBreakerSleepWindowInMilliseconds(PropertyUtil.getOptional("oskari." + GROUP_KEY + ".sleepwindow", 20000))));
     }
 
-    public OskariWFSLoadCommand(String endPoint, String version, String user, String pass,
-            String typeName, ReferencedEnvelope bbox, CoordinateReferenceSystem crs,
-            int maxFeatures, Filter filter, boolean forceGML, Setter setter) {
+
+    public OskariWFSLoadCommand(OskariLayer layer, ReferencedEnvelope bbox,
+            CoordinateReferenceSystem crs, Filter filter, Setter setter) {
         super(setter);
-        this.endPoint = endPoint;
-        this.version = version;
-        this.user = user;
-        this.pass = pass;
-        this.typeName = typeName;
+        this.layer = layer;
         this.bbox = bbox;
         this.crs = crs;
-        this.maxFeatures = maxFeatures;
         this.filter = filter;
-        this.forceGML = forceGML;
     }
 
     @Override
     protected SimpleFeatureCollection run() throws Exception {
-        switch (version) {
+        switch (layer.getVersion()) {
         case WFS_3_VERSION:
-            return OskariWFS3Client.getFeatures(endPoint, user, pass, typeName, bbox, crs, maxFeatures);
+            return OskariWFS3Client.getFeatures(layer, bbox, crs);
         case WFS_2_VERSION:
-            return OskariWFS2Client.getFeatures(endPoint, user, pass, typeName, bbox, crs, maxFeatures, filter, forceGML);
+            return OskariWFS2Client.getFeatures(layer, bbox, crs, filter);
         default:
-            return OskariWFS110Client.getFeatures(endPoint, user, pass, typeName, bbox, crs, maxFeatures, filter, forceGML);
+            return OskariWFS110Client.getFeatures(layer, bbox, crs, filter);
         }
     }
 
     public SimpleFeatureCollection getFallback() {
-        LOG.debug("Error getting features from", endPoint, "Events completed:\n", getExecutionEvents());
         // handler expects an Exception or SimpleFeatureCollection. If we don't throw an exception a null value is returned.
-        throw new ServiceRuntimeException("Error getting features from " + endPoint, getExceptionFromThrowable(getExecutionException()));
+        throw new ServiceRuntimeException("Error getting features from " + layer.getUrl(), getExceptionFromThrowable(getExecutionException()));
     }
 }

--- a/service-wfs3/src/main/java/org/oskari/service/wfs3/OskariWFS3Client.java
+++ b/service-wfs3/src/main/java/org/oskari/service/wfs3/OskariWFS3Client.java
@@ -159,7 +159,7 @@ public class OskariWFS3Client {
         if (CRS.equalsIgnoreMetadata(env.getCoordinateReferenceSystem(), to)) {
             return env;
         }
-        return env.transform(to, true, 5);
+        return env.transform(to, true);
     }
 
     /**
@@ -234,13 +234,17 @@ public class OskariWFS3Client {
             throws ServiceRuntimeException {
         // Linked not needed, but looks better when logging the requests
         Map<String, String> parameters = new LinkedHashMap<>();
-        parameters.put("crs", crsURI);
+        if (crsURI != null) {
+            parameters.put("crs", crsURI);
+        }
         if (bbox != null) {
             String bboxStr = String.format(Locale.US, "%f,%f,%f,%f",
                     bbox.getMinX(), bbox.getMinY(),
                     bbox.getMaxX(), bbox.getMaxY());
             parameters.put("bbox", bboxStr);
-            parameters.put("bbox-crs", crsURI);
+            if (bboxCrsURI != null) {
+                parameters.put("bbox-crs", bboxCrsURI);
+            }
         }
         parameters.put("limit", Integer.toString(Math.min(PAGE_SIZE, hardLimit)));
         return parameters;

--- a/service-wfs3/src/test/java/org/oskari/service/wfs3/OskariWFS3ClientTest.java
+++ b/service-wfs3/src/test/java/org/oskari/service/wfs3/OskariWFS3ClientTest.java
@@ -1,6 +1,7 @@
 package org.oskari.service.wfs3;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -88,9 +89,9 @@ public class OskariWFS3ClientTest {
         layer.setName("rakennus");
         layer.setCapabilities(JSONHelper.createJSONObject("crs-uri", new JSONArray(Arrays.asList("http://www.opengis.net/def/crs/EPSG/0/3067"))));
         CoordinateReferenceSystem epsg3067 = CRS.decode("EPSG:3067");
-        ReferencedEnvelope bbox = new ReferencedEnvelope(500000, 6822000, 501000, 6823000, epsg3067);
-        int limit = 10;
+        ReferencedEnvelope bbox = new ReferencedEnvelope(500000, 501000, 6822000, 6823000, epsg3067);
         SimpleFeatureCollection sfc = OskariWFS3Client.getFeatures(layer, bbox, epsg3067);
+        assertFalse(sfc.isEmpty());
         try (SimpleFeatureIterator it = sfc.features()) {
             while (it.hasNext()) {
                 Geometry geometryEnvelope = ((Geometry) it.next().getDefaultGeometry()).getEnvelope();

--- a/service-wfs3/src/test/java/org/oskari/service/wfs3/OskariWFS3ClientTest.java
+++ b/service-wfs3/src/test/java/org/oskari/service/wfs3/OskariWFS3ClientTest.java
@@ -4,12 +4,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.geometry.jts.JTS;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
+import org.json.JSONArray;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
@@ -17,23 +19,24 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.Geometry;
 
+import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.service.ServiceException;
+import fi.nls.oskari.util.JSONHelper;
 
 public class OskariWFS3ClientTest {
 
     @Ignore("Depends on outside service, results might vary")
     @Test
     public void testGetFeaturesHardLimit() throws ServiceException, IOException {
-        String endPoint = "https://beta-paikkatieto.maanmittauslaitos.fi/geographic-names/wfs3/v1/";
-        String user = null;
-        String pass = null;
-        String collectionId = "places";
+        OskariLayer layer = new OskariLayer();
+        layer.setUrl("https://beta-paikkatieto.maanmittauslaitos.fi/geographic-names/wfs3/v1/");
+        layer.setName("places");
         CoordinateReferenceSystem crs = OskariWFS3Client.getCRS84();
         Envelope envelope = new Envelope(21.35, 21.40, 61.35, 61.40);
         ReferencedEnvelope bbox = new ReferencedEnvelope(envelope, crs);
 
         int limit = 10;
-        SimpleFeatureCollection sfc = OskariWFS3Client.getFeatures(endPoint, user, pass, collectionId, bbox, crs, limit);
+        SimpleFeatureCollection sfc = OskariWFS3Client.getFeatures(layer, bbox, crs);
         assertEquals(limit, sfc.size());
         int i = 0;
         try (SimpleFeatureIterator it = sfc.features()) {
@@ -45,7 +48,7 @@ public class OskariWFS3ClientTest {
         assertEquals(limit, i);
 
         limit = 1000;
-        sfc = OskariWFS3Client.getFeatures(endPoint, user, pass, collectionId, bbox, crs, limit);
+        sfc = OskariWFS3Client.getFeatures(layer, bbox, crs);
         assertEquals(29, sfc.size());
         i = 0;
         try (SimpleFeatureIterator it = sfc.features()) {
@@ -60,13 +63,12 @@ public class OskariWFS3ClientTest {
     @Ignore("Depends on outside service, results might vary")
     @Test
     public void testGetFeaturesHardLimitPaging() throws ServiceException, IOException {
-        String endPoint = "https://beta-paikkatieto.maanmittauslaitos.fi/geographic-names/wfs3/v1/";
-        String user = null;
-        String pass = null;
-        String collectionId = "places";
+        OskariLayer layer = new OskariLayer();
+        layer.setUrl("https://beta-paikkatieto.maanmittauslaitos.fi/geographic-names/wfs3/v1/");
+        layer.setName("places");
         CoordinateReferenceSystem crs = OskariWFS3Client.getCRS84();
         int limit = OskariWFS3Client.PAGE_SIZE + 10;
-        SimpleFeatureCollection sfc = OskariWFS3Client.getFeatures(endPoint, user, pass, collectionId, null, crs, limit);
+        SimpleFeatureCollection sfc = OskariWFS3Client.getFeatures(layer, null, crs);
         assertEquals(limit, sfc.size());
         int i = 0;
         try (SimpleFeatureIterator it = sfc.features()) {
@@ -81,14 +83,14 @@ public class OskariWFS3ClientTest {
     @Ignore("Depends on outside service, results might vary")
     @Test
     public void testGetFeaturesServiceSupportingCRS_EPSG3067() throws Exception {
-        String endPoint = "https://beta-paikkatieto.maanmittauslaitos.fi/maastotiedot/wfs3/v1/";
-        String user = null;
-        String pass = null;
-        String collectionId = "rakennus";
+        OskariLayer layer = new OskariLayer();
+        layer.setUrl("https://beta-paikkatieto.maanmittauslaitos.fi/maastotiedot/wfs3/v1/");
+        layer.setName("rakennus");
+        layer.setCapabilities(JSONHelper.createJSONObject("crs-uri", new JSONArray(Arrays.asList("http://www.opengis.net/def/crs/EPSG/0/3067"))));
         CoordinateReferenceSystem epsg3067 = CRS.decode("EPSG:3067");
         ReferencedEnvelope bbox = new ReferencedEnvelope(500000, 6822000, 501000, 6823000, epsg3067);
         int limit = 10;
-        SimpleFeatureCollection sfc = OskariWFS3Client.getFeatures(endPoint, user, pass, collectionId, bbox, epsg3067, limit);
+        SimpleFeatureCollection sfc = OskariWFS3Client.getFeatures(layer, bbox, epsg3067);
         try (SimpleFeatureIterator it = sfc.features()) {
             while (it.hasNext()) {
                 Geometry geometryEnvelope = ((Geometry) it.next().getDefaultGeometry()).getEnvelope();

--- a/service-wfs3/src/test/java/org/oskari/service/wfs3/OskariWFS3ClientTest.java
+++ b/service-wfs3/src/test/java/org/oskari/service/wfs3/OskariWFS3ClientTest.java
@@ -13,7 +13,6 @@ import org.geotools.referencing.CRS;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
-import org.opengis.referencing.operation.MathTransform;
 
 import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.Geometry;
@@ -81,24 +80,19 @@ public class OskariWFS3ClientTest {
 
     @Ignore("Depends on outside service, results might vary")
     @Test
-    public void testGetFeaturesTransformingToEPSG3067() throws Exception {
-        String endPoint = "https://dev-paikkatieto.maanmittauslaitos.fi/geographic-names/wfs3/v1/";
+    public void testGetFeaturesServiceSupportingCRS_EPSG3067() throws Exception {
+        String endPoint = "https://beta-paikkatieto.maanmittauslaitos.fi/maastotiedot/wfs3/v1/";
         String user = null;
         String pass = null;
-        String collectionId = "places";
-        CoordinateReferenceSystem crs84 = OskariWFS3Client.getCRS84();
-        Envelope envelope = new Envelope(21.35, 21.40, 61.35, 61.40);
-        ReferencedEnvelope bbox = new ReferencedEnvelope(envelope, crs84);
+        String collectionId = "rakennus";
         CoordinateReferenceSystem epsg3067 = CRS.decode("EPSG:3067");
-        MathTransform transform = CRS.findMathTransform(crs84, epsg3067);
-        Envelope transformedEnvelope = JTS.transform(bbox, transform);
-        Geometry transformedEnvelopeGeom = JTS.toGeometry(transformedEnvelope);
+        ReferencedEnvelope bbox = new ReferencedEnvelope(500000, 6822000, 501000, 6823000, epsg3067);
         int limit = 10;
         SimpleFeatureCollection sfc = OskariWFS3Client.getFeatures(endPoint, user, pass, collectionId, bbox, epsg3067, limit);
         try (SimpleFeatureIterator it = sfc.features()) {
             while (it.hasNext()) {
                 Geometry geometryEnvelope = ((Geometry) it.next().getDefaultGeometry()).getEnvelope();
-                assertTrue(geometryEnvelope.within(transformedEnvelopeGeom));
+                assertTrue(geometryEnvelope.within(JTS.toGeometry(bbox)));
             }
         }
     }

--- a/service-wfs3/src/test/java/org/oskari/service/wfs3/WFS3ServiceTest.java
+++ b/service-wfs3/src/test/java/org/oskari/service/wfs3/WFS3ServiceTest.java
@@ -6,9 +6,12 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -53,6 +56,40 @@ public class WFS3ServiceTest {
                 .collect(Collectors.toList());
 
         assertIterablesEquals(expected, actual);
+    }
+
+    @Test
+    public void testGetSupportedCrsURIs() throws Exception {
+        Set<String> expected = Stream.of(
+                "http://www.opengis.net/def/crs/EPSG/0/3067",
+                "http://www.opengis.net/def/crs/EPSG/0/4258",
+                "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+                "http://www.opengis.net/def/crs/EPSG/0/3046",
+                "http://www.opengis.net/def/crs/EPSG/0/3047",
+                "http://www.opengis.net/def/crs/EPSG/0/3048",
+                "http://www.opengis.net/def/crs/EPSG/0/3873",
+                "http://www.opengis.net/def/crs/EPSG/0/3874",
+                "http://www.opengis.net/def/crs/EPSG/0/3875",
+                "http://www.opengis.net/def/crs/EPSG/0/3876",
+                "http://www.opengis.net/def/crs/EPSG/0/3877",
+                "http://www.opengis.net/def/crs/EPSG/0/3878",
+                "http://www.opengis.net/def/crs/EPSG/0/3879",
+                "http://www.opengis.net/def/crs/EPSG/0/3880",
+                "http://www.opengis.net/def/crs/EPSG/0/3881",
+                "http://www.opengis.net/def/crs/EPSG/0/3882",
+                "http://www.opengis.net/def/crs/EPSG/0/3883",
+                "http://www.opengis.net/def/crs/EPSG/0/3884",
+                "http://www.opengis.net/def/crs/EPSG/0/3885")
+                .collect(Collectors.toSet());
+        Set<String> actual = service.getSupportedCrsURIs("placenames");
+
+        List<String> expectedList = new ArrayList<>(expected);
+        List<String> actualList = new ArrayList<>(actual);
+
+        Collections.sort(expectedList);
+        Collections.sort(actualList);
+
+        assertIterablesEquals(expectedList, actualList);
     }
 
     private <T> void assertIterablesEquals(Iterable<T> expected, Iterable<T> actual) {


### PR DESCRIPTION
Currently we make all the requests in CRS84. This adds support for getting the features in targetCRS if the collection supports that.

Refactor WFS clients to use OskariLayer in all it's glory instead of passing 7 different parameters around.

Note that these will probably change when the CRS extension gets fully specified, but hopefully we can get away with only adjusting the logic inside the functions WFS3Service etc.