### PR TITLE
WFS 1.1.0 GML parsing

### DIFF
--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariGML.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariGML.java
@@ -7,13 +7,15 @@ import java.util.Collection;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.dom.DOMSource;
 
 import org.geotools.GML;
 import org.geotools.data.DataUtilities;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.feature.DefaultFeatureCollection;
 import org.geotools.gml3.GMLConfiguration;
-import org.geotools.xml.DOMParser;
+import org.geotools.xml.Parser;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.w3c.dom.Document;
@@ -58,16 +60,22 @@ public class OskariGML extends GML {
          * behind authorization there's no way for us to control the authorization
          * information done when fetching other <xsd:include>'d schemas
          */
-        root.removeAttribute("schemaLocation");
-        root.removeAttribute("xsi:schemaLocation");
+        //root.removeAttribute("schemaLocation");
+        //root.removeAttribute("xsi:schemaLocation");
         OskariWFSConfiguration conf = new OskariWFSConfiguration(username, password);
         for (Object dep : conf.allDependencies()) {
             if (dep instanceof GMLConfiguration) {
                 ((GMLConfiguration) dep).setExtendedArcSurfaceSupport(true);
             }
         }
-        DOMParser parser = new DOMParser(conf, doc);
-        Object obj = parser.parse();
+
+        Parser parser = new Parser(conf);
+        Object obj = null;
+        try {
+            obj = parser.parse(new DOMSource(doc));
+        } catch (TransformerException e) {
+            new IOException(e.getCause());
+        }
         return toFeatureCollection(obj);
     }
 


### PR DESCRIPTION
GeoTools gml parser doesn't parse correctly gml which contains mixed geometry if schema is removed from gml. To fix this issue changed DomParser to Parser and removed schemaLocation removing. With these changes GeoTools parses geometry to Geometry.class as defined in schema. If schema is removed then DomParser parses collection which contains Points and Polygons to MultiPolygon.class.

Tried different parsers (DomParser, Parser, PullParser) with different configurations, but geotools failed to parse geometry correctly. Also tried to retype collection's FeatureType and use FeatureCollection instead of SimpleFeatureCollection. Problematic layer contains also mixed feature types (every feature doesn't share same properties). Somehow Feature properties was build wrongly to GeoJSON if schema was retyped after parsing.

If this solution causes problems with complex type layers then I suggest that schemaLocation should be removed only from complex layers.