### PR TITLE
Statistics datasource complete check fix

### DIFF
--- a/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/DataStatus.java
+++ b/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/DataStatus.java
@@ -18,7 +18,7 @@ public class DataStatus {
     private Instant updateStarted;
 
     public DataStatus(String status) {
-        this(JSONHelper.createJSONObject(status));
+        this(status == null ? null : JSONHelper.createJSONObject(status));
     }
 
     private DataStatus(JSONObject status) {

--- a/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/StatisticalDatasourcePlugin.java
+++ b/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/StatisticalDatasourcePlugin.java
@@ -156,14 +156,11 @@ public abstract class StatisticalDatasourcePlugin {
                 startUpdater(cacheEmpty);
             }
         }
-
-        boolean complete;
-        if (updater == null) {
-            // We aren't running an update - don't poll back for more complete list
-            complete = true;
-        } else {
-            // Only poll back for more complete list if we are running a full update (cache was empty)
-            complete = updater.isFullUpdate();
+        // If we aren't running an update - don't poll back for more complete list
+        boolean complete = true;
+        // Only poll back for more complete list if we are running a full update (cache was empty)
+        if (cacheEmpty && updater != null && updater.isFullUpdate()) {
+            complete = false;
         }
 
         // filter by user


### PR DESCRIPTION
Setting complete boolean from isFullUpdate was opposite that should. Seems that updater isn't set to null when complete. So now complete is checked firstly from cacheEmpty.