### PR TITLE
Add migration to fix styles

### DIFF
--- a/content-resources/src/main/resources/flyway/oskari/V1_55_4__fix_null_styles.sql
+++ b/content-resources/src/main/resources/flyway/oskari/V1_55_4__fix_null_styles.sql
@@ -1,0 +1,1 @@
+update oskari_maplayer set style = '' where style = 'null';


### PR DESCRIPTION
Somewhere along the line the admin-functionality has saved null values as "null" strings to styles. This fixes the issue.