### PR TITLE
SaveLayerHandler edit layer permission

### DIFF
--- a/content-resources/src/main/java/flyway/oskari/V1_54_2__remove_edit_layer_permissions.java
+++ b/content-resources/src/main/java/flyway/oskari/V1_54_2__remove_edit_layer_permissions.java
@@ -1,0 +1,26 @@
+package flyway.oskari;
+
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.util.PropertyUtil;
+import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+
+public class V1_54_2__remove_edit_layer_permissions  implements JdbcMigration {
+    private static final Logger LOG = LogFactory.getLogger(V1_54_2__remove_edit_layer_permissions.class);
+
+    public void migrate(Connection conn) throws Exception {
+        if(PropertyUtil.getOptional("flyway.1_54_2.skip", false)) {
+            LOG.warn("You are skipping remove edit layer permissions migration.",
+                    "Note that Admin has always edit layer permission.",
+                    "Only reason to skip this is if you are using separate role for layer editing");
+            return;
+        }
+        final String sql = "DELETE FROM oskari_permission WHERE permission = 'EDIT_LAYER'";
+        try(PreparedStatement statement = conn.prepareStatement(sql)) {
+            statement.execute();
+        }
+    }
+}

--- a/control-base/src/main/java/fi/nls/oskari/control/layer/SaveLayerHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/SaveLayerHandler.java
@@ -672,7 +672,7 @@ public class SaveLayerHandler extends AbstractLayerAdminHandler {
     }
 
     private void addPermissionsForRoles(final OskariLayer ml,
-                                        final Set<Integer> externalIds,
+                                        final Set<Integer> viewRoleIds,
                                         final Set<Integer> publishRoleIds,
                                         final Set<Integer> downloadRoleIds,
                                         final Set<Integer> viewEmbeddedRoleIds) {
@@ -680,16 +680,11 @@ public class SaveLayerHandler extends AbstractLayerAdminHandler {
         res.setType(ResourceType.maplayer);
         res.setMapping(Integer.toString(ml.getId()));
         // insert permissions
-        LOG.debug("Adding permission", PermissionType.VIEW_LAYER, "for roles:", externalIds);
-        for (int externalId : externalIds) {
+        LOG.debug("Adding permission", PermissionType.VIEW_LAYER, "for roles:", viewRoleIds);
+        for (int externalId : viewRoleIds) {
             Permission permission = new Permission();
             permission.setRoleId(externalId);
             permission.setType(PermissionType.VIEW_LAYER);
-            res.addPermission(permission);
-
-            permission = new Permission();
-            permission.setRoleId(externalId);
-            permission.setType(PermissionType.EDIT_LAYER);
             res.addPermission(permission);
         }
 


### PR DESCRIPTION
Edit layer permission isn't needed to store to db. Added flyway to clean unused permissions.