### PR TITLE
Remove unneeded dependencies

### DIFF
--- a/service-search-opendata/pom.xml
+++ b/service-search-opendata/pom.xml
@@ -15,29 +15,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>fi.nls.oskari.service</groupId>
-			<artifactId>oskari-map</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>fi.nls.oskari.service</groupId>
-			<artifactId>oskari-search</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>fi.nls.oskari.service</groupId>
 			<artifactId>oskari-control-base</artifactId>
-		</dependency>
-       <dependency>
-			<groupId>org.geotools</groupId>
-			<artifactId>gt-epsg-hsql</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
-			<version>${log4j.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-			<version>${log4j.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>fi.nls.oskari</groupId>


### PR DESCRIPTION
Probably copy-pasted from another module. Log4J was the actual reason for the change as it shouldn't be referenced here at all because abstraction (ref in service-logging).