### PR TITLE
Pxweb-crawling improvements

### DIFF
--- a/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/data/StatisticalIndicatorDataModel.java
+++ b/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/data/StatisticalIndicatorDataModel.java
@@ -15,6 +15,7 @@ public class StatisticalIndicatorDataModel {
      * The dimensions have a defined order.
      */
     private List<StatisticalIndicatorDataDimension> dimensions = new ArrayList<>();
+    private boolean hasRegionInfo = false;
 
     // this is the id of the dimension that re-presents time -> enables time-series analyzes
     private String timeVariable;
@@ -48,6 +49,16 @@ public class StatisticalIndicatorDataModel {
     @Override
     public String toString() {
         return "{" + String.valueOf(dimensions) + "}";
+    }
+
+    @JsonIgnore
+    public void setHasRegionInfo(boolean hasRegionInfo) {
+        this.hasRegionInfo = hasRegionInfo;
+    }
+
+    @JsonIgnore
+    public boolean isHasRegionInfo() {
+        return hasRegionInfo;
     }
 
     @JsonIgnore

--- a/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/PxwebStatisticalDatasourcePlugin.java
+++ b/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/PxwebStatisticalDatasourcePlugin.java
@@ -33,12 +33,18 @@ public class PxwebStatisticalDatasourcePlugin extends StatisticalDatasourcePlugi
     @Override
     public void update() {
         List<StatisticalIndicator> indicators = indicatorsParser.parse(getSource().getLayers());
+        int skippedIndicators = 0;
         for (StatisticalIndicator ind : indicators) {
             if(!ind.getDataModel().isHasRegionInfo()) {
                 // skip indicators without region info
+                skippedIndicators++;
                 continue;
             }
             onIndicatorProcessed(ind);
+        }
+        if (skippedIndicators > 0) {
+            LOG.info("Updated datasource:", config.getUrl(), "with", skippedIndicators,
+                    "of", indicators.size(), "indicators skipped for not having region info.");
         }
     }
 

--- a/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/PxwebStatisticalDatasourcePlugin.java
+++ b/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/PxwebStatisticalDatasourcePlugin.java
@@ -34,6 +34,10 @@ public class PxwebStatisticalDatasourcePlugin extends StatisticalDatasourcePlugi
     public void update() {
         List<StatisticalIndicator> indicators = indicatorsParser.parse(getSource().getLayers());
         for (StatisticalIndicator ind : indicators) {
+            if(!ind.getDataModel().isHasRegionInfo()) {
+                // skip indicators without region info
+                continue;
+            }
             onIndicatorProcessed(ind);
         }
     }

--- a/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/parser/PxwebIndicatorsParser.java
+++ b/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/parser/PxwebIndicatorsParser.java
@@ -225,10 +225,10 @@ public class PxwebIndicatorsParser {
         final StatisticalIndicatorDataModel selectors = new StatisticalIndicatorDataModel();
         selectors.setTimeVariable(config.getTimeVariableId());
         for (VariablesItem item: table.getSelectors()) {
+            if(item.getCode().equals(config.getRegionKey())) {
+                selectors.setHasRegionInfo(true);
+            }
             if(config.getIgnoredVariables().contains(item.getCode())) {
-                if(item.getCode().equals(config.getRegionKey())) {
-                    selectors.setHasRegionInfo(true);
-                }
                 continue;
             }
             StatisticalIndicatorDataDimension selector = new StatisticalIndicatorDataDimension(item.getCode());
@@ -266,7 +266,8 @@ public class PxwebIndicatorsParser {
     }
 
     protected String loadUrl(String url) throws IOException {
-        return IOHelper.getURL(url);
+        // make sure there's no spaces
+        return IOHelper.getURL(url.replaceAll(" ", "%20"));
     }
 
     private Collection<String> getLanguages() {

--- a/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/parser/PxwebIndicatorsParser.java
+++ b/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/parser/PxwebIndicatorsParser.java
@@ -41,7 +41,7 @@ public class PxwebIndicatorsParser {
         final String url = getUrl(path);
 
         Collection<String> languages = getLanguages();
-        List<StatisticalIndicator> indicatorList = null;
+        List<StatisticalIndicator> indicatorList;
         if(url.endsWith(".px")) {
             // No id for indicator, assume the service has a separate indicator key config.
             indicatorList = parsePxFileToMultipleIndicators(path, languages);
@@ -226,6 +226,9 @@ public class PxwebIndicatorsParser {
         selectors.setTimeVariable(config.getTimeVariableId());
         for (VariablesItem item: table.getSelectors()) {
             if(config.getIgnoredVariables().contains(item.getCode())) {
+                if(item.getCode().equals(config.getRegionKey())) {
+                    selectors.setHasRegionInfo(true);
+                }
                 continue;
             }
             StatisticalIndicatorDataDimension selector = new StatisticalIndicatorDataDimension(item.getCode());


### PR DESCRIPTION
- Skip indicators that don't have the region key as variable (can't be shown on map).
- Make sure to encode spaces in urls while crawling.