### PR TITLE
WFS client: remove logic of InvalidParameterValue for outputformat

### DIFF
--- a/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
@@ -76,7 +76,7 @@ public class IOHelper {
     }
 
     /**
-     * Reads the given input stream and converts its contents to a string using #DEFAULT_CHARSET
+     * Reads the InputStream of HttpURLConnection and converts its contents to a string using #DEFAULT_CHARSET
      * @param conn
      * @return
      * @throws IOException
@@ -93,19 +93,19 @@ public class IOHelper {
         return readString(conn, DEFAULT_CHARSET);
     }
     /**
-     * Reads the given input stream and converts its contents to a string using given charset
+     * Reads the InputStream of HttpURLConnection and converts its contents to a string using given charset
      * @param conn connection used to get inputstream and detect gzip encoding
      * @param charset
      * @return
      * @throws IOException
      */
     public static String readString(HttpURLConnection conn, final String charset) throws IOException {
-        if(ENCODING_GZIP.equals(conn.getContentEncoding())) {
-            return readString(new GZIPInputStream(conn.getInputStream()), charset);
+        try (InputStream in = conn.getInputStream()) {
+            try (InputStream inner = isResponseGZIPd(conn) ? new GZIPInputStream(in) : in) {
+                return readString(inner, charset);
+            }
         }
-        return readString(conn.getInputStream(), charset);
     }
-
 
     public static List<String> readLines(InputStream in) throws IOException {
         return readLines(in, StandardCharsets.UTF_8);
@@ -175,17 +175,36 @@ public class IOHelper {
     }
 
     /**
-     * Reads the given input stream and returns its contents as a byte array.
+     * Reads the InputStream of HttpURLConnection to a byte array and returns that
      * @param conn used to get inputstream and detect possible gzip encoding
      * @return
      * @throws IOException
      */
     public static byte[] readBytes(HttpURLConnection conn) throws IOException {
-        if(ENCODING_GZIP.equals(conn.getContentEncoding())) {
-            return readBytes(new GZIPInputStream(conn.getInputStream()));
+        try (InputStream in = conn.getInputStream()) {
+            try (InputStream inner = isResponseGZIPd(conn) ? new GZIPInputStream(in) : in) {
+                return readBytes(inner);
+            }
         }
-        return readBytes(conn.getInputStream());
     }
+
+    /**
+     * Reads the InputStream of HttpURLConnection to given OutputStream
+     * @param conn used to get inputstream and detect possible gzip encoding
+     * @throws IOException
+     */
+    public static void readBytesTo(HttpURLConnection conn, OutputStream out) throws IOException {
+        try (InputStream in = conn.getInputStream()) {
+            try (InputStream inner = isResponseGZIPd(conn) ? new GZIPInputStream(in) : in) {
+                copy(inner, out);
+            }
+        }
+    }
+
+    private static boolean isResponseGZIPd(HttpURLConnection conn) {
+        return ENCODING_GZIP.equals(conn.getContentEncoding());
+    }
+
     /**
      * Reads the given input stream and returns its contents as a byte array.
      * @param is
@@ -1116,14 +1135,6 @@ public class IOHelper {
         return s;
     }
 
-    public static InputStream getInputStream(HttpURLConnection conn) {
-        try {
-            return conn.getInputStream();
-        } catch (IOException e) {
-            return conn.getErrorStream();
-        }
-    }
-
     /**
      * Ignore HttpURLConnection response fully 
      * Useful for example when the status code or the content type
@@ -1131,10 +1142,18 @@ public class IOHelper {
      * pooling method to keep the underlying TCP connection alive 
      */
     public static void closeSilently(HttpURLConnection c) {
-        try (InputStream in = getInputStream(c)) {
+        try (InputStream in = getInputOrErrorStream(c)) {
             readFullyIgnoring(in);
         } catch (IOException ignore) {
             // Ignore
+        }
+    }
+
+    private static InputStream getInputOrErrorStream(HttpURLConnection conn) {
+        try {
+            return conn.getInputStream();
+        } catch (IOException e) {
+            return conn.getErrorStream();
         }
     }
 

--- a/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
@@ -1136,6 +1136,19 @@ public class IOHelper {
     }
 
     /**
+     * Deprecated, misleading name,
+     * use getInputOrErrorStream(HttpURLConnection) instead
+     */
+    @Deprecated
+    public static InputStream getInputStream(HttpURLConnection conn) {
+        try {
+            return conn.getInputStream();
+        } catch (IOException e) {
+            return conn.getErrorStream();
+        }
+    }
+
+    /**
      * Ignore HttpURLConnection response fully 
      * Useful for example when the status code or the content type
      * wasn't what was expected. Allows HttpURLConnection

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariGML.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariGML.java
@@ -34,7 +34,7 @@ import net.opengis.wfs.FeatureCollectionType;
  * SimpleFeatureCollection simpleFeatureCollection(Collection<?>
  * are marked private in the GML class, so they are copy-pasted over
  */
-public class OskariGML extends GML {
+public class OskariGML extends GML implements OskariGMLDecoder {
 
     public OskariGML() {
         super(Version.WFS1_1);

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariGML32.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariGML32.java
@@ -18,7 +18,7 @@ import org.xml.sax.SAXException;
 import fi.nls.oskari.util.XmlHelper;
 import net.opengis.wfs20.FeatureCollectionType;
 
-public class OskariGML32 {
+public class OskariGML32 implements OskariGMLDecoder {
 
     public SimpleFeatureCollection decodeFeatureCollection(InputStream in, String username, String password)
             throws IOException, SAXException, ParserConfigurationException {

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariGMLDecoder.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariGMLDecoder.java
@@ -1,0 +1,15 @@
+package org.oskari.service.wfs.client;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.xml.sax.SAXException;
+
+public interface OskariGMLDecoder {
+
+    public SimpleFeatureCollection decodeFeatureCollection(InputStream in, String username, String password) throws IOException, SAXException, ParserConfigurationException;
+
+}

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS110Client.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS110Client.java
@@ -1,11 +1,6 @@
 package org.oskari.service.wfs.client;
 
-import java.io.BufferedInputStream;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.HttpURLConnection;
-import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -16,24 +11,20 @@ import org.opengis.filter.Filter;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 import fi.nls.oskari.domain.map.OskariLayer;
-import fi.nls.oskari.log.LogFactory;
-import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.service.ServiceRuntimeException;
-import fi.nls.oskari.util.IOHelper;
 
 /**
  * Client code for WFS 1.1.0 services
  */
 public class OskariWFS110Client {
 
-    private static final Logger LOG = LogFactory.getLogger(OskariWFS110Client.class);
-
     private static final OskariGML OSKARI_GML = new OskariGML();
 
     private OskariWFS110Client() {}
 
     /**
-     * @return SimpleFeatureCollection containing the parsed Features, or null if all fails
+     * @return SimpleFeatureCollection containing the parsed Features
+     * @throws ServiceRuntimeException if everything fails
      */
     public static SimpleFeatureCollection getFeatures(OskariLayer layer,
             ReferencedEnvelope bbox, CoordinateReferenceSystem crs, Filter filter) {
@@ -41,62 +32,10 @@ public class OskariWFS110Client {
         String typeName = layer.getName();
         String user = layer.getUsername();
         String pass = layer.getPassword();
-
+        boolean tryGeoJSON = OskariWFSClient.tryGeoJSON(layer);
         int maxFeatures = OskariWFSClient.getMaxFeatures(layer);
         Map<String, String> query = getQueryParams(typeName, bbox, crs, maxFeatures, filter);
-        byte[] response;
-        if (OskariWFSClient.tryGeoJSON(layer)) {
-            // First try GeoJSON
-            query.put("OUTPUTFORMAT", "application/json");
-            response = OskariWFSClient.getResponse(endPoint, user, pass, query);
-            try {
-                return OskariWFSClient.parseGeoJSON(new ByteArrayInputStream(response), crs);
-            } catch (IOException e) {
-                if (!OskariWFSClient.isOutputFormatInvalid(new ByteArrayInputStream(response))) {
-                    // If we can not determine that the exception was due to bad
-                    // outputFormat parameter then don't bother trying GML
-                    final String url = IOHelper.constructUrl(endPoint, query);
-                    LOG.debug("Response from", url, "was:\n", new String(response, StandardCharsets.UTF_8));
-                    throw new ServiceRuntimeException("Unable to parse GeoJSON from " + url, e);
-                }
-            }
-        }
-        // Fallback to GML
-        query.remove("OUTPUTFORMAT");
-        response = OskariWFSClient.getResponse(endPoint, user, pass, query);
-
-        try {
-            return OSKARI_GML.decodeFeatureCollection(new ByteArrayInputStream(response), user, pass);
-        } catch (Exception e) {
-            final String url = IOHelper.constructUrl(endPoint, query);
-            LOG.debug("Response from", url, "was:\n", new String(response, StandardCharsets.UTF_8));
-            throw new ServiceRuntimeException("Unable to parse GML from " + url, e);
-        }
-    }
-
-    public static SimpleFeatureCollection getFeaturesGeoJSON(String endPoint, String user, String pass,
-            String typeName, ReferencedEnvelope bbox, CoordinateReferenceSystem crs,
-            int maxFeatures, Filter filter) throws IOException {
-        Map<String, String> query = getQueryParams(typeName, bbox, crs, maxFeatures, filter);
-        query.put("OUTPUTFORMAT", "application/json");
-        HttpURLConnection conn = OskariWFSClient.getConnection(endPoint, user, pass, query);
-        String contentType = conn.getContentType();
-        if (contentType != null && !contentType.contains("json")) {
-            throw new ServiceRuntimeException("Unexpected content type " + contentType);
-        }
-        try (InputStream in = new BufferedInputStream(conn.getInputStream())) {
-            return OskariWFSClient.parseGeoJSON(in, crs);
-        }
-    }
-
-    public static SimpleFeatureCollection getFeaturesGML(String endPoint, String user, String pass,
-            String typeName, ReferencedEnvelope bbox, CoordinateReferenceSystem crs,
-            int maxFeatures, Filter filter) throws Exception {
-        Map<String, String> query = getQueryParams(typeName, bbox, crs, maxFeatures, filter);
-        HttpURLConnection conn = OskariWFSClient.getConnection(endPoint, user, pass, query);
-        try (InputStream in = new BufferedInputStream(conn.getInputStream())) {
-            return OSKARI_GML.decodeFeatureCollection(in, user, pass);
-        }
+        return OskariWFSClient.getFeatures(endPoint, user, pass, query, crs, tryGeoJSON, OSKARI_GML);
     }
 
     protected static Map<String, String> getQueryParams(String typeName, ReferencedEnvelope bbox,

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFSClient.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFSClient.java
@@ -89,9 +89,11 @@ public class OskariWFSClient {
             // Try to parse the same response as GML
             fc = parseGML(response, crs, url, user, pass, gmlDecoder);
             if (fc != null) {
+                LOG.info("Requested JSON but got GML. Possibly misconfigured service for", url);
                 return fc;
             }
             // Okay I guess it wasn't a GML FeatureCollection either - move on
+            LOG.info("Requested JSON but didn't get a parseable result. Possibly misconfigured service for", url);
         }
 
         // Fallback to to requesting GML

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFSClient.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFSClient.java
@@ -19,9 +19,13 @@ import fi.nls.oskari.service.ServiceRuntimeException;
 import org.oskari.geojson.GeoJSONReader2;
 import org.oskari.geojson.GeoJSONSchemaDetector;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -61,17 +65,63 @@ public class OskariWFSClient {
                 srsName);
     }
 
-    protected static byte[] getResponse(String endPoint,
-                                        String user, String pass, Map<String, String> query) {
+    protected static SimpleFeatureCollection getFeatures(String endPoint,
+            String user, String pass, Map<String, String> query,
+            CoordinateReferenceSystem crs, boolean tryGeoJSON, OskariGMLDecoder gmlDecoder) {
+        String url; // for debugging
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        byte[] response;
+        Map<String, String> responseHeaders;
+        SimpleFeatureCollection fc;
+
+        if (tryGeoJSON) {
+            // First try GeoJSON
+            query.put("OUTPUTFORMAT", "application/json");
+            url = IOHelper.constructUrl(endPoint, query);
+            responseHeaders = OskariWFSClient.readResponseTo(endPoint, user, pass, query, baos);
+            response = baos.toByteArray();
+            // TODO: Select parsing algorithm based on response headers (Content-Type)
+            fc = parseGeoJSON(response, crs, url);
+            if (fc != null) {
+                return fc;
+            }
+            // Try to parse the same response as GML
+            fc = parseGML(response, crs, url, user, pass, gmlDecoder);
+            if (fc != null) {
+                return fc;
+            }
+            // Okay I guess it wasn't a GML FeatureCollection either - move on
+        }
+
+        // Fallback to to requesting GML
+        query.remove("OUTPUTFORMAT");
+        url = IOHelper.constructUrl(endPoint, query);
+        baos.reset();
+        responseHeaders = OskariWFSClient.readResponseTo(endPoint, user, pass, query, baos);
+        response = baos.toByteArray();
+        fc = parseGML(response, crs, url, user, pass, gmlDecoder);
+        if (fc != null) {
+            return fc;
+        }
+
+        throw new ServiceRuntimeException("Failed to get features");
+    }
+
+    private static Map<String, String> readResponseTo(String endPoint,
+            String user, String pass, Map<String, String> query, OutputStream out) {
         try {
             HttpURLConnection conn = getConnection(endPoint, user, pass, query);
-            return IOHelper.readBytes(conn);
+            Map<String, String> responseHeaders = new HashMap<>();
+            conn.getHeaderFields().forEach((k, v) -> responseHeaders.put(k, v.get(0)));
+            IOHelper.readBytesTo(conn, out);
+            return responseHeaders;
         } catch (IOException e) {
             throw new ServiceRuntimeException("Unable to read response", e);
         }
     }
 
-    protected static HttpURLConnection getConnection(String endPoint,
+    private static HttpURLConnection getConnection(String endPoint,
                                                      String user, String pass, Map<String, String> query) throws IOException {
         HttpURLConnection conn = IOHelper.getConnection(endPoint, user, pass, query);
         conn = IOHelper.followRedirect(conn, user, pass, query, MAX_REDIRECTS);
@@ -82,13 +132,30 @@ public class OskariWFSClient {
         return conn;
     }
 
-    protected static SimpleFeatureCollection parseGeoJSON(InputStream in,
-                                                        CoordinateReferenceSystem crs) throws IOException {
-        Map<String, Object> geojson = OM.readValue(in, TYPE_REF);
-        boolean ignoreGeometryProperties = true;
-        SimpleFeatureType schema = GeoJSONSchemaDetector.getSchema(geojson, crs, ignoreGeometryProperties);
-        return GeoJSONReader2.toFeatureCollection(geojson, schema);
+    private static SimpleFeatureCollection parseGeoJSON(byte[] response, CoordinateReferenceSystem crs, String url) {
+        try {
+            InputStream in = new ByteArrayInputStream(response);
+            Map<String, Object> geojson = OM.readValue(in, TYPE_REF);
+            boolean ignoreGeometryProperties = true;
+            SimpleFeatureType schema = GeoJSONSchemaDetector.getSchema(geojson, crs, ignoreGeometryProperties);
+            return GeoJSONReader2.toFeatureCollection(geojson, schema);
+        } catch (Exception e) {
+            LOG.info(e, "Unable to parse GeoJSON from", url);
+            LOG.debug("Response from", url, "was:\n", new String(response, StandardCharsets.UTF_8));
+            return null;
+        }
     }
+
+    private static SimpleFeatureCollection parseGML(byte[] response, CoordinateReferenceSystem crs, String url, String user, String pass, OskariGMLDecoder gmlDecoder) {
+        try {
+            return gmlDecoder.decodeFeatureCollection(new ByteArrayInputStream(response), user, pass);
+        } catch (Exception e) {
+            LOG.info(e, "Unable to parse GML from", url);
+            LOG.debug("Response from", url, "was:\n", new String(response, StandardCharsets.UTF_8));
+            return null;
+        }
+    }
+
     protected static boolean tryGeoJSON (OskariLayer layer) {
         if(layer.getAttributes().optBoolean(PROPERTY_FORCE_GML, false)) return false;
 

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFSClient.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFSClient.java
@@ -93,7 +93,7 @@ public class OskariWFSClient {
                 return fc;
             }
             // Okay I guess it wasn't a GML FeatureCollection either - move on
-            LOG.info("Requested JSON but didn't get a parseable result. Possibly misconfigured service for", url);
+            LOG.warn("Requested JSON but didn't get a parseable result. Making a new request for GML. Possibly misconfigured service for", url);
         }
 
         // Fallback to to requesting GML

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFSClient.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFSClient.java
@@ -170,38 +170,4 @@ public class OskariWFSClient {
         return layer.getCapabilities().optInt(KEY_MAX_FEATURES, DEFAULT_MAX_FEATURES);
     }
 
-    protected static boolean isOutputFormatInvalid(InputStream in) {
-        try {
-            OWSException ex = OWSExceptionReportParser.parse(in);
-            return isExceptionDueToInvalidOutputFormat(ex);
-        } catch (Exception e) {
-            LOG.debug(e);
-            return false;
-        }
-    }
-
-    /**
-     * We might get:
-     * <ows:ExceptionReport xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ows="http://www.opengis.net/ows" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ows http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd" version="1.1.0">
-     * <ows:Exception exceptionCode="InvalidParameterValue" locator="Unknown">
-     * <ows:ExceptionText>
-     * <![CDATA[ OutputFormat 'application/json' not supported. ]]>
-     * </ows:ExceptionText>
-     * </ows:Exception>
-     * </ows:ExceptionReport>
-     * @param ex
-     * @return
-     */
-    protected static boolean isExceptionDueToInvalidOutputFormat(OWSException ex) {
-        if (ex.getExceptionCode().equalsIgnoreCase("InvalidParameterValue")) {
-            if (EXC_HANDLING_OUTPUTFORMAT.equalsIgnoreCase(ex.getLocator())) {
-                return true;
-            }
-            if (ex.getExceptionText() != null &&
-                    ex.getExceptionText().toLowerCase().contains(EXC_HANDLING_OUTPUTFORMAT)) {
-                return true;
-            }
-        }
-        return false;
-    }
 }


### PR DESCRIPTION
Many servers just ignore the invalid parameter and respond with GML anyways when requesting GeoJSON. Remove the code that checks if GeoJSON parsing failed because it was an OWSException stating that the specified value for outputformat parameter was invalid.

Also some refactoring.