### PR TITLE
Handle missing locale

### DIFF
--- a/service-map/src/main/java/org/oskari/maplayer/admin/LayerValidator.java
+++ b/service-map/src/main/java/org/oskari/maplayer/admin/LayerValidator.java
@@ -14,6 +14,9 @@ import java.util.Map;
 public class LayerValidator {
 
     public static Map<String, Map<String, String>> validateLocale(Map<String, Map<String, String>> locale) throws ServiceRuntimeException {
+        if (locale == null) {
+            throw new ServiceRuntimeException("Localization for layer names missing");
+        }
         String lang = PropertyUtil.getDefaultLanguage();
         Map<String, String> langLocale = locale.getOrDefault(lang, Collections.emptyMap());
         if (langLocale.get("name") == null) {


### PR DESCRIPTION
Fixes an issue where null locale resulted in npe and `{error: "Unhandled exception occured"}` response for frontend. Happens while frontend doesn't validate layer fields perfectly and user hasn't given any end-user/UI name for the layer (locale).