### PR TITLE
Add parser for querystring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,6 @@
 
         <staxon.version>1.2</staxon.version>
         <lambdaj.version>2.3.3</lambdaj.version>
-        <kevinsawicki.http-request.version>4.0</kevinsawicki.http-request.version>
         <jsoup.version>1.12.1</jsoup.version>
         <ibatis.version>2.3.4.726</ibatis.version>
         <axiom.version>1.2.20</axiom.version>
@@ -716,11 +715,6 @@
                 <groupId>com.googlecode.lambdaj</groupId>
                 <artifactId>lambdaj</artifactId>
                 <version>${lambdaj.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.github.kevinsawicki</groupId>
-                <artifactId>http-request</artifactId>
-                <version>${kevinsawicki.http-request.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jsoup</groupId>

--- a/service-base/pom.xml
+++ b/service-base/pom.xml
@@ -55,10 +55,6 @@
             <artifactId>lambdaj</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.kevinsawicki</groupId>
-            <artifactId>http-request</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
         </dependency>

--- a/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
@@ -732,7 +732,9 @@ public class IOHelper {
      * @param username
      * @param password
      * @return response body
+     * @deprecated
      */
+    @Deprecated
     public static String getRequest(String url, String contentType,
                                     String username, String password, String host, String authorization) {
         HttpRequest request = null;
@@ -850,7 +852,9 @@ public class IOHelper {
      * @param username
      * @param password
      * @return response body
+     * @deprecated
      */
+    @Deprecated
     public static String postRequest(String url, String contentType,
                                      String data, String username, String password, String host,
                                      String authorization) {

--- a/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
@@ -1,6 +1,5 @@
 package fi.nls.oskari.util;
 
-import com.github.kevinsawicki.http.HttpRequest;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 import org.apache.commons.codec.binary.Base64;
@@ -694,84 +693,6 @@ public class IOHelper {
         return in;
     }
 
-    /**
-     * HTTP request method with optional basic authentication and contentType
-     * definition
-     *
-     * @param url
-     * @param data          data to post (if empty, GET method otherwise POST)
-     * @param username
-     * @param password
-     * @param host          host name for header params (optional)
-     * @param authorization (optional)
-     * @param contentType
-     * @return response body
-     */
-    public static String httpRequestAction(String url, String data, String username,
-                                           String password, String host, String authorization,
-                                           String contentType) {
-        String response = null;
-
-        if (!data.isEmpty()) {
-            response = postRequest(url, contentType, data, username, password,
-                    host, authorization);
-
-        } else
-            response = getRequest(url, contentType, username, password, host,
-                    authorization);
-
-        return response;
-    }
-
-    /**
-     * HTTP GET method with optional basic authentication and contentType
-     * definition
-     *
-     * @param url
-     * @param contentType
-     * @param username
-     * @param password
-     * @return response body
-     * @deprecated
-     */
-    @Deprecated
-    public static String getRequest(String url, String contentType,
-                                    String username, String password, String host, String authorization) {
-        HttpRequest request = null;
-        try {
-
-            HttpRequest.keepAlive(false);
-            if (username != null && !username.isEmpty()) {
-                request = HttpRequest.get(url).basic(username, password)
-                        .accept(contentType).connectTimeout(30)
-                        .acceptGzipEncoding().uncompress(true).trustAllCerts()
-                        .trustAllHosts();
-            } else {
-                request = HttpRequest.get(url).contentType(contentType)
-                        .connectTimeout(30).acceptGzipEncoding().uncompress(
-                                true).trustAllCerts().trustAllHosts();
-            }
-            if (host != null && !host.isEmpty()) {
-                request.header("Host", host);
-            }
-
-            if (authorization != null && !authorization.isEmpty()) {
-                request.authorization(authorization);
-            }
-            if (request.ok() || request.code() == 304)
-                return request.body();
-            else {
-                handleHTTPError("GET", url, request.code());
-            }
-
-        } catch (HttpRequest.HttpRequestException e) {
-            handleHTTPRequestFail(url, e);
-        } catch (Exception e) {
-            handleHTTPRequestFail(url, e);
-        }
-        return null;
-    }
-
     public static HttpURLConnection postForm(String url, Map<String, String> keyValuePairs)
             throws IOException {
         String requestBody = getParams(keyValuePairs);
@@ -837,71 +758,6 @@ public class IOHelper {
             baos.writeTo(out);
         }
         return conn;
-    }
-
-    public static String postRequest(String url) {
-        return postRequest(url, "", "", "", null, null, null);
-    }
-
-    /**
-     * HTTP POST method with optional basic authentication and contentType
-     * definition
-     *
-     * @param url
-     * @param contentType
-     * @param username
-     * @param password
-     * @return response body
-     * @deprecated
-     */
-    @Deprecated
-    public static String postRequest(String url, String contentType,
-                                     String data, String username, String password, String host,
-                                     String authorization) {
-        HttpRequest request = null;
-        String response = null;
-        try {
-
-            HttpRequest.keepAlive(false);
-            if (username != null && !username.isEmpty()) {
-                request = HttpRequest.post(url)
-                        .basic(username, password)
-                        .contentType(contentType)
-                        .connectTimeout(getConnectionTimeoutMs())
-                        .acceptGzipEncoding()
-                        .uncompress(true)
-                        .trustAllCerts()
-                        .trustAllHosts()
-                        .send(data);
-            } else {
-                request = HttpRequest.post(url)
-                        .contentType(contentType)
-                        .connectTimeout(getConnectionTimeoutMs())
-                        .acceptGzipEncoding()
-                        .uncompress(true)
-                        .trustAllCerts()
-                        .trustAllHosts()
-                        .send(data);
-            }
-            if (host != null && !host.isEmpty()) {
-                request.header("Host", host);
-            }
-
-            if (authorization != null && !authorization.isEmpty()) {
-                request.authorization(authorization);
-            }
-            if (request.ok() || request.code() == 304)
-                response = request.body();
-            else {
-                handleHTTPError("POST", url, request.code());
-            }
-
-        } catch (HttpRequest.HttpRequestException e) {
-            handleHTTPRequestFail(url, e);
-        } catch (Exception e) {
-            handleHTTPRequestFail(url, e);
-        }
-        return response;
     }
 
     /**

--- a/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
@@ -2,24 +2,23 @@ package fi.nls.oskari.util;
 
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.service.ServiceRuntimeException;
 import org.apache.commons.codec.binary.Base64;
 
 import javax.net.ssl.*;
 import java.io.*;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.net.URLEncoder;
+import java.net.*;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
+import java.util.AbstractMap.SimpleImmutableEntry;
+
+import static java.util.stream.Collectors.toList;
 
 /*
 Methods using HttpRequest were moved from a class called wmshelper and are
@@ -113,7 +112,7 @@ public class IOHelper {
     public static List<String> readLines(InputStream in, Charset cs) throws IOException {
         try (BufferedReader br = new BufferedReader(
                 new InputStreamReader(in, cs))) {
-            return br.lines().collect(Collectors.toList());
+            return br.lines().collect(toList());
         } finally {
             in.close();
         }
@@ -889,6 +888,51 @@ public class IOHelper {
         }
 
         return parts[0] + "://" + parts[1].replaceAll("//", "/");
+    }
+
+    public static Map<String, List<String>> parseQuerystring(String url) {
+        if (url == null) {
+            return Collections.emptyMap();
+        }
+        try {
+            return parseQuerystring(new URL(url));
+        } catch (MalformedURLException e) {
+            throw new ServiceRuntimeException("Malformed URL: " + url, e);
+        }
+    }
+
+    // Java 8 impl from from https://stackoverflow.com/questions/13592236/parse-a-uri-string-into-name-value-collection
+    public static Map<String, List<String>> parseQuerystring(URL url) {
+        if (url == null) {
+            return Collections.emptyMap();
+        }
+        String query = url.getQuery();
+        if (query == null || query.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        return Arrays.stream(query.split("&"))
+                .map(IOHelper::splitQueryParameter)
+                .collect(Collectors.groupingBy(SimpleImmutableEntry::getKey, LinkedHashMap::new, Collectors.mapping(Map.Entry::getValue, Collectors.toList())));
+    }
+
+    public static String removeQueryString(String url) {
+        try {
+            URI uri = new URI(url);
+            return new URI(uri.getScheme(),
+                    uri.getAuthority(),
+                    uri.getPath(),
+                    null, // Ignore the query part of the input url
+                    uri.getFragment()).toString();
+        } catch (URISyntaxException e) {
+            throw new ServiceRuntimeException("Malformed URI: " + url, e);
+        }
+    }
+
+    private static SimpleImmutableEntry<String, String> splitQueryParameter(String it) {
+        final int idx = it.indexOf("=");
+        final String key = idx > 0 ? it.substring(0, idx) : it;
+        final String value = idx > 0 && it.length() > idx + 1 ? it.substring(idx + 1) : null;
+        return new SimpleImmutableEntry<>(key, value);
     }
 
     /**

--- a/service-map/src/main/java/fi/nls/oskari/map/analysis/service/AnalysisDataService.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/analysis/service/AnalysisDataService.java
@@ -15,6 +15,7 @@ import fi.nls.oskari.util.PropertyUtil;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.net.HttpURLConnection;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -85,16 +86,21 @@ public class AnalysisDataService {
                     analysis.getId(), fields, analysislayer.getFieldtypeMap(), geometryProperty, params.getResponsePrefix());
             log.debug("Produced WFS-T:\n" + wfst);
 
-            final String response = IOHelper.httpRequestAction(wfsURL, wfst,
-                    wpsUser, wpsUserPass, null, null, "application/xml");
+            final HttpURLConnection conn = IOHelper.getConnection(wfsURL, wpsUser, wpsUserPass);
+            IOHelper.post(conn, "application/xml", wfst);
+            final String response = IOHelper.readString(conn.getInputStream());
             log.debug("Posted WFS-T, got", response);
 
             // If exceptions, return null
             // Check, if exception result set
-            if (response.indexOf("ows:Exception") > -1) return null;
+            if (response.indexOf("ows:Exception") > -1) {
+                return null;
+            }
 
             // Check, if any inserted data
-            if (response.indexOf("totalInserted>0") > -1) return null;
+            if (response.indexOf("totalInserted>0") > -1) {
+                return null;
+            }
 
             // Set fields and field order, if fields are known before analysis
 

--- a/service-map/src/main/java/fi/nls/oskari/map/analysis/service/AnalysisWebProcessingService.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/analysis/service/AnalysisWebProcessingService.java
@@ -152,15 +152,17 @@ public class AnalysisWebProcessingService {
      * @throws ServiceException
      */
     public String requestWFS2(final String wfsUrl, final String request_data, final String user, final String pw) throws ServiceException {
-        String response = null;
-        try {
-            // GetFeature response
-            response = IOHelper.httpRequestAction(wfsUrl, request_data,user, pw, null, null, "application/json");
 
-        } catch (Exception e) {
+        try {
+            final HttpURLConnection conn = IOHelper.getConnection(wfsUrl, user, pw);
+            IOHelper.writeHeader(conn, IOHelper.HEADER_ACCEPT, "application/json");
+            if (request_data != null && !request_data.isEmpty()) {
+                IOHelper.post(conn, "application/xml", request_data);
+            }
+            return IOHelper.readString(conn.getInputStream());
+        } catch (IOException e) {
             throw new ServiceException("request GetFeature failed due to", e);
         }
-        return response;
     }
 
     /**

--- a/service-map/src/main/java/org/oskari/maplayer/admin/LayerValidator.java
+++ b/service-map/src/main/java/org/oskari/maplayer/admin/LayerValidator.java
@@ -1,17 +1,19 @@
 package org.oskari.maplayer.admin;
 
 import fi.nls.oskari.service.ServiceRuntimeException;
+import fi.nls.oskari.util.ConversionHelper;
+import fi.nls.oskari.util.IOHelper;
 import fi.nls.oskari.util.PropertyUtil;
 import org.oskari.util.HtmlHelper;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
 
 public class LayerValidator {
+
+    private static final Set<String> RESERVED_PARAMS = ConversionHelper.asSet("service", "request", "version");
 
     public static Map<String, Map<String, String>> validateLocale(Map<String, Map<String, String>> locale) throws ServiceRuntimeException {
         String lang = PropertyUtil.getDefaultLanguage();
@@ -24,17 +26,22 @@ public class LayerValidator {
     }
 
     public static String validateUrl(final String url) throws ServiceRuntimeException {
-        // TODO remove query part with ? check or with URL object
-        // TODO: can we remove the whole querystring or should we just remove problematic params like service and request?
-        String baseUrl = url.contains("?") ? url.substring(0, url.indexOf("?")) : url;
-        baseUrl = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
         try {
-            // check that it's a valid url by creating an URL object...
-            new URL(url);
-        } catch (MalformedURLException e) {
+            String baseURL = IOHelper.removeQueryString(url);
+            // remove problematic parameters from URL
+            Map<String, List<String>> params = IOHelper.parseQuerystring(url);
+            List<String> problematicParams = params.keySet()
+                    .stream().filter(key -> RESERVED_PARAMS.contains(key.toLowerCase())).collect(Collectors.toList());
+            // TODO: these are only problematic for OGC urls. Maybe we should skip validation for non-OGC layers?
+            for (String param : problematicParams) {
+                params.remove(param);
+            }
+            String querystring = IOHelper.createQuerystring(params);
+            // return whitelisted params and base url
+            return IOHelper.addQueryString(baseURL, querystring);
+        } catch (Exception e) {
             throw new ServiceRuntimeException("Invalid url: " + url, "invalid_field_value");
         }
-        return baseUrl;
     }
 
     public static String cleanGFIContent(String gfiContent) {

--- a/service-statistics-sotka/src/main/java/fi/nls/oskari/control/statistics/plugins/sotka/parser/SotkaRegionParser.java
+++ b/service-statistics-sotka/src/main/java/fi/nls/oskari/control/statistics/plugins/sotka/parser/SotkaRegionParser.java
@@ -5,14 +5,15 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.kevinsawicki.http.HttpRequest;
 
 import fi.nls.oskari.cache.JedisManager;
 import fi.nls.oskari.control.statistics.plugins.APIException;
 import fi.nls.oskari.control.statistics.plugins.sotka.SotkaConfig;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.util.IOHelper;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -125,7 +126,11 @@ public class SotkaRegionParser {
         String json = JedisManager.get(cacheKey);
 
         if (json == null) {
-            json = HttpRequest.get(url).body();
+            try {
+                json = IOHelper.getURL(url);
+            } catch (IOException e) {
+                throw new APIException("Couldn't read response from SotkaNET: " + url, e);
+            }
             JedisManager.setex(cacheKey, JedisManager.EXPIRY_TIME_DAY, json);
         }
         try {


### PR DESCRIPTION
Note! Includes commits from #528.

Add methods to IOHelper to parse query string to allow easy manipulation of urls. Use methods to only filter out problematic parameters when validating layer data.