### PR TITLE
Fix npe when plugin doesn't have config in db

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/view/modifier/bundle/MapfullHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/view/modifier/bundle/MapfullHandler.java
@@ -551,7 +551,7 @@ public class MapfullHandler extends BundleHandler {
         }
         try {
             JSONObject config = plugin.getJSONObject(KEY_CONFIG);
-            if(config.has(KEY_CENTER_MAP_AUTOMATICALLY)) {
+            if(config != null && config.has(KEY_CENTER_MAP_AUTOMATICALLY)) {
                 config.remove(KEY_CENTER_MAP_AUTOMATICALLY);
             }
         } catch (JSONException jsonex) {


### PR DESCRIPTION
The plugin doesn't usually have a config so this causes unnecessary error logging that can be easily fixed.