### PR TITLE
Enable appsetups to be inserted with id reference allowed

### DIFF
--- a/content-resources/src/main/java/fi/nls/oskari/db/ViewHelper.java
+++ b/content-resources/src/main/java/fi/nls/oskari/db/ViewHelper.java
@@ -87,8 +87,10 @@ public class ViewHelper {
             view.setIsPublic(viewJSON.optBoolean("public", false));
             // onlyUuid doesn't work since the sql uses hardcoded "true". Needs more testing twith existing views to change the defaults.
             view.setOnlyForUuId(viewJSON.optBoolean("onlyUuid", true));
-            view.setName(viewJSON.getString("name"));
+            // This enables creative uses of uuid like having uuid=simplemap
+            view.setUuid(viewJSON.getString("uuid"));
             view.setType(viewJSON.getString("type"));
+            view.setName(viewJSON.getString("name"));
             view.setIsDefault(viewJSON.optBoolean("default"));
             final JSONObject oskari = JSONHelper.getJSONObject(viewJSON, "oskari");
             view.setPage(oskari.getString("page"));

--- a/content-resources/src/main/java/fi/nls/oskari/db/ViewHelper.java
+++ b/content-resources/src/main/java/fi/nls/oskari/db/ViewHelper.java
@@ -85,10 +85,7 @@ public class ViewHelper {
             final View view = new View();
             view.setCreator(ConversionHelper.getLong(viewJSON.optString("creator"), -1));
             view.setIsPublic(viewJSON.optBoolean("public", false));
-            // onlyUuid doesn't work since the sql uses hardcoded "true". Needs more testing twith existing views to change the defaults.
             view.setOnlyForUuId(viewJSON.optBoolean("onlyUuid", true));
-            // This enables creative uses of uuid like having uuid=simplemap
-            view.setUuid(viewJSON.getString("uuid"));
             view.setType(viewJSON.getString("type"));
             view.setName(viewJSON.getString("name"));
             view.setIsDefault(viewJSON.optBoolean("default"));

--- a/control-base/src/test/java/fi/nls/oskari/control/view/GetAppSetupHandlerTest.java
+++ b/control-base/src/test/java/fi/nls/oskari/control/view/GetAppSetupHandlerTest.java
@@ -226,6 +226,7 @@ public class GetAppSetupHandlerTest extends JSONActionRouteTest {
 
         final View dummyView = ViewTestHelper.createMockView("framework.mapfull");
         dummyView.setType(ViewTypes.USER);
+        dummyView.setOnlyForUuId(false);
         doReturn(dummyView).when(viewService).getViewWithConfByOldId(anyLong());
         doReturn(dummyView).when(viewService).getViewWithConf(anyLong());
         doReturn(dummyView).when(viewService).getViewWithConfByUuId(anyString());

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/view/View.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/view/View.java
@@ -17,7 +17,7 @@ public class View implements Serializable {
     private String name = null;
     private String description = null;
     private String uuid = null;
-    private boolean onlyForUuId = false;
+    private boolean onlyForUuId = true;
     private JSONObject metadata = null;
     private List<Bundle> bundles = new ArrayList<Bundle>();
 

--- a/service-map/src/main/java/fi/nls/oskari/map/view/AppSetupMapper.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/view/AppSetupMapper.java
@@ -20,7 +20,7 @@ public interface AppSetupMapper {
 
     @Insert("INSERT INTO portti_view ( name, \"description\", type, application_dev_prefix, page, application, " +
             "            uuid, only_uuid, domain, lang, creator, is_public, is_default, metadata) " +
-            "        VALUES ( #{name}, #{description}, #{type}, #{developmentPath}, #{page}, #{application}, '${uuid}', true, " +
+            "        VALUES ( #{name}, #{description}, #{type}, #{developmentPath}, #{page}, #{application}, '${uuid}', ${onlyForUuId}, " +
             "        #{pubDomain}, #{lang}, #{creator}, #{isPublic}, #{isDefault}, #{metadataAsString} )")
     @Options(useGeneratedKeys=true, keyColumn = "id", keyProperty = "id")
     void addView(View view);

--- a/service-map/src/main/java/fi/nls/oskari/map/view/AppSetupServiceMybatisImpl.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/view/AppSetupServiceMybatisImpl.java
@@ -220,10 +220,7 @@ public class AppSetupServiceMybatisImpl extends ViewService {
     public long addView(View view) throws ViewException {
         try (final SqlSession session = factory.openSession()) {
             final AppSetupMapper mapper = session.getMapper(AppSetupMapper.class);
-            if (view.getUuid() == null || view.getUuid().trim().isEmpty()) {
-                // generate uuid if one doesn't exist
-                view.setUuid(UUID.randomUUID().toString());
-            }
+            view.setUuid(UUID.randomUUID().toString());
             mapper.addView(view);
             long id = view.getId();
             LOG.info("Inserted view with id", id);

--- a/service-map/src/main/java/fi/nls/oskari/map/view/AppSetupServiceMybatisImpl.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/view/AppSetupServiceMybatisImpl.java
@@ -220,7 +220,10 @@ public class AppSetupServiceMybatisImpl extends ViewService {
     public long addView(View view) throws ViewException {
         try (final SqlSession session = factory.openSession()) {
             final AppSetupMapper mapper = session.getMapper(AppSetupMapper.class);
-            view.setUuid(UUID.randomUUID().toString());
+            if (view.getUuid() == null || view.getUuid().trim().isEmpty()) {
+                // generate uuid if one doesn't exist
+                view.setUuid(UUID.randomUUID().toString());
+            }
             mapper.addView(view);
             long id = view.getId();
             LOG.info("Inserted view with id", id);


### PR DESCRIPTION
Loading appsetups with UUID has been the "normal way" to access appsetups for years now. Changed the default value in View.onlyForUuid to true to signify this. Changed insert statement to use the value from View instead of hard-coded true. This enables initial appsetups in extensions to be inserted with view id access making it easier to setup multiple apps and refer to them with a sequence number that id is.

This will be used in the sample-server-extension to have an example embedded map with "known identifier" so it can be easily linked to even with the database being wiped periodically.