### PR TITLE
Layer fetch

### DIFF
--- a/content-resources/src/main/java/fi/nls/oskari/db/LayerHelper.java
+++ b/content-resources/src/main/java/fi/nls/oskari/db/LayerHelper.java
@@ -37,6 +37,7 @@ public class LayerHelper {
             // layer doesn't exist, insert it
             final OskariLayer oskariLayer = LayerAdminJSONHelper.fromJSON(layer);
             int id = layerService.insert(oskariLayer);
+            // TODO: add info from capabilities?
             MapLayerPermissionsHelper.setLayerPermissions(id, layer.getRole_permissions());
 
             if (layer.getGroups() != null) {

--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/AbstractLayerAdminHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/AbstractLayerAdminHandler.java
@@ -71,14 +71,14 @@ public abstract class AbstractLayerAdminHandler extends RestActionHandler {
         return (int) role.getId();
 
     }
-    protected Map<Role, List<String>> getPermissionsGroupByRole (User user, OskariLayer layer) throws ServiceException {
-        Map<Role, List<String>> permissions = new HashMap<>();
+    protected Map<Role, Set<String>> getPermissionsGroupByRole (User user, OskariLayer layer) throws ServiceException {
+        Map<Role, Set<String>> permissions = new HashMap<>();
         String key = Integer.toString(layer.getId());
         Resource res = permissionsService.findResource(ResourceType.maplayer, key)
                 .orElseThrow(()-> new ServiceException("Can't find permissions for maplayer with mapping key: " + key));
 
         for (Role role : getAvailableRoles(user)) {
-            List<String> permissionsForRole = new ArrayList<>();
+            Set<String> permissionsForRole = new HashSet<>();
             for (String permission : getAvailablePermissions()){
                 if (res.hasPermission(role, permission)) {
                     permissionsForRole.add(permission);

--- a/service-admin/src/main/java/org/oskari/admin/LayerAdminJSONHelper.java
+++ b/service-admin/src/main/java/org/oskari/admin/LayerAdminJSONHelper.java
@@ -29,6 +29,14 @@ public class LayerAdminJSONHelper {
         }
     }
 
+    public static String writeJSON(MapLayer layer) {
+        try {
+            return OBJECT_MAPPER.writeValueAsString(layer);
+        } catch (Exception ex) {
+            throw new ServiceRuntimeException("Coudn't write layer to JSON", ex);
+        }
+    }
+
     public static OskariLayer fromJSON(MapLayer model) {
         OskariLayer layer = new OskariLayer();
         layer.setId(model.getId());

--- a/service-admin/src/main/java/org/oskari/admin/LayerCapabilitiesHelper.java
+++ b/service-admin/src/main/java/org/oskari/admin/LayerCapabilitiesHelper.java
@@ -91,7 +91,7 @@ public class LayerCapabilitiesHelper {
     }
 
     // not used currently but this seems The place for this
-    private static void updateCapabilities(OskariLayer ml) throws ServiceException {
+    public static void updateCapabilities(OskariLayer ml) throws ServiceException {
         switch (ml.getType()) {
             case OskariLayer.TYPE_WFS:
                 WFSDataStore wfs = WFSCapabilitiesService.getDataStore(ml);

--- a/service-admin/src/main/java/org/oskari/admin/model/MapLayer.java
+++ b/service-admin/src/main/java/org/oskari/admin/model/MapLayer.java
@@ -9,7 +9,8 @@ import java.util.Set;
  */
 public class MapLayer {
 
-    private int id = -1;
+    // Integer so it can be null and not part of output
+    private Integer id;
     private String type;
     private String url;
     private String username;
@@ -60,11 +61,11 @@ public class MapLayer {
     }*/
     private Map<String, Set<String>> role_permissions;
 
-    public int getId() {
+    public Integer getId() {
         return id;
     }
 
-    public void setId(int id) {
+    public void setId(Integer id) {
         this.id = id;
     }
 

--- a/service-admin/src/main/java/org/oskari/admin/model/MapLayerAdminOutput.java
+++ b/service-admin/src/main/java/org/oskari/admin/model/MapLayerAdminOutput.java
@@ -7,6 +7,7 @@ import java.util.Map;
  */
 public class MapLayerAdminOutput extends MapLayer {
 
+    private String warn;
     private Map<String, Object> capabilities;
 
     public Map<String, Object> getCapabilities() {
@@ -15,5 +16,17 @@ public class MapLayerAdminOutput extends MapLayer {
 
     public void setCapabilities(Map<String, Object> capabilities) {
         this.capabilities = capabilities;
+    }
+
+    /**
+     * Possible warning message that capabilities coulnt' be updated
+     * @return
+     */
+    public String getWarn() {
+        return warn;
+    }
+
+    public void setWarn(String warn) {
+        this.warn = warn;
     }
 }

--- a/service-admin/src/test/java/org/oskari/admin/model/MapLayerTest.java
+++ b/service-admin/src/test/java/org/oskari/admin/model/MapLayerTest.java
@@ -7,7 +7,6 @@ import fi.nls.oskari.util.IOHelper;
 import fi.nls.oskari.util.JSONHelper;
 import org.json.JSONObject;
 import org.junit.Test;
-import org.oskari.admin.model.MapLayer;
 
 import static org.junit.Assert.*;
 

--- a/service-admin/src/test/resources/org/oskari/admin/model/MapLayer-expected.json
+++ b/service-admin/src/test/resources/org/oskari/admin/model/MapLayer-expected.json
@@ -1,5 +1,4 @@
 {
-  "id": -1,
   "type": "wmslayer",
   "url": "http://oskari.org/basemap",
   "name": "basemap",


### PR DESCRIPTION
Refactored LayerAdmin route for fetching layer by id to use the same format as ServiceCapabilities route returns for layers parsed from service capabilities.

Cleaning up capabilities functionality from LayerAdmin (moved to ServiceCapabilities in #511).