### PR TITLE
Check file size when unzipping

### DIFF
--- a/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java
+++ b/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java
@@ -1,10 +1,6 @@
 package org.oskari.control.userlayer;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
+import java.io.*;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -72,6 +68,7 @@ public class CreateUserLayerHandler extends RestActionHandler {
     private static final String PROPERTY_USERLAYER_MAX_FILE_SIZE_MB = "userlayer.max.filesize.mb";
     private static final String PROPERTY_TARGET_EPSG = "oskari.native.srs";
     private static final int MAX_FILES_IN_ZIP = 10;
+    private static final long FILE_SIZE_LIMIT = 1024*1024*100; // Max size of unzipped data, 100MB
 
     private static final Charset[] POSSIBLE_CHARSETS_USED_IN_ZIP_FILE_NAMES = {
             StandardCharsets.UTF_8,
@@ -372,7 +369,7 @@ public class CreateUserLayerHandler extends RestActionHandler {
                 name = "a" + name.substring(name.lastIndexOf('.'));
                 File file = new File(dir, name);
                 try (FileOutputStream fos = new FileOutputStream(file)) {
-                    IOHelper.copy(zis, fos);
+                    IOHelper.copy(zis, fos, FILE_SIZE_LIMIT);
                 }
                 if (mainFile == null) {
                     String ext = getFileExt(name);

--- a/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java
+++ b/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java
@@ -68,7 +68,6 @@ public class CreateUserLayerHandler extends RestActionHandler {
     private static final String PROPERTY_USERLAYER_MAX_FILE_SIZE_MB = "userlayer.max.filesize.mb";
     private static final String PROPERTY_TARGET_EPSG = "oskari.native.srs";
     private static final int MAX_FILES_IN_ZIP = 10;
-    private static final long FILE_SIZE_LIMIT = 1024*1024*100; // Max size of unzipped data, 100MB
 
     private static final Charset[] POSSIBLE_CHARSETS_USED_IN_ZIP_FILE_NAMES = {
             StandardCharsets.UTF_8,
@@ -83,7 +82,7 @@ public class CreateUserLayerHandler extends RestActionHandler {
     private static final String KEY_SOURCE = "layer-source";
     private static final String KEY_STYLE = "layer-style";
 
-    private static final int KB = 1024 * 1024;
+    private static final int KB = 1024;
     private static final int MB = 1024 * KB;
 
     // Store files smaller than 128kb in memory instead of writing them to disk
@@ -93,7 +92,8 @@ public class CreateUserLayerHandler extends RestActionHandler {
 
     private final DiskFileItemFactory diskFileItemFactory = new DiskFileItemFactory(MAX_SIZE_MEMORY, null);
     private final String targetEPSG = PropertyUtil.get(PROPERTY_TARGET_EPSG, "EPSG:4326");
-    private final int userlayerMaxFileSize = PropertyUtil.getOptional(PROPERTY_USERLAYER_MAX_FILE_SIZE_MB, 10) * MB;
+    private static final int userlayerMaxFileSize = PropertyUtil.getOptional(PROPERTY_USERLAYER_MAX_FILE_SIZE_MB, 10) * MB;
+    private static final long FILE_SIZE_LIMIT = 15 * userlayerMaxFileSize; // Max size of unzipped data, 15 * the zip size
 
     private UserLayerDbService userLayerService;
 

--- a/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
@@ -228,15 +228,49 @@ public class IOHelper {
      * @throws IOException
      */
     public static void copy(InputStream in, OutputStream out) throws IOException {
+        copy(in, out, -1);
+    }
+
+    /**
+     * Copies data from InputStream to OutputStream
+     * Does not close either of the streams
+     * Does nothing if either InputStream or OutputStream is null
+     *
+     * @param in
+     * @param out
+     * @param sizeLimit limit the amount of bytes we are willing to copy before failing (negative number for no limit)
+     * @throws IOException
+     */
+    public static void copy(InputStream in, OutputStream out, long sizeLimit) throws IOException {
         if (in == null || out == null) {
             return;
         }
-
-        final byte[] buffer = new byte[4096];
+        int BUFFER_SIZE = 4096;
+        long total = 0;
+        final byte[] buffer = new byte[BUFFER_SIZE];
         int read = 0;
-        while ((read = in.read(buffer, 0, 4096)) != -1) {
+        while ((read = in.read(buffer, 0, BUFFER_SIZE)) != -1) {
             out.write(buffer, 0, read);
+            total += read;
+            if (sizeLimit > -1 && total + BUFFER_SIZE > sizeLimit) {
+                throw new IOException("Size limit reached: " + humanReadableByteCount(sizeLimit));
+            }
         }
+    }
+
+    protected static String humanReadableByteCount(long bytes) {
+        return humanReadableByteCount(bytes, false);
+    }
+
+    // FROM https://programming.guide/java/formatting-byte-size-to-human-readable-format.html
+    protected static String humanReadableByteCount(long bytes, boolean si) {
+        int unit = si ? 1000 : 1024;
+        if (bytes < unit) {
+            return bytes + " B";
+        }
+        int exp = (int) (Math.log(bytes) / Math.log(unit));
+        String pre = (si ? "kMGTPE" : "KMGTPE").charAt(exp-1) + (si ? "" : "i");
+        return String.format("%.1f %sB", bytes / Math.pow(unit, exp), pre);
     }
 
     /**

--- a/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
@@ -250,11 +250,11 @@ public class IOHelper {
         final byte[] buffer = new byte[BUFFER_SIZE];
         int read = 0;
         while ((read = in.read(buffer, 0, BUFFER_SIZE)) != -1) {
-            out.write(buffer, 0, read);
-            total += read;
-            if (sizeLimit > -1 && total + BUFFER_SIZE > sizeLimit) {
+            if (sizeLimit > -1 && total + read > sizeLimit) {
                 throw new IOException("Size limit reached: " + humanReadableByteCount(sizeLimit));
             }
+            out.write(buffer, 0, read);
+            total += read;
         }
     }
 

--- a/service-base/src/test/java/fi/nls/oskari/util/IOHelperTest.java
+++ b/service-base/src/test/java/fi/nls/oskari/util/IOHelperTest.java
@@ -1,16 +1,20 @@
 package fi.nls.oskari.util;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 /**
  * Created with IntelliJ IDEA.
@@ -20,6 +24,7 @@ import static org.junit.Assert.assertEquals;
  * To change this template use File | Settings | File Templates.
  */
 public class IOHelperTest {
+
     @Test
     public void testConstructUrl() throws Exception {
         String baseUrl = "/testing";
@@ -112,4 +117,35 @@ public class IOHelperTest {
         assertEquals(longString, actualLongString);
     }
 
+    @Test
+    public void testHumanReadableBytes() {
+        long hundredMegsInBytes = 1024*1024*100;
+        assertEquals("100,0 MiB", IOHelper.humanReadableByteCount(hundredMegsInBytes));
+        assertEquals("100,0 MiB", IOHelper.humanReadableByteCount(hundredMegsInBytes, false));
+        assertEquals("104,9 MB", IOHelper.humanReadableByteCount(hundredMegsInBytes, true));
+    }
+
+    @Test
+    public void testCopy() throws IOException {
+        byte[] input = new byte[5000];
+        ByteArrayInputStream in = new ByteArrayInputStream(input);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        IOHelper.copy(in, out);
+        assertTrue(Arrays.equals(input, out.toByteArray()));
+    }
+
+    @Test(expected = IOException.class)
+    public void testCopySizeLimit() throws IOException {
+        try {
+            byte[] input = new byte[5000];
+            ByteArrayInputStream in = new ByteArrayInputStream(input);
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            IOHelper.copy(in, out, 400);
+            fail("Should have thrown IOException but did not!");
+        }
+        catch(IOException e) {
+            assertEquals("Size limit reached: 400 B", e.getMessage());
+            throw e;
+        }
+    }
 }

--- a/service-base/src/test/java/fi/nls/oskari/util/IOHelperTest.java
+++ b/service-base/src/test/java/fi/nls/oskari/util/IOHelperTest.java
@@ -120,9 +120,13 @@ public class IOHelperTest {
     @Test
     public void testHumanReadableBytes() {
         long hundredMegsInBytes = 1024*1024*100;
-        assertEquals("100,0 MiB", IOHelper.humanReadableByteCount(hundredMegsInBytes));
-        assertEquals("100,0 MiB", IOHelper.humanReadableByteCount(hundredMegsInBytes, false));
-        assertEquals("104,9 MB", IOHelper.humanReadableByteCount(hundredMegsInBytes, true));
+        assertEquals("100,0 MiB", ignoreNumberFormatting(IOHelper.humanReadableByteCount(hundredMegsInBytes)));
+        assertEquals("100,0 MiB", ignoreNumberFormatting(IOHelper.humanReadableByteCount(hundredMegsInBytes, false)));
+        assertEquals("104,9 MB", ignoreNumberFormatting(IOHelper.humanReadableByteCount(hundredMegsInBytes, true)));
+    }
+
+    private String ignoreNumberFormatting(String str) {
+        return str.replace('.', ',');
     }
 
     @Test

--- a/service-base/src/test/java/fi/nls/oskari/util/IOHelperTest.java
+++ b/service-base/src/test/java/fi/nls/oskari/util/IOHelperTest.java
@@ -1,6 +1,5 @@
 package fi.nls.oskari.util;
 
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 


### PR DESCRIPTION
Add an overloaded version of IOHelper.copy() with third parameter to limit the amount of bytes we are willing to copy. This is used in userlayer import to limit the size of a file that is being unzipped.