### PR TITLE
MapLayerGroups delete with deleteLayers option

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/data/MapLayerGroupsHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/data/MapLayerGroupsHandler.java
@@ -30,241 +30,247 @@ import fi.nls.oskari.util.JSONHelper;
 import fi.nls.oskari.util.PropertyUtil;
 import fi.nls.oskari.util.ResponseHelper;
 
-
 /**
- * CRUD for Maplayer groups. Get is callable by anyone, other methods require admin user.
+ * CRUD for Maplayer groups. Get is callable by anyone, other methods require
+ * admin user.
  */
 @OskariActionRoute("MapLayerGroups")
 public class MapLayerGroupsHandler extends RestActionHandler {
 
-    private static final String KEY_LOCALES = "locales";
-    private static final String KEY_PARENT_ID = "parentId";
-    private static final String KEY_SELECTABLE = "selectable";
-    private static final String PARAM_DELETE_LAYERS = "deleteLayers";
+	private static final String KEY_LOCALES = "locales";
+	private static final String KEY_PARENT_ID = "parentId";
+	private static final String KEY_SELECTABLE = "selectable";
+	private static final String PARAM_DELETE_LAYERS = "deleteLayers";
 
-    private OskariMapLayerGroupService oskariMapLayerGroupService;
-    private OskariLayerGroupLinkService linkService;
-    private OskariLayerService mapLayerService = ServiceFactory.getMapLayerService();
+	private OskariMapLayerGroupService oskariMapLayerGroupService;
+	private OskariLayerGroupLinkService linkService;
+	private OskariLayerService mapLayerService = ServiceFactory.getMapLayerService();
 
-    public void setOskariMapLayerGroupService(final OskariMapLayerGroupService service) {
-        oskariMapLayerGroupService = service;
-    }
+	public void setOskariMapLayerGroupService(final OskariMapLayerGroupService service) {
+		oskariMapLayerGroupService = service;
+	}
 
-    public void setLinkService(OskariLayerGroupLinkService linkService) {
-        this.linkService = linkService;
-    }
+	public void setLinkService(OskariLayerGroupLinkService linkService) {
+		this.linkService = linkService;
+	}
 
-    public void init() {
-        // setup service if it hasn't been initialized
-        if(oskariMapLayerGroupService == null) {
-            setOskariMapLayerGroupService(new OskariMapLayerGroupServiceIbatisImpl());
-        }
-        if (linkService == null) {
-            setLinkService(new OskariLayerGroupLinkServiceMybatisImpl());
-        }
-    }
-
-    /**
-     * Handles listing and single maplayer group find
-     * @param params
-     * @throws ActionException
-     */
-    public void handleGet(ActionParameters params) throws ActionException {
-        final int id = params.getHttpParam(PARAM_ID, -1);
-        if(id != -1) {
-            // find single group
-            final MaplayerGroup maplayerGroup = oskariMapLayerGroupService.find(id);
-            ResponseHelper.writeResponse(params, maplayerGroup.getAsJSON());
-            return;
-        }
-
-        // find all maplayerGroups
-        final List<MaplayerGroup> maplayerGroups = oskariMapLayerGroupService.findAll();
-        final JSONArray list = new JSONArray();
-        for (MaplayerGroup maplayerGroup : maplayerGroups) {
-            list.put(maplayerGroup.getAsJSON());
-        }
-        final JSONObject result = new JSONObject();
-        JSONHelper.putValue(result, "mapLayerGroups", list);
-        ResponseHelper.writeResponse(params, result);
-    }
-
-    /**
-     * Handles insert
-     * @param params
-     * @throws ActionException
-     */
-    public void handlePut(ActionParameters params) throws ActionException {
-        params.requireAdminUser();
-        MaplayerGroup maplayerGroup = populateFromRequest(params.getPayLoadJSON());
-
-        // Check at group depth is maximum 3
-        if(!isAllowedGroupDepth(maplayerGroup)) {
-            throw new ActionParamsException("Maximum group depth is 3");
-        }
-
-        final int id = oskariMapLayerGroupService.insert(maplayerGroup);
-        // check insert by loading from DB
-        final MaplayerGroup savedMapLayerGroup = oskariMapLayerGroupService.find(id);
-        AuditLog.user(params.getClientIp(), params.getUser())
-                .withParam("id", id)
-                .withParam("name", maplayerGroup.getName(PropertyUtil.getDefaultLanguage()))
-                .added(AuditLog.ResourceType.MAPLAYER_GROUP);
-        ResponseHelper.writeResponse(params, savedMapLayerGroup.getAsJSON());
-    }
-
-    /**
-     * Handles update
-     * @param params
-     * @throws ActionException
-     */
-    public void handlePost(ActionParameters params) throws ActionException {
-        params.requireAdminUser();
-        MaplayerGroup maplayerGroup = populateFromRequest(params.getPayLoadJSON());
-        if(maplayerGroup.getId() == -1) {
-            // hierarchical admin apparently sends id as separate param
-            maplayerGroup.setId(params.getRequiredParamInt(PARAM_ID));
-        }
-        oskariMapLayerGroupService.update(maplayerGroup);
-
-        AuditLog.user(params.getClientIp(), params.getUser())
-                .withParam("id", maplayerGroup.getId())
-                .withParam("name", maplayerGroup.getName(PropertyUtil.getDefaultLanguage()))
-                .updated(AuditLog.ResourceType.MAPLAYER_GROUP);
-
-        ResponseHelper.writeResponse(params, maplayerGroup.getAsJSON());
-    }
-
-    /**
-     * Handles removal
-     * @param params
-     * @throws ActionException
-     */
-    public void handleDelete(ActionParameters params) throws ActionException {
-        params.requireAdminUser();
-        final int groupId = params.getRequiredParamInt(PARAM_ID);
-        final Object deleteLayers = params.getHttpParam(PARAM_DELETE_LAYERS);
-        
-        final MaplayerGroup maplayerGroup = oskariMapLayerGroupService.find(groupId);
-        
-        if(deleteLayers != null) {
-        	handleDelete(params,maplayerGroup, deleteLayers);
-        } else {
-        	handleDeleteLegacy(params, maplayerGroup);
-        }    
-    }
-
-    /**
-     * Delete handling used with new layer admin since version 1.55.0.
-     * Removes map layers linked to the group from system when deleteLayers parameter is true.
-     * With value false, layers remain in the system but links to the group are removed.
-     * 
-     * @param params
-     * @param maplayerGroup
-     * @param deleteLayersObj
-     * @throws ActionParamsException
-     */
-    private void handleDelete(ActionParameters params, MaplayerGroup maplayerGroup , Object deleteLayersObj) throws ActionParamsException {
-    	 boolean deleteLayers;
-    	 try {
-    		 deleteLayers = Boolean.parseBoolean((String) deleteLayersObj);
-         } catch (Exception e) {
-             throw new ActionParamsException("DeleteLayers parameter " + deleteLayersObj + " could not be parsed to boolean!");
-         }
-    	 
-    	 List<OskariLayer> layers = mapLayerService.findByGroupId(maplayerGroup.getId());  
-    	
-    	 List<String> layerNamesToBeDeleted;
-    	 
-    	 if(deleteLayers) {
-    		layers.forEach(layer -> mapLayerService.delete(layer.getId()));
-    		layerNamesToBeDeleted = layers.stream().map(OskariLayer::getName)
-					.collect(Collectors.toList());
-    	 } else {
-    		 linkService.deleteLinksByGroupId(maplayerGroup.getId());
-    		 layerNamesToBeDeleted = new ArrayList<String>();
-    	 }
-    	 
-    	 oskariMapLayerGroupService.delete(maplayerGroup.getId());
-    	 AuditLog.user(params.getClientIp(), params.getUser())
-         	.withParam("id", maplayerGroup.getId())
-         	.withParam("name", maplayerGroup.getName(PropertyUtil.getDefaultLanguage()))
-         	.withMsg("map layers " + layerNamesToBeDeleted + " deleted with map layer group" )
-         	.deleted(AuditLog.ResourceType.MAPLAYER_GROUP);
-
-    	 ResponseHelper.writeResponse(params, maplayerGroup.getAsJSON());
+	public void init() {
+		// setup service if it hasn't been initialized
+		if (oskariMapLayerGroupService == null) {
+			setOskariMapLayerGroupService(new OskariMapLayerGroupServiceIbatisImpl());
+		}
+		if (linkService == null) {
+			setLinkService(new OskariLayerGroupLinkServiceMybatisImpl());
+		}
 	}
 
 	/**
-     * Delete handling used with old layer admin prior version 1.55.0.
-     * Throws exception if the map layer group has linked map layers.
-     * 
-     * @param params
-     * @param maplayerGroup
-     * @param groupId
-     * @throws ActionParamsException
-     */
-    private void handleDeleteLegacy(ActionParameters params, MaplayerGroup maplayerGroup) throws ActionParamsException {
-    	if (linkService.hasLinks(maplayerGroup.getId())) {
-             // maplayer group with maplayers under it can't be removed
-             throw new ActionParamsException("Maplayers linked to maplayer group", JSONHelper.createJSONObject("code", "not_empty"));
-         }
-         oskariMapLayerGroupService.delete(maplayerGroup.getId());
+	 * Handles listing and single maplayer group find
+	 * 
+	 * @param params
+	 * @throws ActionException
+	 */
+	public void handleGet(ActionParameters params) throws ActionException {
+		final int id = params.getHttpParam(PARAM_ID, -1);
+		if (id != -1) {
+			// find single group
+			final MaplayerGroup maplayerGroup = oskariMapLayerGroupService.find(id);
+			ResponseHelper.writeResponse(params, maplayerGroup.getAsJSON());
+			return;
+		}
 
-         AuditLog.user(params.getClientIp(), params.getUser())
-                 .withParam("id", maplayerGroup.getId())
-                 .withParam("name", maplayerGroup.getName(PropertyUtil.getDefaultLanguage()))
-                 .deleted(AuditLog.ResourceType.MAPLAYER_GROUP);
-
-         ResponseHelper.writeResponse(params, maplayerGroup.getAsJSON());
+		// find all maplayerGroups
+		final List<MaplayerGroup> maplayerGroups = oskariMapLayerGroupService.findAll();
+		final JSONArray list = new JSONArray();
+		for (MaplayerGroup maplayerGroup : maplayerGroups) {
+			list.put(maplayerGroup.getAsJSON());
+		}
+		final JSONObject result = new JSONObject();
+		JSONHelper.putValue(result, "mapLayerGroups", list);
+		ResponseHelper.writeResponse(params, result);
 	}
 
 	/**
-     * Calculate group depth
-     * @param groupId group id
-     * @param depth current depth
-     * @return group depth
-     */
-    private int getGroupDepth(int groupId, int depth) {
-        depth++;
-        MaplayerGroup maplayerGroup = oskariMapLayerGroupService.find(groupId);
-        if(maplayerGroup.getParentId() == -1) {
-            return depth;
-        }
-        return getGroupDepth(maplayerGroup.getParentId(), depth);
-    }
+	 * Handles insert
+	 * 
+	 * @param params
+	 * @throws ActionException
+	 */
+	public void handlePut(ActionParameters params) throws ActionException {
+		params.requireAdminUser();
+		MaplayerGroup maplayerGroup = populateFromRequest(params.getPayLoadJSON());
 
-    /**
-     * Has allowed group depth
-     * @param maplayerGroup maplayer group
-     * @return is allowed group depth
-     */
-    private boolean isAllowedGroupDepth(MaplayerGroup maplayerGroup) {
-        if(maplayerGroup.getParentId() != -1 && getGroupDepth(maplayerGroup.getParentId(), 0) > 2) {
-            return false;
-        }
-        return true;
-    }
+		// Check at group depth is maximum 3
+		if (!isAllowedGroupDepth(maplayerGroup)) {
+			throw new ActionParamsException("Maximum group depth is 3");
+		}
 
-    private MaplayerGroup populateFromRequest(JSONObject mapLayerGroupJSON) throws ActionException {
-        MaplayerGroup maplayerGroup = new MaplayerGroup();
-        try{
-            JSONObject locales = mapLayerGroupJSON.getJSONObject(KEY_LOCALES);
-            // The classic admin sends id as part of the JSON payload (as string, but with number value...)
-            maplayerGroup.setId(ConversionHelper.getInt(mapLayerGroupJSON.optString("id"), -1));
-            maplayerGroup.setParentId(mapLayerGroupJSON.optInt(KEY_PARENT_ID, -1));
-            maplayerGroup.setSelectable(mapLayerGroupJSON.optBoolean(KEY_SELECTABLE, true));
-            Iterator<?> keys = locales.keys();
+		final int id = oskariMapLayerGroupService.insert(maplayerGroup);
+		// check insert by loading from DB
+		final MaplayerGroup savedMapLayerGroup = oskariMapLayerGroupService.find(id);
+		AuditLog.user(params.getClientIp(), params.getUser()).withParam("id", id)
+				.withParam("name", maplayerGroup.getName(PropertyUtil.getDefaultLanguage()))
+				.added(AuditLog.ResourceType.MAPLAYER_GROUP);
+		ResponseHelper.writeResponse(params, savedMapLayerGroup.getAsJSON());
+	}
 
-            while( keys.hasNext() ) {
-                String locale = (String)keys.next();
-                String name = locales.getString(locale);
-                maplayerGroup.setName(locale, name);
-            }
-        } catch(JSONException ex) {
-            throw new ActionException("Cannot populate maplayer group from request", ex);
-        }
+	/**
+	 * Handles update
+	 * 
+	 * @param params
+	 * @throws ActionException
+	 */
+	public void handlePost(ActionParameters params) throws ActionException {
+		params.requireAdminUser();
+		MaplayerGroup maplayerGroup = populateFromRequest(params.getPayLoadJSON());
+		if (maplayerGroup.getId() == -1) {
+			// hierarchical admin apparently sends id as separate param
+			maplayerGroup.setId(params.getRequiredParamInt(PARAM_ID));
+		}
+		oskariMapLayerGroupService.update(maplayerGroup);
 
-        return maplayerGroup;
-    }
+		AuditLog.user(params.getClientIp(), params.getUser()).withParam("id", maplayerGroup.getId())
+				.withParam("name", maplayerGroup.getName(PropertyUtil.getDefaultLanguage()))
+				.updated(AuditLog.ResourceType.MAPLAYER_GROUP);
+
+		ResponseHelper.writeResponse(params, maplayerGroup.getAsJSON());
+	}
+
+	/**
+	 * Handles removal
+	 * 
+	 * @param params
+	 * @throws ActionException
+	 */
+	public void handleDelete(ActionParameters params) throws ActionException {
+		params.requireAdminUser();
+		final int groupId = params.getRequiredParamInt(PARAM_ID);
+		final Object deleteLayers = params.getHttpParam(PARAM_DELETE_LAYERS);
+
+		final MaplayerGroup maplayerGroup = oskariMapLayerGroupService.find(groupId);
+
+		if (deleteLayers != null) {
+			handleDelete(params, maplayerGroup, deleteLayers);
+		} else {
+			handleDeleteLegacy(params, maplayerGroup);
+		}
+	}
+
+	/**
+	 * Delete handling used with new layer admin since version 1.55.0. Removes map
+	 * layers linked to the group from system when deleteLayers parameter is true.
+	 * With value false, layers remain in the system but links to the group are
+	 * removed.
+	 * 
+	 * @param params
+	 * @param maplayerGroup
+	 * @param deleteLayersObj
+	 * @throws ActionParamsException
+	 */
+	private void handleDelete(ActionParameters params, MaplayerGroup maplayerGroup, Object deleteLayersObj)
+			throws ActionParamsException {
+		boolean deleteLayers;
+		try {
+			deleteLayers = Boolean.parseBoolean((String) deleteLayersObj);
+		} catch (Exception e) {
+			throw new ActionParamsException(
+					"DeleteLayers parameter " + deleteLayersObj + " could not be parsed to boolean!");
+		}
+
+		List<OskariLayer> layers = mapLayerService.findByGroupId(maplayerGroup.getId());
+
+		List<String> layerNamesToBeDeleted;
+
+		if (deleteLayers) {
+			layers.forEach(layer -> mapLayerService.delete(layer.getId()));
+			layerNamesToBeDeleted = layers.stream().map(OskariLayer::getName).collect(Collectors.toList());
+		} else {
+			linkService.deleteLinksByGroupId(maplayerGroup.getId());
+			layerNamesToBeDeleted = new ArrayList<String>();
+		}
+
+		oskariMapLayerGroupService.delete(maplayerGroup.getId());
+		AuditLog.user(params.getClientIp(), params.getUser()).withParam("id", maplayerGroup.getId())
+				.withParam("name", maplayerGroup.getName(PropertyUtil.getDefaultLanguage()))
+				.withMsg("map layers " + layerNamesToBeDeleted + " deleted with map layer group")
+				.deleted(AuditLog.ResourceType.MAPLAYER_GROUP);
+
+		ResponseHelper.writeResponse(params, maplayerGroup.getAsJSON());
+	}
+
+	/**
+	 * Delete handling used with old layer admin prior version 1.55.0. Throws
+	 * exception if the map layer group has linked map layers.
+	 * 
+	 * @param params
+	 * @param maplayerGroup
+	 * @param groupId
+	 * @throws ActionParamsException
+	 */
+	private void handleDeleteLegacy(ActionParameters params, MaplayerGroup maplayerGroup) throws ActionParamsException {
+		if (linkService.hasLinks(maplayerGroup.getId())) {
+			// maplayer group with maplayers under it can't be removed
+			throw new ActionParamsException("Maplayers linked to maplayer group",
+					JSONHelper.createJSONObject("code", "not_empty"));
+		}
+		oskariMapLayerGroupService.delete(maplayerGroup.getId());
+
+		AuditLog.user(params.getClientIp(), params.getUser()).withParam("id", maplayerGroup.getId())
+				.withParam("name", maplayerGroup.getName(PropertyUtil.getDefaultLanguage()))
+				.deleted(AuditLog.ResourceType.MAPLAYER_GROUP);
+
+		ResponseHelper.writeResponse(params, maplayerGroup.getAsJSON());
+	}
+
+	/**
+	 * Calculate group depth
+	 * 
+	 * @param groupId group id
+	 * @param depth   current depth
+	 * @return group depth
+	 */
+	private int getGroupDepth(int groupId, int depth) {
+		depth++;
+		MaplayerGroup maplayerGroup = oskariMapLayerGroupService.find(groupId);
+		if (maplayerGroup.getParentId() == -1) {
+			return depth;
+		}
+		return getGroupDepth(maplayerGroup.getParentId(), depth);
+	}
+
+	/**
+	 * Has allowed group depth
+	 * 
+	 * @param maplayerGroup maplayer group
+	 * @return is allowed group depth
+	 */
+	private boolean isAllowedGroupDepth(MaplayerGroup maplayerGroup) {
+		if (maplayerGroup.getParentId() != -1 && getGroupDepth(maplayerGroup.getParentId(), 0) > 2) {
+			return false;
+		}
+		return true;
+	}
+
+	private MaplayerGroup populateFromRequest(JSONObject mapLayerGroupJSON) throws ActionException {
+		MaplayerGroup maplayerGroup = new MaplayerGroup();
+		try {
+			JSONObject locales = mapLayerGroupJSON.getJSONObject(KEY_LOCALES);
+			// The classic admin sends id as part of the JSON payload (as string, but with
+			// number value...)
+			maplayerGroup.setId(ConversionHelper.getInt(mapLayerGroupJSON.optString("id"), -1));
+			maplayerGroup.setParentId(mapLayerGroupJSON.optInt(KEY_PARENT_ID, -1));
+			maplayerGroup.setSelectable(mapLayerGroupJSON.optBoolean(KEY_SELECTABLE, true));
+			Iterator<?> keys = locales.keys();
+
+			while (keys.hasNext()) {
+				String locale = (String) keys.next();
+				String name = locales.getString(locale);
+				maplayerGroup.setName(locale, name);
+			}
+		} catch (JSONException ex) {
+			throw new ActionException("Cannot populate maplayer group from request", ex);
+		}
+
+		return maplayerGroup;
+	}
 }

--- a/control-base/src/main/java/fi/nls/oskari/control/data/MapLayerGroupsHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/data/MapLayerGroupsHandler.java
@@ -1,25 +1,34 @@
 package fi.nls.oskari.control.data;
 
+import static fi.nls.oskari.control.ActionConstants.PARAM_ID;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.oskari.log.AuditLog;
+import org.oskari.service.util.ServiceFactory;
+
 import fi.mml.map.mapwindow.service.db.OskariMapLayerGroupService;
 import fi.mml.map.mapwindow.service.db.OskariMapLayerGroupServiceIbatisImpl;
 import fi.nls.oskari.annotation.OskariActionRoute;
-import fi.nls.oskari.control.*;
+import fi.nls.oskari.control.ActionException;
+import fi.nls.oskari.control.ActionParameters;
+import fi.nls.oskari.control.ActionParamsException;
+import fi.nls.oskari.control.RestActionHandler;
 import fi.nls.oskari.domain.map.MaplayerGroup;
+import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.map.layer.OskariLayerService;
 import fi.nls.oskari.map.layer.group.link.OskariLayerGroupLinkService;
 import fi.nls.oskari.map.layer.group.link.OskariLayerGroupLinkServiceMybatisImpl;
 import fi.nls.oskari.util.ConversionHelper;
 import fi.nls.oskari.util.JSONHelper;
 import fi.nls.oskari.util.PropertyUtil;
 import fi.nls.oskari.util.ResponseHelper;
-import org.oskari.log.AuditLog;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-
-import java.util.Iterator;
-import java.util.List;
-
-import static fi.nls.oskari.control.ActionConstants.PARAM_ID;
 
 
 /**
@@ -31,9 +40,11 @@ public class MapLayerGroupsHandler extends RestActionHandler {
     private static final String KEY_LOCALES = "locales";
     private static final String KEY_PARENT_ID = "parentId";
     private static final String KEY_SELECTABLE = "selectable";
+    private static final String PARAM_DELETE_LAYERS = "deleteLayers";
 
     private OskariMapLayerGroupService oskariMapLayerGroupService;
     private OskariLayerGroupLinkService linkService;
+    private OskariLayerService mapLayerService = ServiceFactory.getMapLayerService();
 
     public void setOskariMapLayerGroupService(final OskariMapLayerGroupService service) {
         oskariMapLayerGroupService = service;
@@ -132,22 +143,83 @@ public class MapLayerGroupsHandler extends RestActionHandler {
     public void handleDelete(ActionParameters params) throws ActionException {
         params.requireAdminUser();
         final int groupId = params.getRequiredParamInt(PARAM_ID);
+        final Object deleteLayers = params.getHttpParam(PARAM_DELETE_LAYERS);
+        
         final MaplayerGroup maplayerGroup = oskariMapLayerGroupService.find(groupId);
-        if (linkService.hasLinks(groupId)) {
-            // maplayer group with maplayers under it can't be removed
-            throw new ActionParamsException("Maplayers linked to maplayer group", JSONHelper.createJSONObject("code", "not_empty"));
-        }
-        oskariMapLayerGroupService.delete(groupId);
-
-        AuditLog.user(params.getClientIp(), params.getUser())
-                .withParam("id", maplayerGroup.getId())
-                .withParam("name", maplayerGroup.getName(PropertyUtil.getDefaultLanguage()))
-                .deleted(AuditLog.ResourceType.MAPLAYER_GROUP);
-
-        ResponseHelper.writeResponse(params, maplayerGroup.getAsJSON());
+        
+        if(deleteLayers != null) {
+        	handleDelete(params,maplayerGroup, deleteLayers);
+        } else {
+        	handleDeleteLegacy(params, maplayerGroup);
+        }    
     }
 
     /**
+     * Delete handling used with new layer admin since version 1.55.0.
+     * Removes map layers linked to the group from system when deleteLayers parameter is true.
+     * With value false, layers remain in the system but links to the group are removed.
+     * 
+     * @param params
+     * @param maplayerGroup
+     * @param deleteLayersObj
+     * @throws ActionParamsException
+     */
+    private void handleDelete(ActionParameters params, MaplayerGroup maplayerGroup , Object deleteLayersObj) throws ActionParamsException {
+    	 boolean deleteLayers;
+    	 try {
+    		 deleteLayers = Boolean.parseBoolean((String) deleteLayersObj);
+         } catch (Exception e) {
+             throw new ActionParamsException("DeleteLayers parameter " + deleteLayersObj + " could not be parsed to boolean!");
+         }
+    	 
+    	 List<OskariLayer> layers = mapLayerService.findByGroupId(maplayerGroup.getId());  
+    	
+    	 List<String> layerNamesToBeDeleted;
+    	 
+    	 if(deleteLayers) {
+    		layers.forEach(layer -> mapLayerService.delete(layer.getId()));
+    		layerNamesToBeDeleted = layers.stream().map(OskariLayer::getName)
+					.collect(Collectors.toList());
+    	 } else {
+    		 linkService.deleteLinksByGroupId(maplayerGroup.getId());
+    		 layerNamesToBeDeleted = new ArrayList<String>();
+    	 }
+    	 
+    	 oskariMapLayerGroupService.delete(maplayerGroup.getId());
+    	 AuditLog.user(params.getClientIp(), params.getUser())
+         	.withParam("id", maplayerGroup.getId())
+         	.withParam("name", maplayerGroup.getName(PropertyUtil.getDefaultLanguage()))
+         	.withMsg("map layers " + layerNamesToBeDeleted + " deleted with map layer group" )
+         	.deleted(AuditLog.ResourceType.MAPLAYER_GROUP);
+
+    	 ResponseHelper.writeResponse(params, maplayerGroup.getAsJSON());
+	}
+
+	/**
+     * Delete handling used with old layer admin prior version 1.55.0.
+     * Throws exception if the map layer group has linked map layers.
+     * 
+     * @param params
+     * @param maplayerGroup
+     * @param groupId
+     * @throws ActionParamsException
+     */
+    private void handleDeleteLegacy(ActionParameters params, MaplayerGroup maplayerGroup) throws ActionParamsException {
+    	if (linkService.hasLinks(maplayerGroup.getId())) {
+             // maplayer group with maplayers under it can't be removed
+             throw new ActionParamsException("Maplayers linked to maplayer group", JSONHelper.createJSONObject("code", "not_empty"));
+         }
+         oskariMapLayerGroupService.delete(maplayerGroup.getId());
+
+         AuditLog.user(params.getClientIp(), params.getUser())
+                 .withParam("id", maplayerGroup.getId())
+                 .withParam("name", maplayerGroup.getName(PropertyUtil.getDefaultLanguage()))
+                 .deleted(AuditLog.ResourceType.MAPLAYER_GROUP);
+
+         ResponseHelper.writeResponse(params, maplayerGroup.getAsJSON());
+	}
+
+	/**
      * Calculate group depth
      * @param groupId group id
      * @param depth current depth

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/OskariLayerService.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/OskariLayerService.java
@@ -15,6 +15,7 @@ public abstract class OskariLayerService extends OskariComponent {
     public abstract List<OskariLayer> findByMetadataId(String uuid);
     public abstract List<OskariLayer> findAllWithPositiveUpdateRateSec();
     public abstract List<OskariLayer> findByDataProviderId(final int dataProviderId);
+    public abstract List<OskariLayer> findByGroupId(final int groupId);
     public abstract Map<String, List<Integer>> findNamesAndIdsByUrl(final String url, final String type);
     public abstract int insert(final OskariLayer layer);
     public abstract void update(final OskariLayer layer);

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/OskariLayerServiceMybatisImpl.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/OskariLayerServiceMybatisImpl.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 import javax.sql.DataSource;
 
@@ -17,6 +18,7 @@ import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 import org.apache.ibatis.transaction.TransactionFactory;
 import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
+import org.oskari.service.util.ServiceFactory;
 
 import fi.nls.oskari.annotation.Oskari;
 import fi.nls.oskari.db.DatasourceHelper;
@@ -24,6 +26,8 @@ import fi.nls.oskari.domain.map.DataProvider;
 import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.map.layer.group.link.OskariLayerGroupLink;
+import fi.nls.oskari.map.layer.group.link.OskariLayerGroupLinkService;
 import fi.nls.oskari.mybatis.JSONObjectMybatisTypeHandler;
 import fi.nls.oskari.util.ConversionHelper;
 import fi.nls.oskari.util.JSONHelper;
@@ -33,7 +37,8 @@ public class OskariLayerServiceMybatisImpl extends OskariLayerService {
 
     private static final Logger LOG = LogFactory.getLogger(OskariLayerServiceMybatisImpl.class);
 
-    private static DataProviderService dataProviderService = new DataProviderServiceMybatisImpl();
+    private static DataProviderService dataProviderService = ServiceFactory.getDataProviderService();
+    private static OskariLayerGroupLinkService linkService = ServiceFactory.getOskariLayerGroupLinkService();
 
     private SqlSessionFactory factory = null;
 
@@ -323,6 +328,13 @@ public class OskariLayerServiceMybatisImpl extends OskariLayerService {
             LOG.warn(e, "Exception while getting oskari layers with dataprovider id");
         }
         return Collections.emptyList();
+	}
+    
+    @Override
+	public List<OskariLayer> findByGroupId(int groupId) {
+    	List <OskariLayerGroupLink> links = linkService.findByGroupId(groupId);
+    	List<Integer> layerIds = links.stream().map(OskariLayerGroupLink::getLayerId).collect(Collectors.toList());
+		return this.findByIdList(layerIds);
 	}
     
     public Map<String, List<Integer>> findNamesAndIdsByUrl (final String url, final String type) {

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/group/link/OskariLayerGroupLinkMapper.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/group/link/OskariLayerGroupLinkMapper.java
@@ -40,6 +40,10 @@ public interface OskariLayerGroupLinkMapper {
             + " WHERE maplayerid = #{layerId}")
     void deleteByLayerId(@Param("layerId") int layerId);
 
+    @Delete("DELETE FROM oskari_maplayer_group_link"
+            + " WHERE groupid = #{groupid}")
+    void deleteByGroupId(@Param("groupid") int groupId);
+
     @Update("UPDATE oskari_maplayer_group_link"
             + " SET order_number = #{orderNumber}"
             + " WHERE maplayerid = #{layerId} AND groupid = #{groupId}")

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/group/link/OskariLayerGroupLinkService.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/group/link/OskariLayerGroupLinkService.java
@@ -16,6 +16,7 @@ public abstract class OskariLayerGroupLinkService extends OskariComponent {
 
     public abstract void deleteLink(int layerId, int groupId);
     public abstract void deleteLinksByLayerId(int layerId);
+    public abstract void deleteLinksByGroupId(int groupId);
 
     public abstract void replace(OskariLayerGroupLink old, OskariLayerGroupLink link);
     public abstract boolean hasLinks(int groupId);

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/group/link/OskariLayerGroupLinkServiceMybatisImpl.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/group/link/OskariLayerGroupLinkServiceMybatisImpl.java
@@ -120,4 +120,12 @@ public class OskariLayerGroupLinkServiceMybatisImpl extends OskariLayerGroupLink
             return getMapper(session).hasLinks(groupId);
         }
     }
+
+	@Override
+	public void deleteLinksByGroupId(int groupId) {
+		 try (SqlSession session = factory.openSession()) {
+	            getMapper(session).deleteByGroupId(groupId);
+	            session.commit();
+	     }
+	}
 }


### PR DESCRIPTION
New deleteLayers parameter is added to MapLayerGroups delete action route. Backwards compatibility is tried to obtain by making mentioned parameter optional. If the parameter is not provided (action route called from old layer admin) handling should work as before changes in this PR. When deleteLayers parameter is true, layers linked to map layer group and links are deleted from database. When deleteLayers  parameters is false, only links are deleted and map layers remain in the system.