### PR TITLE
Fix error in SQL-mapping

### DIFF
--- a/service-map/src/main/resources/fi/nls/oskari/map/layer/OskariLayerMapper.xml
+++ b/service-map/src/main/resources/fi/nls/oskari/map/layer/OskariLayerMapper.xml
@@ -183,7 +183,7 @@
 
     </select>
 
-    <select id="findByUuId"
+    <select id="findByUuid"
             parameterType="String"
             resultType="java.util.HashMap">
 


### PR DESCRIPTION
The Mybatis Java mapper interface OskariLayerMapper has a method findByUuid() so there was a mismatch with the SQL id and things like MetadataCatalogueChannelSearchService.getOskariLayerWithUuid() didn't work properly. This fixes the issue.