### PR TITLE
Improve exception and http status code handling at capabilities fetching 

### DIFF
--- a/service-base/src/main/java/fi/nls/oskari/service/ServiceUnauthorizedException.java
+++ b/service-base/src/main/java/fi/nls/oskari/service/ServiceUnauthorizedException.java
@@ -1,0 +1,14 @@
+package fi.nls.oskari.service;
+
+public class ServiceUnauthorizedException extends ServiceException {
+	
+	private static final long serialVersionUID = 2323366761769429030L;
+
+	public ServiceUnauthorizedException(final String message, final Exception e) {
+        super(message, e);
+    }
+
+    public ServiceUnauthorizedException(final String message) {
+        super(message);
+    }
+}

--- a/servlet-map/src/main/java/fi/nls/oskari/AjaxController.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/AjaxController.java
@@ -80,26 +80,8 @@ public class AjaxController {
                     .withMsg(error.getMessage())
                     .errored(AuditLog.ResourceType.GENERIC);
             
-            if (isServiceUnauthrorizedException(e)) {
-            	ResponseHelper.writeError(params, e.getMessage(), HttpServletResponse.SC_UNAUTHORIZED);
-            } else {
-            	ResponseHelper.writeError(params, e.getMessage());
-            }
-            
+           
+            ResponseHelper.writeError(params, e.getMessage());
         } 
-    }
-    
-    private boolean isServiceUnauthrorizedException(Throwable t) {
-    	return getRootCause(t) instanceof ServiceUnauthorizedException;
-    }
-    
-    private Throwable getRootCause(Throwable e) {
-        Throwable cause = null;
-        Throwable result = e;
-
-        while(null != (cause = result.getCause())  && (result != cause) ) {
-            result = cause;
-        }
-        return result;
     }
 }


### PR DESCRIPTION
This pull request contains logic to return HTTP status code 401 to frontend when exception indicating error with HTTP status code 401 or 403 is thrown from org.geotools.data.DataStoreFinder.getDataStore() at capabilities fetching. 