### PR TITLE
Default schedule for capabilities update

### DIFF
--- a/service-capabilities-update/src/main/java/org/oskari/capabilities/UpdateCapabilitiesJob.java
+++ b/service-capabilities-update/src/main/java/org/oskari/capabilities/UpdateCapabilitiesJob.java
@@ -88,4 +88,14 @@ public class UpdateCapabilitiesJob extends ScheduledJob {
         return false;
     }
 
+    @Override
+    public String getCronLine() {
+        String line = super.getCronLine();
+        if(line != null) {
+            // use property if specified
+            return line;
+        }
+        // default if not specified (daily)
+        return "0 0 0 * * ?";
+    }
 }


### PR DESCRIPTION
The administrator can set a time interval in seconds per layer for how frequently the capabilities should be updated from a service (this is mandatory for layers with frequently changing capabilities like timeseries layers for weather). However the scheduled job that should make the update isn't scheduled to run by default. This change makes it run daily but allows the administrator to change it with oskari-ext.properties with a custom cronline like:
```
oskari.scheduler.job.UpdateCapabilitiesJob.cronLine=0 0 * * * ?
```