### PR TITLE
Store indicator path to id for deep PXWeb crawling

### DIFF
--- a/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/PxwebConfig.java
+++ b/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/PxwebConfig.java
@@ -11,6 +11,8 @@ import java.util.Set;
  */
 public class PxwebConfig {
 
+    public static final String ID_SEPARATOR = "::";
+
     private long datasourceId;
     private String url;
     private String regionKey;

--- a/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/PxwebStatisticalDatasourcePlugin.java
+++ b/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/PxwebStatisticalDatasourcePlugin.java
@@ -118,7 +118,7 @@ public class PxwebStatisticalDatasourcePlugin extends StatisticalDatasourcePlugi
             if(separatorIndex == -1) {
                 throw new ServiceRuntimeException("Unidentified indicator id: " + indicatorId);
             }
-            String indicatorSelector = indicatorId.substring(separatorIndex + 2);
+            String indicatorSelector = indicatorId.substring(separatorIndex + PxwebConfig.ID_SEPARATOR.length());
             indicatorId = indicatorId.substring(0, separatorIndex);
             params.addDimension(new StatisticalIndicatorDataDimension(config.getIndicatorKey(), indicatorSelector));
         }
@@ -181,7 +181,9 @@ public class PxwebStatisticalDatasourcePlugin extends StatisticalDatasourcePlugi
 
     private String createUrl(String baseUrl, String pathId) {
         if(!baseUrl.endsWith(".px")) {
-            return IOHelper.fixPath(baseUrl + "/" + IOHelper.urlEncode(pathId));
+            // URLencode id and replace any encoded / in path back from %2F
+            // Pxweb doesn't seem to like spaces as + so use payload encoding instead to change spaces to %20
+            return IOHelper.fixPath(baseUrl + "/" + IOHelper.urlEncodePayload(pathId).replace("%2F", "/"));
         }
         return baseUrl;
     }

--- a/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/PxwebStatisticalDatasourcePlugin.java
+++ b/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/PxwebStatisticalDatasourcePlugin.java
@@ -114,7 +114,7 @@ public class PxwebStatisticalDatasourcePlugin extends StatisticalDatasourcePlugi
         String indicatorId = indicator.getId();
         if(config.hasIndicatorKey()) {
             // indicatorId will be something.px::[value of indicatorKey]
-            int separatorIndex = indicatorId.lastIndexOf("::");
+            int separatorIndex = indicatorId.lastIndexOf(PxwebConfig.ID_SEPARATOR);
             if(separatorIndex == -1) {
                 throw new ServiceRuntimeException("Unidentified indicator id: " + indicatorId);
             }

--- a/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/parser/PxwebIndicatorsParser.java
+++ b/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/parser/PxwebIndicatorsParser.java
@@ -217,7 +217,7 @@ public class PxwebIndicatorsParser {
     }
 
     private String createIndicatorId(PxTableItem table, String item) {
-        return createIndicatorId(table) + "::" + item;
+        return createIndicatorId(table) + PxwebConfig.ID_SEPARATOR + item;
     }
 
     protected StatisticalIndicatorDataModel getModel(PxTableItem table) {

--- a/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/parser/PxwebIndicatorsParser.java
+++ b/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/parser/PxwebIndicatorsParser.java
@@ -46,7 +46,7 @@ public class PxwebIndicatorsParser {
             // No id for indicator, assume the service has a separate indicator key config.
             indicatorList = parsePxFileToMultipleIndicators(path, languages);
         } else {
-            indicatorList = parseStructuredService(null, languages);
+            indicatorList = parseStructuredService(path, languages);
         }
         setupLayers(indicatorList, layers, url);
         return indicatorList;
@@ -75,11 +75,12 @@ public class PxwebIndicatorsParser {
             languages.forEach(lang -> {
                 try {
                     PxTableItem table = getPxTable(path, lang, item.id);
-                    StatisticalIndicator ind = indicatorMap.get(item.id);
+                    String indicatorId = createIndicatorId(table);
+                    StatisticalIndicator ind = indicatorMap.get(indicatorId);
                     if (ind == null) {
                         ind = new StatisticalIndicator();
-                        ind.setId(item.id);
-                        indicatorMap.put(item.id, ind);
+                        ind.setId(indicatorId);
+                        indicatorMap.put(indicatorId, ind);
                         indicators.add(ind);
                     }
                     ind.addName(lang, item.text);
@@ -195,7 +196,7 @@ public class PxwebIndicatorsParser {
         }
         for(IdNamePair item: indicatorList.getLabels()) {
             StatisticalIndicator indicator = new StatisticalIndicator();
-            indicator.setId(table.getId() + "::" + item.getKey());
+            indicator.setId(createIndicatorId(table, item.getKey()));
             indicator.addName(lang, item.getValue());
             indicator.addDescription(lang, table.getTitle());
             indicator.setDataModel(selectors);
@@ -203,6 +204,20 @@ public class PxwebIndicatorsParser {
         }
 
         return list;
+    }
+
+    private String createIndicatorId(PxTableItem table) {
+        if (table.getPath() != null) {
+            if (table.getPath().endsWith(".px")) {
+                return table.getPath();
+            }
+            return table.getPath() + "/" + table.getId();
+        }
+        return table.getId();
+    }
+
+    private String createIndicatorId(PxTableItem table, String item) {
+        return createIndicatorId(table) + "::" + item;
     }
 
     protected StatisticalIndicatorDataModel getModel(PxTableItem table) {

--- a/service-statistics-pxweb/src/test/resources/fi/nls/oskari/control/statistics/plugins/pxweb/parser/config2folderstruct_hki_live.json
+++ b/service-statistics-pxweb/src/test/resources/fi/nls/oskari/control/statistics/plugins/pxweb/parser/config2folderstruct_hki_live.json
@@ -1,0 +1,7 @@
+{
+  "url": "http://api.aluesarjat.fi/PXWeb/api/v1/fi/Helsingin%20seudun%20tilastot/P%C3%A4%C3%A4kaupunkiseutu%20alueittain",
+  "info": {
+    "url": "http://api.aluesarjat.fi"
+  },
+  "regionKey": "Alue"
+}

--- a/service-statistics-pxweb/src/test/resources/fi/nls/oskari/control/statistics/plugins/pxweb/parser/config2folderstruct_luke.json
+++ b/service-statistics-pxweb/src/test/resources/fi/nls/oskari/control/statistics/plugins/pxweb/parser/config2folderstruct_luke.json
@@ -1,0 +1,8 @@
+{
+  "url": "https://statdb.luke.fi/pxweb/api/v1/fi/LUKE/02%20Maatalous/02%20Rakenne",
+  "info": {
+    "url": "https://stat.luke.fi/"
+  },
+  "regionKey": "ELY-keskus",
+  "indicatorKey": "Muuttuja"
+}

--- a/service-statistics-pxweb/src/test/resources/fi/nls/oskari/control/statistics/plugins/pxweb/parser/config2folderstruct_tk_indicator_key.json
+++ b/service-statistics-pxweb/src/test/resources/fi/nls/oskari/control/statistics/plugins/pxweb/parser/config2folderstruct_tk_indicator_key.json
@@ -1,9 +1,10 @@
 {
-  "url": "https://pxnet2.stat.fi/pxweb/api/v1/{language}/Kuntien_avainluvut/2019/",
+  "url": "https://pxnet2.stat.fi/pxweb/api/v1/{language}/Kuntien_avainluvut/2019/kuntien_avainluvut_2019_aikasarja.px",
   "info": {
     "url": "http://www.tilastokeskus.fi"
   },
   "regionKey": "Alue 2019",
+  "indicatorKey": "Tiedot",
   "hints": {
     "dimensions": [
       {


### PR DESCRIPTION
Fixes an issue where PXWeb baseurl wasn't a full path to the px-file. The path in the middle was lost when crawling through the API to deep structures. Now it's saved as part of the indicator id.