### PR TITLE
URL handling for capabilities in layer admin

### DIFF
--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/ServiceCapabilitiesHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/ServiceCapabilitiesHandler.java
@@ -12,6 +12,7 @@ import fi.nls.oskari.service.ServiceUnauthorizedException;
 import fi.nls.oskari.util.PropertyUtil;
 import fi.nls.oskari.util.ResponseHelper;
 import org.oskari.admin.LayerCapabilitiesHelper;
+import org.oskari.maplayer.admin.LayerValidator;
 import org.oskari.maplayer.model.ServiceCapabilitiesResult;
 
 import javax.servlet.http.HttpServletResponse;
@@ -70,26 +71,13 @@ public class ServiceCapabilitiesHandler extends AbstractLayerAdminHandler {
     }
 
     private ServiceCapabilitiesResult getLayersFromService(ActionParameters params) throws ServiceException, ActionException {
-        final String url = validateUrl(params.getRequiredParam(PARAM_CAPABILITIES_URL));
+        final String url = LayerValidator.validateUrl(params.getRequiredParam(PARAM_CAPABILITIES_URL));
         final String type = params.getRequiredParam(PARAM_TYPE);
         final String version = params.getRequiredParam(PARAM_VERSION);
         final String username = params.getHttpParam(PARAM_USERNAME, "");
         final String password = params.getHttpParam(PARAM_PASSWORD, "");
         final String currentSrs = params.getHttpParam(PARAM_CURRENT_SRS, PropertyUtil.get("oskari.native.srs", "EPSG:4326"));
         return LayerCapabilitiesHelper.getCapabilitiesResults(url, type, version, username, password, currentSrs);
-    }
-
-    private String validateUrl(final String url) throws ActionParamsException {
-        // TODO remove query part with ? check or with URL object
-        String baseUrl = url.contains("?") ? url.substring(0, url.indexOf("?")) : url;
-        baseUrl = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
-        try {
-            // check that it's a valid url by creating an URL object...
-            new URL(url);
-        } catch (MalformedURLException e) {
-            throw new ActionParamsException("Invalid url: " + url, ERROR_INVALID_FIELD_VALUE);
-        }
-        return baseUrl;
     }
 
     private boolean isServiceUnauthrorizedException(Throwable t) {

--- a/service-map/src/main/java/fi/nls/oskari/service/capabilities/CapabilitiesCacheService.java
+++ b/service-map/src/main/java/fi/nls/oskari/service/capabilities/CapabilitiesCacheService.java
@@ -5,6 +5,7 @@ import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.service.OskariComponent;
 import fi.nls.oskari.service.ServiceException;
+import fi.nls.oskari.service.ServiceUnauthorizedException;
 import fi.nls.oskari.util.IOHelper;
 import fi.nls.oskari.util.PropertyUtil;
 import fi.nls.oskari.util.XmlHelper;
@@ -97,6 +98,9 @@ public abstract class CapabilitiesCacheService extends OskariComponent {
             conn.setReadTimeout(TIMEOUT_MS);
 
             int sc = conn.getResponseCode();
+            if (sc == HttpURLConnection.HTTP_FORBIDDEN || sc == HttpURLConnection.HTTP_UNAUTHORIZED) {
+                throw new ServiceUnauthorizedException("Wrong credentials for service");
+            }
             if (sc != HttpURLConnection.HTTP_OK) {
                 throw new ServiceException("Unexpected Status code: " + sc);
             }


### PR DESCRIPTION
Changed to use LayerValidator for consistency. Now allows URL-parameters that are not "problematic" (ie. request/service/version).

Also added http response code detection for capabilities service for handling wrong credentials. This was added to WFS-capabilities on different PR a couple of months ago but it was missing from WMS/WMTS capabilities.