### PR TITLE
Remove unnecessary logging

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/view/modifier/bundle/MapfullHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/view/modifier/bundle/MapfullHandler.java
@@ -549,16 +549,10 @@ public class MapfullHandler extends BundleHandler {
         if (plugin == null) {
             return;
         }
-        try {
-            JSONObject config = plugin.getJSONObject(KEY_CONFIG);
-            if(config != null && config.has(KEY_CENTER_MAP_AUTOMATICALLY)) {
-                config.remove(KEY_CENTER_MAP_AUTOMATICALLY);
-            }
-        } catch (JSONException jsonex) {
-            LOGGER.error("Problem trying to modify "
-                    + PLUGIN_MYLOCATION + " " + KEY_CENTER_MAP_AUTOMATICALLY + ".", jsonex);
+        JSONObject config = plugin.optJSONObject(KEY_CONFIG);
+        if(config != null && config.has(KEY_CENTER_MAP_AUTOMATICALLY)) {
+            config.remove(KEY_CENTER_MAP_AUTOMATICALLY);
         }
-
     }
 
     private void removePlugin(final String pluginClassName,


### PR DESCRIPTION
If MyLocationPlugin doesn't have a config (it isn't required) each GetAppSetup call writes this in log:
```
2019-12-17 17:28:40,296 ERROR fi.nls.oskari.control.view.modifier.bundle.MapfullHandler - Problem trying to modify Oskari.mapframework.bundle.mapmodule.p
lugin.MyLocationPlugin centerMapAutomatically. org.json.JSONException@1df8266f[                                                                          
  cause=<null>                                                                                                                                           
  detailMessage=JSONObject["config"] not found.                                                                                                          
  cause=org.json.JSONException@1df8266f                                                                                                                  
  stackTrace={}                                                                                                                                          
  suppressedExceptions=[]                                                                                                                                
]                                                                                                                                                        
```

This removes the unnecessary logging.