### PR TITLE
Fix filter encoding version for WFS 1.1

### DIFF
--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS110Client.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS110Client.java
@@ -124,7 +124,9 @@ public class OskariWFS110Client {
         try {
             Encoder encoder = new Encoder(new OGCConfiguration());
             encoder.setOmitXMLDeclaration(true);
-            return encoder.encodeAsString(filter, org.geotools.filter.v1_0.OGC.Filter);
+            // https://docs.geoserver.org/stable/en/user/filter/syntax.html
+            // Filter Encoding 1.1 is used in WFS 1.1
+            return encoder.encodeAsString(filter, org.geotools.filter.v1_1.OGC.Filter);
         } catch (IOException e) {
             throw new ServiceRuntimeException("Failed to encode filter!", e);
         }

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS110Client.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS110Client.java
@@ -10,7 +10,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.geotools.data.simple.SimpleFeatureCollection;
-import org.geotools.filter.v1_0.OGCConfiguration;
+import org.geotools.filter.v1_1.OGCConfiguration;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.xml.Encoder;
 import org.opengis.filter.Filter;

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS110Client.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS110Client.java
@@ -10,7 +10,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.geotools.data.simple.SimpleFeatureCollection;
-import org.geotools.filter.v1_1.OGCConfiguration;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.xml.Encoder;
 import org.opengis.filter.Filter;
@@ -122,10 +121,10 @@ public class OskariWFS110Client {
             return null;
         }
         try {
-            Encoder encoder = new Encoder(new OGCConfiguration());
-            encoder.setOmitXMLDeclaration(true);
             // https://docs.geoserver.org/stable/en/user/filter/syntax.html
             // Filter Encoding 1.1 is used in WFS 1.1
+            Encoder encoder = new Encoder(new org.geotools.filter.v1_1.OGCConfiguration());
+            encoder.setOmitXMLDeclaration(true);
             return encoder.encodeAsString(filter, org.geotools.filter.v1_1.OGC.Filter);
         } catch (IOException e) {
             throw new ServiceRuntimeException("Failed to encode filter!", e);

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS2Client.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS2Client.java
@@ -6,7 +6,6 @@ import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.service.ServiceRuntimeException;
 import fi.nls.oskari.util.IOHelper;
 import org.geotools.data.simple.SimpleFeatureCollection;
-import org.geotools.filter.v2_0.FESConfiguration;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.xml.Encoder;
 import org.opengis.filter.Filter;
@@ -101,10 +100,10 @@ public class OskariWFS2Client {
             return null;
         }
         try {
-            Encoder encoder = new Encoder(new FESConfiguration());
-            encoder.setOmitXMLDeclaration(true);
             // https://docs.geoserver.org/stable/en/user/filter/syntax.html
             // Filter Encoding 2.0 is used in WFS 2.0
+            Encoder encoder = new Encoder(new org.geotools.filter.v2_0.FESConfiguration());
+            encoder.setOmitXMLDeclaration(true);
             return encoder.encodeAsString(filter, org.geotools.filter.v2_0.FES.Filter);
         } catch (IOException e) {
             throw new ServiceRuntimeException("Failed to encode filter!", e);

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS2Client.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS2Client.java
@@ -104,7 +104,7 @@ public class OskariWFS2Client {
             Encoder encoder = new Encoder(new FESConfiguration());
             encoder.setOmitXMLDeclaration(true);
             // https://docs.geoserver.org/stable/en/user/filter/syntax.html
-            // ilter Encoding 2.0 is used in WFS 2.0
+            // Filter Encoding 2.0 is used in WFS 2.0
             return encoder.encodeAsString(filter, org.geotools.filter.v2_0.FES.Filter);
         } catch (IOException e) {
             throw new ServiceRuntimeException("Failed to encode filter!", e);

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS2Client.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS2Client.java
@@ -103,6 +103,8 @@ public class OskariWFS2Client {
         try {
             Encoder encoder = new Encoder(new FESConfiguration());
             encoder.setOmitXMLDeclaration(true);
+            // https://docs.geoserver.org/stable/en/user/filter/syntax.html
+            // ilter Encoding 2.0 is used in WFS 2.0
             return encoder.encodeAsString(filter, org.geotools.filter.v2_0.FES.Filter);
         } catch (IOException e) {
             throw new ServiceRuntimeException("Failed to encode filter!", e);

--- a/service-wfs-client/src/test/java/org/oskari/service/wfs/client/OskariWFS110ClientTest.java
+++ b/service-wfs-client/src/test/java/org/oskari/service/wfs/client/OskariWFS110ClientTest.java
@@ -15,7 +15,7 @@ public class OskariWFS110ClientTest {
         Filter f = ff.equals(ff.property("bar"), ff.literal("foo"));
         String actual = OskariWFS110Client.getFilter(f);
         String expected = "<ogc:Filter xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:gml=\"http://www.opengis.net/gml\" xmlns:ogc=\"http://www.opengis.net/ogc\">"
-                + "<ogc:PropertyIsEqualTo>"
+                + "<ogc:PropertyIsEqualTo matchCase=\"true\">"
                 + "<ogc:PropertyName>bar</ogc:PropertyName>"
                 + "<ogc:Literal>foo</ogc:Literal>"
                 + "</ogc:PropertyIsEqualTo>"


### PR DESCRIPTION
Fixed problematic filter encoding for WFS-requests (used 1.0 with WFS 1.1 and now filter is encoded to supported 1.1) causing GeoServer to go OOM/throw OutOfMemoryException:

Filter Encoding 1.1 is used in WFS 1.1
Filter Encoding 2.0 is used in WFS 2.0
(https://docs.geoserver.org/stable/en/user/filter/syntax.html)