### PR TITLE
Move Resource caching from PermissionHelper to the service implementation

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/layer/PermissionHelper.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/PermissionHelper.java
@@ -24,9 +24,7 @@ import java.util.Optional;
 public class PermissionHelper {
 
     private static final Logger LOG = LogFactory.getLogger(PermissionHelper.class);
-    private static final String RESOURCE_CACHE_NAME = "permission_resources";
     private static final String LAYER_CACHE_NAME = "layer_resources";
-    private final Cache<Resource> resourceCache = CacheManager.getCache(PermissionHelper.class.getName() + RESOURCE_CACHE_NAME);
     private final Cache<OskariLayer> layerCache = CacheManager.getCache(PermissionHelper.class.getName() + LAYER_CACHE_NAME);
     private OskariLayerService layerService;
     private PermissionService permissionsService;
@@ -85,26 +83,13 @@ public class PermissionHelper {
         return layer;
     }
 
-    /**
-     * Gets resource from cache
-     * @return resource
-     */
     private Resource getResource(final OskariLayer layer) {
-
         String mapping = Integer.toString(layer.getId());
-        Resource resource = resourceCache.get(mapping);
-        if (resource != null) {
-            return resource;
-        }
-        Optional<Resource> dbRes = permissionsService.findResource(ResourceType.maplayer, mapping);
-        if (!dbRes.isPresent()) {
+        Optional<Resource> resource = permissionsService.findResource(ResourceType.maplayer, mapping);
+        if (!resource.isPresent()) {
             LOG.warn("Permissions not found for layer:", layer.getId());
-        } else {
-            resource = dbRes.get();
-            LOG.debug("Caching a layer permission resource", resource, "Permissions", resource.getPermissions());
-            resourceCache.put(mapping, resource);
+            return null;
         }
-
-        return resource;
+        return resource.get();
     }
 }

--- a/service-permissions/src/main/java/org/oskari/permissions/ResourceMapper.java
+++ b/service-permissions/src/main/java/org/oskari/permissions/ResourceMapper.java
@@ -34,6 +34,9 @@ public interface ResourceMapper {
             + "WHERE id = #{id}")
     Resource findById(@Param("id") int id);
 
+    @Select("SELECT EXISTS (SELECT 1 FROM oskari_resource WHERE id = #{id})")
+    boolean existsById(@Param("id") int id);
+
     @ResultMap("ResourceResult")
     @Select("SELECT id,"
             + "resource_type,"
@@ -57,6 +60,9 @@ public interface ResourceMapper {
             + "WHERE resource_type = #{type} "
             + "AND resource_mapping = #{mapping}")
     Resource findByTypeAndMapping(@Param("type") String type, @Param("mapping") String mapping);
+
+    @Select("SELECT EXISTS (SELECT 1 FROM oskari_resource WHERE resource_type = #{type} AND resource_mapping = #{mapping})")
+    boolean existsByTypeAndMapping(@Param("type") String type, @Param("mapping") String mapping);
 
     @Select("select distinct\n" +
             "            r.resource_mapping\n" +


### PR DESCRIPTION
`PermissionHelper`s cache of `Resource`s gets outdated when changes are made via PermissionService. Move the caching of Resource objects by type and mapping from `PermissionHelper` to the actual service implementation.