### PR TITLE
Add logic to delete dataprovider

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/layer/DataProviderHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/DataProviderHandler.java
@@ -86,14 +86,14 @@ public class DataProviderHandler extends RestActionHandler {
 				throw new ActionParamsException("Dataprovider not found with id " + id);
 			}
 			
-			List<Integer> layerIdsToBeDeleted = deleteLayers ? layers.stream().map(OskariLayer::getId)
-					.collect(Collectors.toList()) : new ArrayList<Integer>();
+			List<String> layerNamesToBeDeleted = deleteLayers ? layers.stream().map(OskariLayer::getName)
+					.collect(Collectors.toList()) : new ArrayList<String>();
 			
 			dataProviderService.delete(id);
 
 			AuditLog.user(params.getClientIp(), params.getUser()).withParam("id", dataProvider.getId())
 					.withParam("name", dataProvider.getName(PropertyUtil.getDefaultLanguage()))
-					.withMsg("map layers " + layerIdsToBeDeleted + " deleted with data provider" )
+					.withMsg("map layers " + layerNamesToBeDeleted + " deleted with data provider" )
 					.deleted(AuditLog.ResourceType.DATAPROVIDER);
 
 			// write deleted organization as response

--- a/control-base/src/main/java/fi/nls/oskari/control/layer/DataProviderHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/DataProviderHandler.java
@@ -1,13 +1,21 @@
 package fi.nls.oskari.control.layer;
 
+import java.util.List;
+
+import org.oskari.log.AuditLog;
 import org.oskari.service.util.ServiceFactory;
 
 import fi.nls.oskari.annotation.OskariActionRoute;
+import fi.nls.oskari.control.ActionDeniedException;
 import fi.nls.oskari.control.ActionException;
 import fi.nls.oskari.control.ActionParameters;
+import fi.nls.oskari.control.ActionParamsException;
 import fi.nls.oskari.control.RestActionHandler;
 import fi.nls.oskari.domain.map.DataProvider;
+import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.map.layer.DataProviderService;
+import fi.nls.oskari.map.layer.OskariLayerService;
+import fi.nls.oskari.util.PropertyUtil;
 import fi.nls.oskari.util.ResponseHelper;
 
 /**
@@ -17,8 +25,10 @@ import fi.nls.oskari.util.ResponseHelper;
 public class DataProviderHandler extends RestActionHandler {
 
 	private static final String PARAM_ID = "id";
+	private static final String PARAM_DELETE_LAYERS = "deleteLayers";
 
-	private DataProviderService service = ServiceFactory.getDataProviderService();
+	private DataProviderService dataProviderService = ServiceFactory.getDataProviderService();
+	private OskariLayerService mapLayerService = ServiceFactory.getMapLayerService();
 
 	@Override
 	public void handleGet(ActionParameters params) throws ActionException {
@@ -26,10 +36,85 @@ public class DataProviderHandler extends RestActionHandler {
 		final int id = params.getRequiredParamInt(PARAM_ID);
 		
 		try {
-			DataProvider d = service.find(id);
+			DataProvider d = dataProviderService.find(id);
 			ResponseHelper.writeResponse(params, d.getAsJSON());
 		} catch (Exception e) {
 			throw new ActionException("Data provider query failed", e);
 		}
+	}
+	@Override
+	public void handleDelete(ActionParameters params) throws ActionException {
+		
+		final int id = params.getRequiredParamInt(PARAM_ID);
+		final boolean deleteLayers = params.getRequiredParamBoolean(PARAM_DELETE_LAYERS);
+		
+		if(!dataProviderService.hasPermissionToUpdate(params.getUser(), id)) {
+            throw new ActionDeniedException("Unauthorized user tried to remove data provider id=" + id);
+        }
+		
+		if(deleteLayers) {
+			deleteDataProviderAndLayers(id, params);
+		} else {
+			deleteDataProvider(id, params);
+		}
+	}
+	
+	/**
+	 * Method deletes data provider.
+	 * Data provider is removed from map layers belonging to the data provider prior delete.
+	 *
+	 * @param int id
+	 * @param ActionParameters params
+	 * @throws ActionException
+	 */
+	private void deleteDataProvider(int id, ActionParameters params) throws ActionException {
+		try {
+			DataProvider dataProvider = dataProviderService.find(id);
+            if(dataProvider == null) {
+                throw new ActionParamsException("Dataprovider not found with id " + id);
+            }
+			List<OskariLayer> layers = mapLayerService.findByDataProviderId(id);
+			layers.stream().forEach(layer -> {
+				layer.removeDataprovider(id);
+				mapLayerService.update(layer);
+			});
+			dataProviderService.delete(id);
+			AuditLog.user(params.getClientIp(), params.getUser())
+	            .withParam("id", dataProvider.getId())
+	            .withParam("name", dataProvider.getName(PropertyUtil.getDefaultLanguage()))
+	            .deleted(AuditLog.ResourceType.DATAPROVIDER);
+
+			// write deleted organization as response
+			ResponseHelper.writeResponse(params, dataProvider.getAsJSON());
+		} catch (Exception e) {
+            throw new ActionException("Couldn't delete data provider with id:" + id, e);
+        }
+	}
+	/**
+	 * Method deletes data provider and map layers which belong to the data provider.
+	 *
+	 * @param int id
+	 * @param ActionParameters params
+	 * @throws ActionException
+	 */
+	private void deleteDataProviderAndLayers(int id, ActionParameters params) throws ActionException {
+		try {
+            DataProvider organization = dataProviderService.find(id);
+            if(organization == null) {
+                throw new ActionParamsException("Dataprovider not found with id " + id);
+            }
+            // cascade in db will handle that layers are deleted
+            dataProviderService.delete(id);
+
+            AuditLog.user(params.getClientIp(), params.getUser())
+                    .withParam("id", organization.getId())
+                    .withParam("name", organization.getName(PropertyUtil.getDefaultLanguage()))
+                    .deleted(AuditLog.ResourceType.DATAPROVIDER);
+
+            // write deleted organization as response
+            ResponseHelper.writeResponse(params, organization.getAsJSON());
+        } catch (Exception e) {
+            throw new ActionException("Couldn't delete data provider and its map layers - id:" + id, e);
+        }
 	}
 }

--- a/control-base/src/main/java/fi/nls/oskari/control/layer/DataProviderHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/DataProviderHandler.java
@@ -32,9 +32,9 @@ public class DataProviderHandler extends RestActionHandler {
 
 	@Override
 	public void handleGet(ActionParameters params) throws ActionException {
-		
+
 		final int id = params.getRequiredParamInt(PARAM_ID);
-		
+
 		try {
 			DataProvider d = dataProviderService.find(id);
 			ResponseHelper.writeResponse(params, d.getAsJSON());
@@ -42,79 +42,80 @@ public class DataProviderHandler extends RestActionHandler {
 			throw new ActionException("Data provider query failed", e);
 		}
 	}
+
 	@Override
 	public void handleDelete(ActionParameters params) throws ActionException {
-		
+
 		final int id = params.getRequiredParamInt(PARAM_ID);
 		final boolean deleteLayers = params.getRequiredParamBoolean(PARAM_DELETE_LAYERS);
-		
-		if(!dataProviderService.hasPermissionToUpdate(params.getUser(), id)) {
-            throw new ActionDeniedException("Unauthorized user tried to remove data provider id=" + id);
-        }
-		
-		if(deleteLayers) {
+
+		if (!dataProviderService.hasPermissionToUpdate(params.getUser(), id)) {
+			throw new ActionDeniedException("Unauthorized user tried to remove data provider id=" + id);
+		}
+
+		if (deleteLayers) {
 			deleteDataProviderAndLayers(id, params);
 		} else {
 			deleteDataProvider(id, params);
 		}
 	}
-	
+
 	/**
-	 * Method deletes data provider.
-	 * Data provider is removed from map layers belonging to the data provider prior delete.
+	 * Method deletes data provider. Data provider is removed from map layers
+	 * belonging to the data provider prior delete.
 	 *
-	 * @param int id
+	 * @param int              id
 	 * @param ActionParameters params
 	 * @throws ActionException
 	 */
 	private void deleteDataProvider(int id, ActionParameters params) throws ActionException {
 		try {
 			DataProvider dataProvider = dataProviderService.find(id);
-            if(dataProvider == null) {
-                throw new ActionParamsException("Dataprovider not found with id " + id);
-            }
+			if (dataProvider == null) {
+				throw new ActionParamsException("Dataprovider not found with id " + id);
+			}
 			List<OskariLayer> layers = mapLayerService.findByDataProviderId(id);
 			layers.stream().forEach(layer -> {
 				layer.removeDataprovider(id);
 				mapLayerService.update(layer);
 			});
 			dataProviderService.delete(id);
-			AuditLog.user(params.getClientIp(), params.getUser())
-	            .withParam("id", dataProvider.getId())
-	            .withParam("name", dataProvider.getName(PropertyUtil.getDefaultLanguage()))
-	            .deleted(AuditLog.ResourceType.DATAPROVIDER);
+			AuditLog.user(params.getClientIp(), params.getUser()).withParam("id", dataProvider.getId())
+					.withParam("name", dataProvider.getName(PropertyUtil.getDefaultLanguage()))
+					.deleted(AuditLog.ResourceType.DATAPROVIDER);
 
 			// write deleted organization as response
 			ResponseHelper.writeResponse(params, dataProvider.getAsJSON());
 		} catch (Exception e) {
-            throw new ActionException("Couldn't delete data provider with id:" + id, e);
-        }
+			throw new ActionException("Couldn't delete data provider with id:" + id, e);
+		}
 	}
+
 	/**
-	 * Method deletes data provider and map layers which belong to the data provider.
+	 * Method deletes data provider and map layers which belong to the data
+	 * provider.
 	 *
-	 * @param int id
+	 * @param int              id
 	 * @param ActionParameters params
 	 * @throws ActionException
 	 */
 	private void deleteDataProviderAndLayers(int id, ActionParameters params) throws ActionException {
 		try {
-            DataProvider organization = dataProviderService.find(id);
-            if(organization == null) {
-                throw new ActionParamsException("Dataprovider not found with id " + id);
-            }
-            // cascade in db will handle that layers are deleted
-            dataProviderService.delete(id);
+			DataProvider organization = dataProviderService.find(id);
+			if (organization == null) {
+				throw new ActionParamsException("Dataprovider not found with id " + id);
+			}
+			// cascade in db will handle that layers are deleted
+			dataProviderService.delete(id);
 
-            AuditLog.user(params.getClientIp(), params.getUser())
-                    .withParam("id", organization.getId())
-                    .withParam("name", organization.getName(PropertyUtil.getDefaultLanguage()))
-                    .deleted(AuditLog.ResourceType.DATAPROVIDER);
+			AuditLog.user(params.getClientIp(), params.getUser()).withParam("id", organization.getId())
+					.withParam("name", organization.getName(PropertyUtil.getDefaultLanguage()))
+					.deleted(AuditLog.ResourceType.DATAPROVIDER);
 
-            // write deleted organization as response
-            ResponseHelper.writeResponse(params, organization.getAsJSON());
-        } catch (Exception e) {
-            throw new ActionException("Couldn't delete data provider and its map layers - id:" + id, e);
-        }
+			// write deleted organization as response
+			ResponseHelper.writeResponse(params, organization.getAsJSON());
+		} catch (Exception e) {
+			throw new ActionException("Couldn't delete data provider and its map layers - id:" + id, e);
+		}
 	}
 }

--- a/control-base/src/main/java/fi/nls/oskari/control/layer/DeleteOrganizationHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/DeleteOrganizationHandler.java
@@ -13,7 +13,9 @@ import fi.nls.oskari.map.layer.DataProviderService;
 import static fi.nls.oskari.control.ActionConstants.PARAM_ID;
 
 /**
- * For deleting a dataprovider/organization
+ * For deleting a data provider/organization
+ *
+ * @deprecated As of release 1.55.0, use fi.nls.oskari.control.layer.DataProvider action route instead
  */
 @OskariActionRoute("DeleteOrganization")
 public class DeleteOrganizationHandler extends RestActionHandler {

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/OskariLayer.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/OskariLayer.java
@@ -28,7 +28,7 @@ public class OskariLayer extends JSONLocalizedNameAndTitle implements Comparable
 
     private boolean isBaseMap = false;
     private boolean isInternal = false;
-    private int dataproviderId;
+    private Integer dataproviderId;
 
     private String name;
     private String url;
@@ -91,6 +91,10 @@ public class OskariLayer extends JSONLocalizedNameAndTitle implements Comparable
             dataProviders.add(dataProvider);
             setDataproviderId(dataProvider.getId());
         }
+    }
+    public void removeDataprovider(final int id) {
+        dataProviders.removeIf(d -> d.getId() == id);
+        setDataproviderId(null);
     }
 
     public int compareTo(OskariLayer l) {
@@ -243,11 +247,11 @@ public class OskariLayer extends JSONLocalizedNameAndTitle implements Comparable
         isInternal = internal;
     }
 
-    public int getDataproviderId() {
+    public Integer getDataproviderId() {
         return dataproviderId;
     }
 
-    public void setDataproviderId(int dataproviderId) {
+    public void setDataproviderId(Integer dataproviderId) {
         this.dataproviderId = dataproviderId;
     }
 

--- a/service-control/src/main/java/fi/nls/oskari/control/ActionParameters.java
+++ b/service-control/src/main/java/fi/nls/oskari/control/ActionParameters.java
@@ -157,13 +157,12 @@ public class ActionParameters {
      * @throws ActionParamsException if parameter is not found, is empty or can't be parsed as double
      */
     public boolean getRequiredParamBoolean(final String key) throws ActionParamsException {
-        final String errMsg = "Required parameter '" + key + "' missing!";
-        final String val = getRequiredParam(key, errMsg);
+        final String val = getRequiredParam(key);
 
         try {
             return Boolean.parseBoolean(val);
         } catch (Exception e) {
-            throw new ActionParamsException(errMsg);
+            throw new ActionParamsException(e.getMessage());
         }
     }
 

--- a/service-control/src/main/java/fi/nls/oskari/control/ActionParameters.java
+++ b/service-control/src/main/java/fi/nls/oskari/control/ActionParameters.java
@@ -150,6 +150,22 @@ public class ActionParameters {
             throw new ActionParamsException(errMsg);
         }
     }
+    /**
+     * Returns a cleaned up (think XSS) value for the requested parameter
+     * @param key parameter name
+     * @return cleaned up value for the parameter as boolean
+     * @throws ActionParamsException if parameter is not found, is empty or can't be parsed as double
+     */
+    public boolean getRequiredParamBoolean(final String key) throws ActionParamsException {
+        final String errMsg = "Required parameter '" + key + "' missing!";
+        final String val = getRequiredParam(key, errMsg);
+
+        try {
+            return Boolean.parseBoolean(val);
+        } catch (Exception e) {
+            throw new ActionParamsException(errMsg);
+        }
+    }
 
 
     /**

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/OskariLayerMapper.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/OskariLayerMapper.java
@@ -19,6 +19,8 @@ public interface OskariLayerMapper {
     List<Map<String,Object>> findAllWithPositiveUpdateRateSec();
     @Select ("select id, name from oskari_maplayer where type = #{type} and url like #{url} ||'%'")
     List<Map<String,Object>> findIdAndNameByUrl(@Param("url") final String url, @Param("type") final String type);
+    @Select ("select * from oskari_maplayer where dataprovider_id = #{dataProviderId}")
+    List<Map<String,Object>> findByDataProviderId(@Param("dataProviderId") final int dataProviderId);
     int update(final OskariLayer layer);
     void insert(final OskariLayer layer);
     int delete(final int layerId);

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/OskariLayerService.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/OskariLayerService.java
@@ -14,6 +14,7 @@ public abstract class OskariLayerService extends OskariComponent {
     public abstract List<OskariLayer> findByUrlAndName(final String url, final String name);
     public abstract List<OskariLayer> findByMetadataId(String uuid);
     public abstract List<OskariLayer> findAllWithPositiveUpdateRateSec();
+    public abstract List<OskariLayer> findByDataProviderId(final int dataProviderId);
     public abstract Map<String, List<Integer>> findNamesAndIdsByUrl(final String url, final String type);
     public abstract int insert(final OskariLayer layer);
     public abstract void update(final OskariLayer layer);

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/OskariLayerServiceMybatisImpl.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/OskariLayerServiceMybatisImpl.java
@@ -1,5 +1,23 @@
 package fi.nls.oskari.map.layer;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import javax.sql.DataSource;
+
+import org.apache.ibatis.mapping.Environment;
+import org.apache.ibatis.session.Configuration;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.apache.ibatis.transaction.TransactionFactory;
+import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
+
 import fi.nls.oskari.annotation.Oskari;
 import fi.nls.oskari.db.DatasourceHelper;
 import fi.nls.oskari.domain.map.DataProvider;
@@ -9,17 +27,6 @@ import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.mybatis.JSONObjectMybatisTypeHandler;
 import fi.nls.oskari.util.ConversionHelper;
 import fi.nls.oskari.util.JSONHelper;
-import org.apache.ibatis.mapping.Environment;
-import org.apache.ibatis.session.Configuration;
-import org.apache.ibatis.session.SqlSession;
-import org.apache.ibatis.session.SqlSessionFactory;
-import org.apache.ibatis.session.SqlSessionFactoryBuilder;
-import org.apache.ibatis.transaction.TransactionFactory;
-import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
-
-import javax.sql.DataSource;
-import java.util.*;
-import java.util.stream.Collectors;
 
 @Oskari("OskariLayerService")
 public class OskariLayerServiceMybatisImpl extends OskariLayerService {
@@ -303,6 +310,23 @@ public class OskariLayerServiceMybatisImpl extends OskariLayerService {
         }
         return Collections.emptyList();
     }
+    
+    @Override
+	public List<OskariLayer> findByDataProviderId(int dataProviderId) {
+    	LOG.debug("Find by data provider id: " + dataProviderId);
+        final SqlSession session = factory.openSession();
+        try {
+            final OskariLayerMapper mapper = session.getMapper(OskariLayerMapper.class);
+            List<Map<String,Object>> result = mapper.findByDataProviderId(dataProviderId);
+            return mapDataList(result);
+        } catch (Exception e) {
+            LOG.warn(e, "Exception while getting oskari layers with dataprovider id");
+        } finally {
+            session.close();
+        }
+        return Collections.emptyList();
+	}
+    
     public Map<String, List<Integer>> findNamesAndIdsByUrl (final String url, final String type) {
         final SqlSession session = factory.openSession();
         try {
@@ -369,5 +393,4 @@ public class OskariLayerServiceMybatisImpl extends OskariLayerService {
     public void delete(Map<String, String> parameterMap) {
         delete(ConversionHelper.getInt(parameterMap.get("id"), -1));
     }
-
 }

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/OskariLayerServiceMybatisImpl.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/OskariLayerServiceMybatisImpl.java
@@ -314,15 +314,13 @@ public class OskariLayerServiceMybatisImpl extends OskariLayerService {
     @Override
 	public List<OskariLayer> findByDataProviderId(int dataProviderId) {
     	LOG.debug("Find by data provider id: " + dataProviderId);
-        final SqlSession session = factory.openSession();
-        try {
+
+        try (SqlSession session = factory.openSession()){
             final OskariLayerMapper mapper = session.getMapper(OskariLayerMapper.class);
             List<Map<String,Object>> result = mapper.findByDataProviderId(dataProviderId);
             return mapDataList(result);
         } catch (Exception e) {
             LOG.warn(e, "Exception while getting oskari layers with dataprovider id");
-        } finally {
-            session.close();
         }
         return Collections.emptyList();
 	}


### PR DESCRIPTION
Pull request contains logic to delete data provider using newly created DataProvider action route. Map layers belonging to the data provider are deleted if mandatory deleteLayers parameter is set to true. With value false, the data provider is removed from map layers. Previously used DeleteOrganization action route is marked as deprecated.  