### PR TITLE
ProjectinHelper doesn't function like it should

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/feature/AbstractFeatureHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/feature/AbstractFeatureHandler.java
@@ -132,7 +132,8 @@ public abstract class AbstractFeatureHandler extends RestActionHandler {
             }
             JSONArray data = geometries.getJSONArray("data");
             Geometry geometry = getGeometry(geometryType, data, getSrid(srsName, 3067));
-            if(ProjectionHelper.isFirstAxisNorth(crs)) {
+            //TODO: ProjectinHelper doesn't function like it should
+            if(ProjectionHelper.isFirstAxisNorth(crs) || srsName.equals("EPSG:3879")) {
                 // reverse xy
                 ProjectionHelper.flipFeatureYX(geometry);
             }


### PR DESCRIPTION
ProjectionHelper is not currently working like it was intended so we have to put in condition for EPSG:3879 for it to flip those geometries like it is supposed to. Not sure if it's the case with other CRS but this one is tested and used a lot.