### PR TITLE
Fix refactored layer insert / Migration helpers to throw exception on errors

### DIFF
--- a/content-resources/src/main/java/fi/nls/oskari/db/DBHandler.java
+++ b/content-resources/src/main/java/fi/nls/oskari/db/DBHandler.java
@@ -2,6 +2,7 @@ package fi.nls.oskari.db;
 
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.service.ServiceRuntimeException;
 import fi.nls.oskari.service.db.BaseIbatisService;
 import fi.nls.oskari.util.ConversionHelper;
 import fi.nls.oskari.util.IOHelper;
@@ -290,6 +291,7 @@ public class DBHandler {
 
         } catch (Exception e) {
             getLog().error(e, "Error creating content");
+            throw new ServiceRuntimeException("Unable to process setup file", e);
         }
     }
 

--- a/content-resources/src/main/java/fi/nls/oskari/db/ViewHelper.java
+++ b/content-resources/src/main/java/fi/nls/oskari/db/ViewHelper.java
@@ -8,6 +8,7 @@ import fi.nls.oskari.map.view.BundleService;
 import fi.nls.oskari.map.view.BundleServiceMybatisImpl;
 import fi.nls.oskari.map.view.ViewService;
 import fi.nls.oskari.map.view.AppSetupServiceMybatisImpl;
+import fi.nls.oskari.service.ServiceRuntimeException;
 import fi.nls.oskari.util.ConversionHelper;
 import fi.nls.oskari.util.IOHelper;
 import fi.nls.oskari.util.JSONHelper;
@@ -48,8 +49,8 @@ public class ViewHelper {
             return viewId;
         } catch (Exception ex) {
             log.error(ex, "Unable to insert view! ");
+            throw new ServiceRuntimeException("Unable to insert appsetup", ex);
         }
-        return -1;
     }
 
     public static Set<Integer> setupLayers(JSONObject viewJSON)
@@ -64,6 +65,7 @@ public class ViewHelper {
                     selectedLayerIds.add(LayerHelper.setupLayer(layerfile));
                 } catch (Exception ex) {
                     log.warn("Unable to setup layers from:", layerfile);
+                    throw ex;
                 }
             }
         }

--- a/service-admin/src/main/java/org/oskari/admin/LayerAdminJSONHelper.java
+++ b/service-admin/src/main/java/org/oskari/admin/LayerAdminJSONHelper.java
@@ -39,7 +39,11 @@ public class LayerAdminJSONHelper {
 
     public static OskariLayer fromJSON(MapLayer model) {
         OskariLayer layer = new OskariLayer();
-        layer.setId(model.getId());
+        Integer id = model.getId();
+        if (id != null) {
+            // unboxing null Integer to int causes NPE so not calling setId() with null value
+            layer.setId(model.getId());
+        }
         layer.setType(model.getType());
         layer.setUrl(model.getUrl());
         layer.setUsername(model.getUsername());
@@ -134,10 +138,10 @@ public class LayerAdminJSONHelper {
         if (model.getDataprovider_id() > 0) {
             provider = getDataProviderService().find(model.getDataprovider_id());
         } else if (model.getDataprovider() != null) {
-            provider = getDataProviderService().find(model.getDataprovider_id());
+            provider = getDataProviderService().findByName(model.getDataprovider());
         }
         if (provider == null) {
-            throw new ServiceRuntimeException("Couln't find data provider for layer");
+            throw new ServiceRuntimeException("Couln't find data provider for layer (" + model.getDataprovider_id() + "/" + model.getDataprovider() + ")");
         }
         return provider.getId();
     }

--- a/service-admin/src/main/java/org/oskari/admin/LayerAdminJSONHelper.java
+++ b/service-admin/src/main/java/org/oskari/admin/LayerAdminJSONHelper.java
@@ -48,7 +48,10 @@ public class LayerAdminJSONHelper {
         layer.setUrl(model.getUrl());
         layer.setUsername(model.getUsername());
         layer.setPassword(model.getPassword());
-        layer.setVersion(model.getVersion());
+        if (model.getVersion() != null) {
+            // version is non-null in db (empty string is ok)
+            layer.setVersion(model.getVersion());
+        }
         layer.setName(model.getName());
         layer.setLocale(new JSONObject(model.getLocale()));
 

--- a/service-admin/src/main/java/org/oskari/admin/LayerAdminJSONHelper.java
+++ b/service-admin/src/main/java/org/oskari/admin/LayerAdminJSONHelper.java
@@ -79,7 +79,10 @@ public class LayerAdminJSONHelper {
         layer.setRefreshRate(model.getRefresh_rate());
         layer.setCapabilitiesUpdateRateSec(model.getCapabilities_update_rate_sec());
 
-        layer.setDataproviderId(getDataProviderId(model));
+        // FIX
+        DataProvider provider = getDataProvider(model);
+        layer.addDataprovider(provider);
+        layer.setDataproviderId(provider.getId());
         layer.setInternal(model.isInternal());
 
         // TODO: handle sublayers layer.getSublayers()
@@ -122,7 +125,12 @@ public class LayerAdminJSONHelper {
         out.setRefresh_rate(layer.getRefreshRate());
         out.setCapabilities_update_rate_sec(layer.getCapabilitiesUpdateRateSec());
 
-        out.setDataprovider_id(layer.getDataproviderId());
+        DataProvider provider = layer.getGroup();
+        if (provider != null) {
+            out.setDataprovider_id(provider.getId());
+        } else {
+            out.setDataprovider_id(layer.getDataproviderId());
+        }
         out.setInternal(layer.isInternal()); // we might not need to write this
         out.setCapabilities(JSONHelper.getObjectAsMap(layer.getCapabilities()));
 
@@ -133,7 +141,7 @@ public class LayerAdminJSONHelper {
     }
 
 
-    private static int getDataProviderId(MapLayer model) {
+    private static DataProvider getDataProvider(MapLayer model) {
         DataProvider provider = null;
         if (model.getDataprovider_id() > 0) {
             provider = getDataProviderService().find(model.getDataprovider_id());
@@ -143,7 +151,7 @@ public class LayerAdminJSONHelper {
         if (provider == null) {
             throw new ServiceRuntimeException("Couln't find data provider for layer (" + model.getDataprovider_id() + "/" + model.getDataprovider() + ")");
         }
-        return provider.getId();
+        return provider;
     }
 
     private static DataProviderService getDataProviderService() {

--- a/service-admin/src/main/java/org/oskari/admin/LayerAdminJSONHelper.java
+++ b/service-admin/src/main/java/org/oskari/admin/LayerAdminJSONHelper.java
@@ -49,7 +49,7 @@ public class LayerAdminJSONHelper {
         layer.setUsername(model.getUsername());
         layer.setPassword(model.getPassword());
         if (model.getVersion() != null) {
-            // version is non-null in db (empty string is ok)
+            // version has non-null requirement in db (empty string is ok)
             layer.setVersion(model.getVersion());
         }
         layer.setName(model.getName());
@@ -82,7 +82,6 @@ public class LayerAdminJSONHelper {
         layer.setRefreshRate(model.getRefresh_rate());
         layer.setCapabilitiesUpdateRateSec(model.getCapabilities_update_rate_sec());
 
-        // FIX
         DataProvider provider = getDataProvider(model);
         layer.addDataprovider(provider);
         layer.setDataproviderId(provider.getId());


### PR DESCRIPTION
Fixes an issue introduced in #512 where id can be null. Also fixes an issue with data provider mapping between JSON payload <> OskariLayer <> JSON payload.

Also makes appsetup/layer insertion using existing helper classes on migration scripts fail on errors so database don't need to be wiped between attempts to fix content migrations.