### PR TITLE
Reduce logging for short circuits and timeouts

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandler.java
@@ -15,6 +15,9 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.oskari.service.user.UserLayerService;
 import org.oskari.service.wfs.client.OskariWFSClient;
 
+import com.netflix.hystrix.exception.HystrixRuntimeException;
+import com.netflix.hystrix.exception.HystrixRuntimeException.FailureType;
+
 import fi.nls.oskari.annotation.OskariActionRoute;
 import fi.nls.oskari.control.ActionCommonException;
 import fi.nls.oskari.control.ActionConstants;
@@ -29,6 +32,8 @@ import fi.nls.oskari.util.ResponseHelper;
 public class GetWFSFeaturesHandler extends AbstractWFSFeaturesHandler {
 
     protected static final String ERR_BBOX_INVALID = "Invalid bbox";
+    protected static final String ERR_SHORT_CIRCUIT = "Backing service disabled temporarily";
+    protected static final String ERR_TIMEOUT = "Request to backing service timed out";
     protected static final String ERR_FAILED_TO_RETRIEVE_FEATURES = "Failed to retrieve features";
     protected static final String ERR_GEOJSON_ENCODE_FAIL = "Failed to write GeoJSON";
 
@@ -61,14 +66,7 @@ public class GetWFSFeaturesHandler extends AbstractWFSFeaturesHandler {
         }
 
         ReferencedEnvelope bbox = parseBbox(bboxStr, targetCRS);
-
-        SimpleFeatureCollection fc;
-        try {
-            fc = featureClient.getFeatures(id, layer, bbox, targetCRS, contentProcessor);
-        } catch (ServiceRuntimeException e) {
-            throw new ActionCommonException(ERR_FAILED_TO_RETRIEVE_FEATURES, e);
-        }
-
+        SimpleFeatureCollection fc = getFeatures(id, layer, bbox, targetCRS, contentProcessor);
         if (fc.isEmpty()) {
             ResponseHelper.writeResponse(params, 200,
                     GEOJSON_CONTENT_TYPE, EMPTY_GEOJSON_FEATURE_COLLECTION);
@@ -106,6 +104,28 @@ public class GetWFSFeaturesHandler extends AbstractWFSFeaturesHandler {
             return new ReferencedEnvelope(x1, x2, y1, y2, crs);
         } catch (NumberFormatException e) {
             throw new ActionParamsException(ERR_BBOX_INVALID);
+        }
+    }
+
+    private SimpleFeatureCollection getFeatures(String id, OskariLayer layer, ReferencedEnvelope bbox,
+            CoordinateReferenceSystem targetCRS, Optional<UserLayerService> contentProcessor) throws ActionException {
+        try {
+            return featureClient.getFeatures(id, layer, bbox, targetCRS, contentProcessor);
+        } catch (HystrixRuntimeException e) {
+            if (e.getFailureType() == FailureType.SHORTCIRCUIT) {
+                throw new ActionCommonException(ERR_SHORT_CIRCUIT, e);
+            }
+            if (e.getFailureType() == FailureType.TIMEOUT) {
+                throw new ActionCommonException(ERR_TIMEOUT, e);
+            }
+            if (e.getCause() != null) {
+                if (e.getCause() instanceof ServiceRuntimeException) {
+                    throw new ActionCommonException(ERR_FAILED_TO_RETRIEVE_FEATURES, e);
+                }
+            }
+            throw new ActionException(ERR_FAILED_TO_RETRIEVE_FEATURES, e);
+        } catch (ServiceRuntimeException e) {
+            throw new ActionCommonException(ERR_FAILED_TO_RETRIEVE_FEATURES, e);
         }
     }
 

--- a/control-base/src/main/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandler.java
@@ -113,10 +113,10 @@ public class GetWFSFeaturesHandler extends AbstractWFSFeaturesHandler {
             return featureClient.getFeatures(id, layer, bbox, targetCRS, contentProcessor);
         } catch (HystrixRuntimeException e) {
             if (e.getFailureType() == FailureType.SHORTCIRCUIT) {
-                throw new ActionCommonException(ERR_SHORT_CIRCUIT, e);
+                throw new ActionCommonException(ERR_SHORT_CIRCUIT);
             }
             if (e.getFailureType() == FailureType.TIMEOUT) {
-                throw new ActionCommonException(ERR_TIMEOUT, e);
+                throw new ActionCommonException(ERR_TIMEOUT);
             }
             if (e.getCause() != null) {
                 if (e.getCause() instanceof ServiceRuntimeException) {

--- a/control-mvt/src/main/java/org/oskari/control/mvt/GetWFSVectorTileHandler.java
+++ b/control-mvt/src/main/java/org/oskari/control/mvt/GetWFSVectorTileHandler.java
@@ -30,6 +30,7 @@ import com.vividsolutions.jts.geom.Point;
 import fi.nls.oskari.annotation.OskariActionRoute;
 import fi.nls.oskari.cache.CacheManager;
 import fi.nls.oskari.cache.ComputeOnceCache;
+import fi.nls.oskari.control.ActionCommonException;
 import fi.nls.oskari.control.ActionConstants;
 import fi.nls.oskari.control.ActionException;
 import fi.nls.oskari.control.ActionParameters;
@@ -127,8 +128,8 @@ public class GetWFSVectorTileHandler extends AbstractWFSFeaturesHandler {
             } else {
                 resp = tileCache.get(cacheKey, __ -> createTile(id, layer, crs, grid, targetZ, z, x, y, contentProcessor));
             }
-        } catch (ServiceRuntimeException e) {
-            throw new ActionException(e.getMessage());
+        } catch (Exception e) {
+            throw new ActionCommonException(e.getMessage(), e);
         }
         params.getResponse().addHeader("Access-Control-Allow-Origin", "*");
         params.getResponse().addHeader("Content-Encoding", "gzip");
@@ -209,16 +210,13 @@ public class GetWFSVectorTileHandler extends AbstractWFSFeaturesHandler {
      */
     private byte[] createTile(String id, OskariLayer layer, CoordinateReferenceSystem crs,
             WFSTileGrid grid, int targetZ, int z, int x, int y,
-            Optional<UserLayerService> contentProcessor) throws ServiceRuntimeException {
+            Optional<UserLayerService> contentProcessor) {
         List<TileCoord> tilesToLoad = getTilesToLoad(targetZ, z, x, y);
 
         DefaultFeatureCollection sfc = new DefaultFeatureCollection();
         for (TileCoord tile : tilesToLoad) {
             SimpleFeatureCollection tileFeatures = getFeatures(id, layer, crs, grid, tile, contentProcessor);
-            if (tileFeatures == null) {
-                throw new ServiceRuntimeException("Failed to get features from service");
-            }
-            addAll(sfc, tileFeatures);
+            sfc.addAll(tileFeatures);
         }
 
         String mvtLayer = layer.getName();
@@ -286,20 +284,11 @@ public class GetWFSVectorTileHandler extends AbstractWFSFeaturesHandler {
 
     private SimpleFeatureCollection getFeatures(String id, OskariLayer layer,
             CoordinateReferenceSystem crs, WFSTileGrid grid, TileCoord tile,
-            Optional<UserLayerService> processor) throws ServiceRuntimeException {
+            Optional<UserLayerService> processor) {
         double[] box = grid.getTileExtent(tile);
         Envelope envelope = new Envelope(box[0], box[2], box[1], box[3]);
-        Envelope bufferedEnvelope = new Envelope(envelope);
-        ReferencedEnvelope bbox = new ReferencedEnvelope(bufferedEnvelope, crs);
+        ReferencedEnvelope bbox = new ReferencedEnvelope(envelope, crs);
         return featureClient.getFeatures(id, layer, bbox, crs, processor);
-    }
-
-    private static void addAll(DefaultFeatureCollection sfc, SimpleFeatureCollection toAdd) {
-        try (SimpleFeatureIterator it = toAdd.features()) {
-            while (it.hasNext()) {
-                sfc.add(it.next());
-            }
-        }
     }
 
     private boolean isOnlyPointFeatures(SimpleFeatureCollection sfc) {

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariFeatureClient.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariFeatureClient.java
@@ -41,7 +41,7 @@ public class OskariFeatureClient {
     }
 
     public SimpleFeatureCollection getFeatures(String id, OskariLayer layer, ReferencedEnvelope bbox,
-            CoordinateReferenceSystem targetCRS, Optional<UserLayerService> processor) throws ServiceRuntimeException {
+            CoordinateReferenceSystem targetCRS, Optional<UserLayerService> processor) {
         CoordinateReferenceSystem nativeCRS = getNativeCRS();
         boolean needsTransform = !CRS.equalsIgnoreMetadata(nativeCRS, targetCRS);
 
@@ -71,10 +71,9 @@ public class OskariFeatureClient {
         }
     }
 
-
     private SimpleFeatureCollection getFeaturesNoTransform(String id, OskariLayer layer,
             ReferencedEnvelope bbox, CoordinateReferenceSystem crs,
-            Optional<UserLayerService> processor) throws ServiceRuntimeException {
+            Optional<UserLayerService> processor) {
         Filter filter = processor.map(proc -> proc.getWFSFilter(id, bbox)).orElse(null);
 
         SimpleFeatureCollection sfc = wfsClient.getFeatures(layer, bbox, crs, filter);

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFSClient.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFSClient.java
@@ -25,6 +25,7 @@ import java.util.Locale;
 import java.util.Map;
 
 public class OskariWFSClient {
+
     private static final Logger LOG = LogFactory.getLogger(OskariWFS110Client.class);
     private static final String EXC_HANDLING_OUTPUTFORMAT = "outputformat";
     private static final TypeReference<HashMap<String, Object>> TYPE_REF = new TypeReference<HashMap<String, Object>>() {};
@@ -32,7 +33,7 @@ public class OskariWFSClient {
     private static final int MAX_REDIRECTS = 5;
 
     public SimpleFeatureCollection getFeatures(OskariLayer layer,
-            ReferencedEnvelope bbox, CoordinateReferenceSystem crs, Filter filter) throws ServiceRuntimeException {
+            ReferencedEnvelope bbox, CoordinateReferenceSystem crs, Filter filter) {
         return new OskariWFSLoadCommand(layer, bbox, crs, filter).execute();
     }
 

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFSLoadCommand.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFSLoadCommand.java
@@ -1,7 +1,6 @@
 package org.oskari.service.wfs.client;
 
 import fi.nls.oskari.domain.map.OskariLayer;
-import fi.nls.oskari.service.ServiceRuntimeException;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.opengis.filter.Filter;
@@ -67,8 +66,4 @@ public class OskariWFSLoadCommand extends HystrixCommand<SimpleFeatureCollection
         }
     }
 
-    public SimpleFeatureCollection getFallback() {
-        // handler expects an Exception or SimpleFeatureCollection. If we don't throw an exception a null value is returned.
-        throw new ServiceRuntimeException("Error getting features from " + layer.getUrl(), getExceptionFromThrowable(getExecutionException()));
-    }
 }


### PR DESCRIPTION
Don't log stack traces for short circuits and timeouts for GetWFSFeatures requests