### PR TITLE
Allow session storing in Redis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,10 +49,8 @@
         <fi.nls.oskari.service.version>${project.version}</fi.nls.oskari.service.version>
 
         <spring.version>4.3.25.RELEASE</spring.version>
-        <!-- saml 1.0.3.RELEASE uses security 4.2.5, check saml-extension for upgrades before updating security
-            Tested with 4.2.6.
-        -->
         <spring-security.version>4.2.13.RELEASE</spring-security.version>
+        <spring.session.version>1.3.5.RELEASE</spring.session.version>
 
         <javax.servlet.version>3.1.0</javax.servlet.version>
         <javax.servlet.jsp.version>2.0</javax.servlet.jsp.version>
@@ -499,10 +497,10 @@
                 </exclusions>
             </dependency>
             <dependency>
-								<groupId>org.springframework.security</groupId>
-								<artifactId>spring-security-core</artifactId>
-								<version>${spring-security.version}</version>
-								<exclusions>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-core</artifactId>
+                <version>${spring-security.version}</version>
+                <exclusions>
                     <!-- exclude aopalliance
                     Reason: Same classes are included in spring-aop (causing conflict if we have both)
                     -->
@@ -511,7 +509,17 @@
                         <artifactId>aopalliance</artifactId>
                     </exclusion>
                 </exclusions>
-						</dependency>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.session</groupId>
+                <artifactId>spring-session</artifactId>
+                <version>${spring.session.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.session</groupId>
+                <artifactId>spring-session-data-redis</artifactId>
+                <version>${spring.session.version}</version>
+            </dependency>
             <dependency>
                 <groupId>xerces</groupId>
                 <artifactId>xercesImpl</artifactId>

--- a/servlet-map/pom.xml
+++ b/servlet-map/pom.xml
@@ -49,6 +49,14 @@
             <artifactId>spring-security-config</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.session</groupId>
+            <artifactId>spring-session</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.session</groupId>
+            <artifactId>spring-session-data-redis</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
         </dependency>

--- a/servlet-map/src/main/java/fi/nls/oskari/spring/session/RedisSessionConfig.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/spring/session/RedisSessionConfig.java
@@ -1,0 +1,30 @@
+package fi.nls.oskari.spring.session;
+
+import fi.nls.oskari.util.PropertyUtil;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.session.data.redis.RedisFlushMode;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
+import org.springframework.session.web.http.CookieSerializer;
+import org.springframework.session.web.http.DefaultCookieSerializer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+
+// TODO: Check if maxInactiveIntervalInSeconds can be configured
+@Configuration
+@Profile(RedisSessionConfig.PROFILE)
+@EnableRedisHttpSession(maxInactiveIntervalInSeconds=7200)
+public class RedisSessionConfig extends WebMvcConfigurerAdapter {
+
+    public static final String PROFILE ="redis-session";
+
+    @Bean
+    public JedisConnectionFactory connectionFactory() {
+        JedisConnectionFactory jedis = new JedisConnectionFactory();
+        jedis.setHostName(PropertyUtil.get("redis.hostname", "127.0.0.1"));
+        jedis.setPort(PropertyUtil.getOptional("redis.port", 6379));
+        jedis.setUsePool(true);
+        return jedis;
+    }
+}


### PR DESCRIPTION
Enables clustering and server restarts without sessions dying.

By default the servlet container handles sessions as before (Jetty/Tomcat) but by adding `redis-session` as profile on oskari-ext.properties the sessions are handled by Spring and saved to Redis.

    oskari.profiles=[other, profiles,] redis-session