### PR TITLE
Refactoring the background process updating IndicatorList caches

### DIFF
--- a/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/DataSourceCachePopulator.java
+++ b/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/DataSourceCachePopulator.java
@@ -1,0 +1,66 @@
+package fi.nls.oskari.control.statistics.plugins;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.TemporalAmount;
+import java.util.ArrayList;
+import java.util.List;
+
+import fi.nls.oskari.control.statistics.data.StatisticalIndicator;
+
+/**
+ * Used to preload and -process statistical indicator data from a datasource
+ * 
+ * This version of DataSourceUpdater should be used when there cache is empty
+ * Uses ArrayList for storing the WorkQueue, gradually 'commits' the results to Redis
+ * 
+ * @see fi.nls.oskari.control.statistics.plugins.DataSourceUpdater
+ * @see fi.nls.oskari.control.statistics.plugins.DataSourceCacheUpdater
+ */
+public final class DataSourceCachePopulator extends DataSourceUpdater {
+
+    private static final TemporalAmount SYNC_INTERVAL = Duration.ofSeconds(20);
+
+    private List<StatisticalIndicator> workQueue;
+    private Instant lastSync;
+
+    public DataSourceCachePopulator(StatisticalDatasourcePlugin plugin) {
+        super(plugin);
+        this.workQueue = new ArrayList<>();
+    }
+
+    @Override
+    protected void updateStarted() {
+        super.updateStarted();
+        lastSync = Instant.now();
+    }
+
+    @Override
+    protected void addToWorkQueue(StatisticalIndicator indicator) {
+        workQueue.add(indicator);
+        if (workQueue.size() > 30 || Instant.now().isAfter(lastSync.plus(SYNC_INTERVAL))) {
+            storeIndicatorList(getIndicators());
+        }
+    }
+
+    @Override
+    protected List<StatisticalIndicator> getIndicators() {
+        List<StatisticalIndicator> indicators = new ArrayList<>();
+        indicators.addAll(plugin.getProcessedIndicators());
+        indicators.addAll(workQueue);
+        return indicators;
+    }
+
+    @Override
+    protected void storeIndicatorList(List<StatisticalIndicator> indicators) {
+        super.storeIndicatorList(indicators);
+        workQueue.clear();
+        lastSync = Instant.now();
+    }
+
+    @Override
+    public boolean isFullUpdate() {
+        return true;
+    }
+
+}

--- a/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/DataSourceCacheUpdater.java
+++ b/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/DataSourceCacheUpdater.java
@@ -1,0 +1,81 @@
+package fi.nls.oskari.control.statistics.plugins;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import fi.nls.oskari.cache.JedisManager;
+import fi.nls.oskari.control.statistics.data.StatisticalIndicator;
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+
+/**
+ * Used to preload and -process statistical indicator data from a datasource
+ * 
+ * This version of DataSourceUpdater should be used when already cached version of the indicator list exists.
+ * Uses Redis for storing the WorkQueue
+ * 
+ * @see fi.nls.oskari.control.statistics.plugins.DataSourceUpdater
+ * @see fi.nls.oskari.control.statistics.plugins.DataSourceCachePopulator
+ */
+public final class DataSourceCacheUpdater extends DataSourceUpdater {
+
+    private static final Logger LOG = LogFactory.getLogger(DataSourceCacheUpdater.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    public DataSourceCacheUpdater(StatisticalDatasourcePlugin plugin) {
+        super(plugin);
+    }
+
+    protected void addToWorkQueue(StatisticalIndicator indicator) {
+        // maybe add a metric how many indicators are processed/timeunit at some point
+        try {
+            String json = MAPPER.writeValueAsString(indicator);
+            JedisManager.pushToList(getIndicatorListWorkKey(), json);
+        } catch (JsonProcessingException ex) {
+            LOG.error(ex, "Error updating indicator list");
+        }
+    }
+
+    @Override
+    protected void updateStarted() {
+        super.updateStarted();
+        // remove any previous work fron Redis
+        JedisManager.del(getIndicatorListWorkKey());
+    }
+
+    @Override
+    protected List<StatisticalIndicator> getIndicators() {
+        final String workCacheKey = getIndicatorListWorkKey();
+        final List<StatisticalIndicator> processIndicators = new ArrayList<>();
+
+        // read work queue to Java objects
+        String json = JedisManager.popList(workCacheKey, true);
+        while(json != null) {
+            try {
+                StatisticalIndicator indicator = MAPPER.readValue(json, StatisticalIndicator.class);
+                processIndicators.add(indicator);
+            } catch (IOException ex) {
+                LOG.error(ex, "Couldn't read indicator data from work queue:", json);
+            }
+            json = JedisManager.popList(workCacheKey, true);
+        }
+        return processIndicators;
+    }
+
+    /**
+     * Returns a Redis key that should hold currently processed indicators of this datasource as list.
+     */
+    private String getIndicatorListWorkKey() {
+        return StatisticalDatasourcePlugin.CACHE_PREFIX + "worklist:" + plugin.getSource().getId();
+    }
+
+    @Override
+    public boolean isFullUpdate() {
+        return false;
+    }
+
+}

--- a/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/DataSourceUpdater.java
+++ b/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/DataSourceUpdater.java
@@ -7,29 +7,22 @@ import fi.nls.oskari.control.statistics.data.StatisticalIndicator;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Used to preload and -process statistical indicator data from a datasource
  */
-public class DataSourceUpdater implements Runnable {
+public abstract class DataSourceUpdater implements Runnable {
 
-    private static final Logger LOG = LogFactory.getLogger(StatisticalDatasourcePlugin.class);
+    private static final Logger LOG = LogFactory.getLogger(DataSourceUpdater.class);
 
-    private StatisticalDatasourcePlugin plugin;
-    private static final ObjectMapper MAPPER = new ObjectMapper();
-    private boolean wasCacheEmptyOnStart = false;
-    private long lastSync = -1;
-    private long indicatorsProcessedSinceLastSync = 0;
-    // 30 seconds between syncs
-    private long syncThreshold = 20 * 1000;
+    protected StatisticalDatasourcePlugin plugin;
 
     public DataSourceUpdater(StatisticalDatasourcePlugin plugin) {
         this.plugin = plugin;
     }
 
+    @Override
     public void run() {
         updateStarted();
         try {
@@ -42,99 +35,40 @@ public class DataSourceUpdater implements Runnable {
     }
 
     protected void updateStarted() {
-        // remove any previous work
-        JedisManager.del(getIndicatorListWorkKey());
-        wasCacheEmptyOnStart = plugin.isCacheEmpty();
-        lastSync = System.currentTimeMillis();
-        indicatorsProcessedSinceLastSync = 0;
-        // setup status
         DataStatus status = plugin.getStatus();
-        status.setUpdating(true);
-        status.setUpdateStarted();
-        JedisManager.setex(plugin.getStatusKey(), JedisManager.EXPIRY_TIME_DAY * 7, status.toJSON().toString());
-    }
-    protected void addToWorkQueue(StatisticalIndicator indicator) {
-        // maybe add a metric how many indicators are processed/timeunit at some point
-        try {
-            String json = MAPPER.writeValueAsString(indicator);
-            JedisManager.pushToList(getIndicatorListWorkKey(), json);
-            indicatorsProcessedSinceLastSync++;
-        } catch (JsonProcessingException ex) {
-            LOG.error(ex, "Error updating indicator list");
-        }
-        // we are populating empty cache AND if time between sync > threshold -> syncWorkToIndicators()
-        // wasCacheEmptyOnStart is important as it switches between full rewrite AND gradual update
-        if(wasCacheEmptyOnStart && (indicatorsProcessedSinceLastSync > 30 || System.currentTimeMillis() - lastSync > syncThreshold)) {
-            syncWorkToIndicators();
-        }
-    }
-    /**
-     * Returns a Redis key that should hold currently processed indicators of this datasource as list.
-     * @return
-     */
-    private String getIndicatorListWorkKey() {
-        return plugin.CACHE_PREFIX + "worklist:" + plugin.getSource().getId();
+        status.startUpdate();
+        JedisManager.setex(plugin.getStatusKey(), JedisManager.EXPIRY_TIME_DAY * 7, status.toString());
     }
 
-    List<StatisticalIndicator> getWorkQueue() {
-        final String workCacheKey = getIndicatorListWorkKey();
-        final List<StatisticalIndicator> processIndicators = new ArrayList<>();
-
-        // read work queue to Java classes
-        String json = JedisManager.popList(workCacheKey, true);
-        while(json != null) {
-            try {
-                StatisticalIndicator indicator = MAPPER.readValue(json, StatisticalIndicator.class);
-                processIndicators.add(indicator);
-            } catch (IOException ex) {
-                LOG.error(ex, "Couldn't read indicator data from work queue:", json);
-            }
-            json = JedisManager.popList(workCacheKey, true);
-        }
-        return processIndicators;
+    protected void updateCompleted() {
+        storeIndicatorList(getIndicators());
+        DataStatus status = plugin.getStatus();
+        status.finishUpdate();
+        JedisManager.setex(plugin.getStatusKey(), JedisManager.EXPIRY_TIME_DAY * 7, status.toString());
     }
 
     /**
-     * Should be called only after the whole listing has been processed IF cache already has indicator data (rewrites the previous list).
-     * Should be called multiple times if cache was EMPTY when the update started (gradually adds to the existing listing).
+     * Store the list of indicators to Redis as JSON
      */
-    protected void syncWorkToIndicators() {
-        lastSync = System.currentTimeMillis();
-        indicatorsProcessedSinceLastSync = 0;
-        final List<StatisticalIndicator> processIndicators = getWorkQueue();
-        // read existing list and merge processed ones to it
-        final List<StatisticalIndicator> existingIndicators = getProcessedIndicators();
-
-        // merge
-        existingIndicators.addAll(processIndicators);
+    protected void storeIndicatorList(List<StatisticalIndicator> indicators) {
+        if (indicators.isEmpty()) {
+            return;
+        }
 
         final ObjectMapper listMapper = new ObjectMapper();
         // skip f.ex. description and source when writing list
         listMapper.addMixIn(StatisticalIndicator.class, JacksonIndicatorListMixin.class);
         // write new indicator list
         try {
-            String result = listMapper.writeValueAsString(existingIndicators);
+            String result = listMapper.writeValueAsString(indicators);
             JedisManager.setex(plugin.getIndicatorListKey(), JedisManager.EXPIRY_TIME_DAY * 7, result);
         } catch (JsonProcessingException ex) {
             LOG.error(ex, "Error updating indicator list");
         }
     }
-    private List<StatisticalIndicator> getProcessedIndicators() {
-        if(wasCacheEmptyOnStart) {
-            // continue to add to the existing ones
-            return plugin.getProcessedIndicators();
-        }
-        // write to new list if we are updating a cached list
-        return new ArrayList<>();
-    }
 
-    protected void updateCompleted() {
-        // sync the remaining work list to actual indicators listing
-        syncWorkToIndicators();
-        // setup status
-        DataStatus status = plugin.getStatus();
-        status.setUpdating(false);
-        status.setLastUpdate();
-        JedisManager.setex(plugin.getStatusKey(), JedisManager.EXPIRY_TIME_DAY * 7, status.toJSON().toString());
-    }
+    public abstract boolean isFullUpdate();
+    protected abstract void addToWorkQueue(StatisticalIndicator indicator);
+    protected abstract List<StatisticalIndicator> getIndicators();
+
 }

--- a/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/DataStatus.java
+++ b/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/DataStatus.java
@@ -1,94 +1,63 @@
 package fi.nls.oskari.control.statistics.plugins;
 
-import fi.nls.oskari.util.JSONHelper;
+import java.time.Instant;
+
 import org.json.JSONObject;
 
-import java.util.Date;
+import fi.nls.oskari.util.JSONHelper;
 
 /**
  * Holds datasource remote sync status for statistical datasources
  */
 public class DataStatus {
 
-    private static final String KEY_COMPLETE = "complete";
     private static final String KEY_LAST = "lastUpdate";
     private static final String KEY_START = "updateStart";
 
-    private long lastUpdate = -1;
-    private long updateStarted = -1;
-    private boolean isUpdating = false;
+    private Instant lastUpdate;
+    private Instant updateStarted;
 
     public DataStatus(String status) {
         this(JSONHelper.createJSONObject(status));
     }
 
-    public DataStatus(JSONObject status) {
-        if(status == null) {
+    private DataStatus(JSONObject status) {
+        if (status == null) {
             return;
         }
-        isUpdating = !status.optBoolean(KEY_COMPLETE);
-        lastUpdate = status.optLong(KEY_LAST, -1);
-        updateStarted = status.optLong(KEY_START, -1);
+        long last = status.optLong(KEY_LAST, -1);
+        long start = status.optLong(KEY_START, -1);
+        this.lastUpdate = last == -1 ? null : Instant.ofEpochMilli(last);
+        this.updateStarted = start == -1 ? null : Instant.ofEpochMilli(start);
     }
 
-    public JSONObject toJSON() {
-        JSONObject val = JSONHelper.createJSONObject(KEY_COMPLETE, !isUpdating());
-        JSONHelper.putValue(val, KEY_LAST, lastUpdate);
-        JSONHelper.putValue(val, KEY_START, updateStarted);
-        return val;
+    @Override
+    public String toString() {
+        return toJSON().toString();
     }
 
-    private Date getDate(long ts) {
-        if(ts == -1) {
-            return null;
-        }
-        return new Date(ts);
+    private JSONObject toJSON() {
+        JSONObject json = new JSONObject();
+        JSONHelper.putValue(json, KEY_LAST, lastUpdate.toEpochMilli());
+        JSONHelper.putValue(json, KEY_START, updateStarted.toEpochMilli());
+        return json;
     }
 
-    public boolean shouldUpdate(long refreshPeriodms) {
-        if(isUpdating()) {
-            return false;
-        }
-        if(lastUpdate == -1) {
-            return true;
-        }
-        return System.currentTimeMillis() > lastUpdate + refreshPeriodms;
+    public Instant getLastUpdate() {
+        return lastUpdate;
     }
 
-    public Date getLastUpdate() {
-        return getDate(lastUpdate);
+    public Instant getUpdateStarted() {
+        return updateStarted;
     }
 
-    public void setLastUpdate() {
-        setLastUpdate(new Date());
-    }
-    public void setLastUpdate(Date date) {
-        setLastUpdate(date.getTime());
+    public void startUpdate() {
+        this.updateStarted = Instant.now();
     }
 
-    public void setLastUpdate(long lastUpdate) {
-        this.lastUpdate = lastUpdate;
+    public void finishUpdate() {
+        this.lastUpdate = Instant.now();
+        this.updateStarted = null;
     }
 
-    public Date getUpdateStarted() {
-        return getDate(updateStarted);
-    }
-
-    public void setUpdateStarted() {
-        setUpdateStarted(new Date());
-    }
-    public void setUpdateStarted(Date date) {
-        setUpdateStarted(date.getTime());
-    }
-    public void setUpdateStarted(long updateStarted) {
-        this.updateStarted = updateStarted;
-    }
-
-    public boolean isUpdating() {
-        return isUpdating;
-    }
-
-    public void setUpdating(boolean updating) {
-        isUpdating = updating;
-    }
 }

--- a/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/db/StatisticalDatasource.java
+++ b/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/db/StatisticalDatasource.java
@@ -20,7 +20,7 @@ public class StatisticalDatasource {
     private String plugin;
     private List<DatasourceLayer> layers = new ArrayList<>();
     private long maxUpdateDuration = TimeUnit.HOURS.toMillis(6);
-    private long updateInterval = 1000 * 60 * 60 * 24;
+    private long updateInterval = TimeUnit.HOURS.toMillis(24);
     private long cachePeriod = updateInterval * 7;
     private JSONObject hints;
 

--- a/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/db/StatisticalDatasource.java
+++ b/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/db/StatisticalDatasource.java
@@ -6,6 +6,7 @@ import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * This is the value object for the statistical indicator data source definition rows in the database.
@@ -18,6 +19,7 @@ public class StatisticalDatasource {
     private String config;
     private String plugin;
     private List<DatasourceLayer> layers = new ArrayList<>();
+    private long maxUpdateDuration = TimeUnit.HOURS.toMillis(6);
     private long updateInterval = 1000 * 60 * 60 * 24;
     private long cachePeriod = updateInterval * 7;
     private JSONObject hints;
@@ -28,6 +30,16 @@ public class StatisticalDatasource {
 
     public void setLayers(List<DatasourceLayer> layers) {
         this.layers = layers;
+    }
+
+    /**
+     * How long the update process is allowed to last before
+     * we can safely determine something horrible has happened
+     * 
+     * TODO: Remove hard-coded value
+     */
+    public long getMaxUpdateDuration() {
+        return maxUpdateDuration;
     }
 
     public long getUpdateInterval() {


### PR DESCRIPTION
Split logic from DataSourceUpdater into two separate classes, more clearly separate the cases of having an empty cache vs having cache but just want to refresh it.

Check if the update process has been running for too long. In case it has, restart it.

Only send the `"complete": false` to the client if we are running a "full update" e.g. the cache was empty when the update process started.

Remove the boolean isUpdating/complete flag from `DataStatus`. Instead use `updateStarted` field to determine whether it is updating or not.