### PR TITLE
Enable app health checks

### DIFF
--- a/service-base/src/main/java/org/oskari/status/AppStatus.java
+++ b/service-base/src/main/java/org/oskari/status/AppStatus.java
@@ -1,0 +1,76 @@
+package org.oskari.status;
+
+import fi.nls.oskari.service.OskariComponent;
+
+/**
+ * Get status with:
+ *   OskariComponentManager.getComponentsOfType(AppStatus.class)
+ *
+ * Usage example:
+ boolean highSeverityChecksOk = getChecks().stream()
+ .filter(s -> s.isEnabled())
+ .filter(s -> s.getSeverity() == AppStatus.Severity.HIGH)
+ .allMatch(s -> s.isOk());
+ */
+public abstract class AppStatus extends OskariComponent {
+
+    public enum Severity {
+        // allow app to keep running
+        LOW,
+        // app should stop responding if this is not OK
+        HIGH
+    };
+
+    public enum Level {
+        // all good
+        OK,
+        // parts of the feature is working while others are not
+        PARTIAL,
+        // not working at all
+        BROKEN
+    };
+
+    /**
+     * Name for the check that could be shown in a status monitor
+     * @return
+     */
+    public String getName() {
+        return this.getClass().getName();
+    }
+
+    public boolean isEnabled() {
+        return true;
+    }
+    /**
+     * Describe what is being checked
+     * @return
+     */
+    public String getDescription() {
+        return "";
+    }
+
+    /**
+     * Provide reason for check failing
+     * @return
+     */
+    public String getReason() {
+        return "";
+    }
+
+    /**
+     * LOW if the app can run even without this feature working
+     * HIGH if the app should be stopped when this functionality is not working
+     * @return
+     */
+    public abstract Severity getSeverity();
+
+    /**
+     * Level of functionality: ok, partial, broken == not working
+     * @return
+     */
+    public abstract Level getLevel();
+
+    public boolean isOk() {
+        return Level.OK.equals(getLevel());
+    }
+}

--- a/service-base/src/main/java/org/oskari/status/ForceDisableByFile.java
+++ b/service-base/src/main/java/org/oskari/status/ForceDisableByFile.java
@@ -1,0 +1,54 @@
+package org.oskari.status;
+
+import fi.nls.oskari.annotation.Oskari;
+import fi.nls.oskari.service.OskariComponent;
+import fi.nls.oskari.util.PropertyUtil;
+
+import java.io.File;
+
+@Oskari
+public class ForceDisableByFile extends AppStatus {
+
+    private String fileToCheck;
+
+    public void init() {
+        fileToCheck = PropertyUtil.get("disablefile.path", null);
+    }
+
+    public boolean isEnabled() {
+        return fileToCheck != null;
+    }
+
+    /**
+     * File found -> app should be disabled
+     * not found -> OK
+     * @return
+     */
+    public Level getLevel() {
+        File status = new File(fileToCheck);
+        if(status.exists()) {
+            return Level.BROKEN;
+        }
+        return Level.OK;
+    }
+
+    public String getDescription() {
+        return "Checks if file '" + fileToCheck + "' exists.";
+    }
+
+    /**
+     * Provide reason for check failing
+     * @return
+     */
+    public String getReason() {
+        return fileToCheck + " file exists";
+    }
+
+    /**
+     * This is a manual check for file. If it exists -> the app should be stopped
+     * @return
+     */
+    public Severity getSeverity() {
+        return Severity.HIGH;
+    }
+}

--- a/servlet-map/src/main/java/fi/nls/oskari/ForceDisableByFile.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/ForceDisableByFile.java
@@ -1,8 +1,9 @@
-package org.oskari.status;
+package fi.nls.oskari;
 
 import fi.nls.oskari.annotation.Oskari;
 import fi.nls.oskari.service.OskariComponent;
 import fi.nls.oskari.util.PropertyUtil;
+import org.oskari.status.AppStatus;
 
 import java.io.File;
 

--- a/servlet-map/src/main/java/fi/nls/oskari/StatusController.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/StatusController.java
@@ -1,0 +1,45 @@
+package fi.nls.oskari;
+
+import fi.nls.oskari.control.ActionParameters;
+import fi.nls.oskari.service.OskariComponentManager;
+import fi.nls.oskari.spring.extension.OskariParam;
+import org.oskari.status.AppStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+@Controller
+public class StatusController {
+
+    private Collection<AppStatus> getChecks() {
+        Map<String, AppStatus> statuses = OskariComponentManager.getComponentsOfType(AppStatus.class);
+        return statuses.values();
+    }
+
+    @RequestMapping("/health")
+    public ResponseEntity<String> health() {
+        boolean highSeverityChecksOk = getChecks().stream()
+                .filter(s -> s.isEnabled())
+                .filter(s -> s.getSeverity() == AppStatus.Severity.HIGH)
+                .allMatch(s -> s.isOk());
+        if (!highSeverityChecksOk) {
+            return new ResponseEntity<String>("DISABLED", HttpStatus.SERVICE_UNAVAILABLE);
+        }
+        return new ResponseEntity("OK", HttpStatus.OK);
+    }
+
+    @RequestMapping("/status")
+    public Collection<AppStatus> status(@OskariParam ActionParameters params) {
+        if (!params.getUser().isAdmin()) {
+            return null;
+        }
+        return getChecks();
+    }
+
+}

--- a/servlet-map/src/main/java/fi/nls/oskari/StatusController.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/StatusController.java
@@ -9,8 +9,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -35,9 +37,10 @@ public class StatusController {
     }
 
     @RequestMapping("/status")
+    @ResponseBody
     public Collection<AppStatus> status(@OskariParam ActionParameters params) {
         if (!params.getUser().isAdmin()) {
-            return null;
+            return Collections.emptyList();
         }
         return getChecks();
     }

--- a/servlet-map/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/servlet-map/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+fi.nls.oskari.annotation.OskariComponentAnnotationProcessor


### PR DESCRIPTION
- Adds a AppStatus concept as OskariComponent. These can be used to add custom checks on an application to detect if it's working properly or not. 
- One example is provided where you can define a file reference in `oskari-ext.properties` like `disablefile.path=/var/run/oskari-disable`. If the file exists the status indicator will show that the app should be considered to be in a non-healthy state. This can be used to trigger a request routing policy on a front-server/proxy to route requests to another node in the cluster from now on.
- Adds a new controller for paths `/health` and `/status` to Oskari. Health returns either OK or DISABLED based on HIGH-severity status indicators returning OK or not. Status can be used for building a dashboard to show the application status and it only returns meaningful content for admin-users. For example thematic maps might have a status of partially working if there's problems connecting to some datasource but not all of them.

To add more status indicators you can add a class in the classpath extending OskariComponent and annotating it with Oskari (see ForceDisableByFile.java). Note that the Maven module where you add the status class needs to have the annotation processor enabled (META-INF/services/javax.annotation.processing.Processor in this PR).