### PR TITLE
Error handling for capabilities parsing

### DIFF
--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/ServiceCapabilitiesHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/ServiceCapabilitiesHandler.java
@@ -16,7 +16,10 @@ import org.oskari.maplayer.admin.LayerValidator;
 import org.oskari.maplayer.model.ServiceCapabilitiesResult;
 
 import javax.servlet.http.HttpServletResponse;
+import javax.xml.stream.XMLStreamException;
+import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.SocketTimeoutException;
 import java.net.URL;
 
 @OskariActionRoute("ServiceCapabilities")
@@ -62,8 +65,15 @@ public class ServiceCapabilitiesHandler extends AbstractLayerAdminHandler {
             params.getResponse().setContentType("application/json;charset=UTF-8");
             ResponseHelper.writeResponse(params, output);
         } catch (Exception e) {
-            if (isServiceUnauthrorizedException(e)) {
+            Throwable rootcause = getRootCause(e);
+            if (rootcause instanceof ServiceUnauthorizedException) {
                 ResponseHelper.writeError(params, e.getMessage(), HttpServletResponse.SC_UNAUTHORIZED);
+            } else if (rootcause instanceof SocketTimeoutException) {
+                ResponseHelper.writeError(params, e.getMessage(), HttpServletResponse.SC_REQUEST_TIMEOUT);
+            } else if (rootcause instanceof IOException) {
+                ResponseHelper.writeError(params, e.getMessage(), HttpServletResponse.SC_BAD_REQUEST);
+            } else if (rootcause instanceof XMLStreamException) {
+                ResponseHelper.writeError(params, e.getMessage(), HttpServletResponse.SC_EXPECTATION_FAILED);
             } else {
                 ResponseHelper.writeError(params, e.getMessage());
             }
@@ -82,6 +92,7 @@ public class ServiceCapabilitiesHandler extends AbstractLayerAdminHandler {
 
     private boolean isServiceUnauthrorizedException(Throwable t) {
         return getRootCause(t) instanceof ServiceUnauthorizedException;
+
     }
 
     private Throwable getRootCause(Throwable e) {

--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/ServiceCapabilitiesHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/ServiceCapabilitiesHandler.java
@@ -72,7 +72,7 @@ public class ServiceCapabilitiesHandler extends AbstractLayerAdminHandler {
                 ResponseHelper.writeError(params, e.getMessage(), HttpServletResponse.SC_REQUEST_TIMEOUT);
             } else if (rootcause instanceof IOException) {
                 ResponseHelper.writeError(params, e.getMessage(), HttpServletResponse.SC_BAD_REQUEST);
-            } else if (rootcause instanceof XMLStreamException) {
+            } else if (rootcause instanceof XMLStreamException || rootcause instanceof ServiceException) {
                 ResponseHelper.writeError(params, e.getMessage(), HttpServletResponse.SC_EXPECTATION_FAILED);
             } else {
                 ResponseHelper.writeError(params, e.getMessage());

--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/ServiceCapabilitiesHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/ServiceCapabilitiesHandler.java
@@ -12,6 +12,7 @@ import fi.nls.oskari.service.ServiceUnauthorizedException;
 import fi.nls.oskari.util.PropertyUtil;
 import fi.nls.oskari.util.ResponseHelper;
 import org.oskari.admin.LayerCapabilitiesHelper;
+import org.oskari.maplayer.admin.LayerValidator;
 import org.oskari.maplayer.model.ServiceCapabilitiesResult;
 
 import javax.servlet.http.HttpServletResponse;
@@ -70,26 +71,13 @@ public class ServiceCapabilitiesHandler extends AbstractLayerAdminHandler {
     }
 
     private ServiceCapabilitiesResult getLayersFromService(ActionParameters params) throws ServiceException, ActionException {
-        final String url = validateUrl(params.getRequiredParam(PARAM_CAPABILITIES_URL));
+        final String url = LayerValidator.validateUrl(params.getRequiredParam(PARAM_CAPABILITIES_URL));
         final String type = params.getRequiredParam(PARAM_TYPE);
         final String version = params.getRequiredParam(PARAM_VERSION);
         final String username = params.getHttpParam(PARAM_USERNAME, "");
         final String password = params.getHttpParam(PARAM_PASSWORD, "");
         final String currentSrs = params.getHttpParam(PARAM_CURRENT_SRS, PropertyUtil.get("oskari.native.srs", "EPSG:4326"));
         return LayerCapabilitiesHelper.getCapabilitiesResults(url, type, version, username, password, currentSrs);
-    }
-
-    private String validateUrl(final String url) throws ActionParamsException {
-        // TODO remove query part with ? check or with URL object
-        String baseUrl = url.contains("?") ? url.substring(0, url.indexOf("?")) : url;
-        baseUrl = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
-        try {
-            // check that it's a valid url by creating an URL object...
-            new URL(url);
-        } catch (MalformedURLException e) {
-            throw new ActionParamsException("Invalid url: " + url, ERROR_INVALID_FIELD_VALUE);
-        }
-        return baseUrl;
     }
 
     private boolean isServiceUnauthrorizedException(Throwable t) {

--- a/service-map/src/main/java/fi/nls/oskari/service/capabilities/CapabilitiesCacheService.java
+++ b/service-map/src/main/java/fi/nls/oskari/service/capabilities/CapabilitiesCacheService.java
@@ -5,6 +5,7 @@ import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.service.OskariComponent;
 import fi.nls.oskari.service.ServiceException;
+import fi.nls.oskari.service.ServiceUnauthorizedException;
 import fi.nls.oskari.util.IOHelper;
 import fi.nls.oskari.util.PropertyUtil;
 import fi.nls.oskari.util.XmlHelper;
@@ -97,6 +98,9 @@ public abstract class CapabilitiesCacheService extends OskariComponent {
             conn.setReadTimeout(TIMEOUT_MS);
 
             int sc = conn.getResponseCode();
+            if (sc == HttpURLConnection.HTTP_FORBIDDEN || sc == HttpURLConnection.HTTP_UNAUTHORIZED) {
+                throw new ServiceUnauthorizedException("Wrong credentials for service");
+            }
             if (sc != HttpURLConnection.HTTP_OK) {
                 throw new ServiceException("Unexpected Status code: " + sc);
             }

--- a/service-map/src/main/java/fi/nls/oskari/wfs/WFSCapabilitiesService.java
+++ b/service-map/src/main/java/fi/nls/oskari/wfs/WFSCapabilitiesService.java
@@ -67,12 +67,12 @@ public class WFSCapabilitiesService {
         } catch (IOException e) {
 			if (isUnauthorizedException(e)) {
 				throw new ServiceUnauthorizedException("Unauthorized response received from url: " + url + " Message: " + e.getMessage());
-			}else {
-				throw new ServiceException("Couldn't read/get wfs capabilities response from url: " + url + " Message: " + e.getMessage());
+			} else {
+				throw new ServiceException("Couldn't read/get wfs capabilities response from url: " + url + " Message: " + e.getMessage(), e);
 			}
 		} 
         catch (Exception ex) {
-            throw new ServiceException("Couldn't read/get wfs capabilities response from url: " + url + " Message: " + ex.getMessage());
+            throw new ServiceException("Couldn't read/get wfs capabilities response from url: " + url + " Message: " + ex.getMessage(), ex);
         }
     }
     

--- a/service-map/src/main/java/fi/nls/oskari/wfs/WFSCapabilitiesService.java
+++ b/service-map/src/main/java/fi/nls/oskari/wfs/WFSCapabilitiesService.java
@@ -66,7 +66,11 @@ public class WFSCapabilitiesService {
             //IllegalStateException: Unable to parse GetCapabilities document
         } catch (IOException e) {
 			if (isUnauthorizedException(e)) {
-				throw new ServiceUnauthorizedException("Unauthorized response received from url: " + url + " Message: " + e.getMessage());
+                // Don't attach IOException as it is detected as root cause and wrong error is sent to user
+                throw new ServiceUnauthorizedException("Unauthorized response received from url: " + url + " Message: " + e.getMessage());
+            } else if (isParseException(e)) {
+			    // Don't attach IOException as it is detected as root cause and wrong error is sent to user
+                throw new ServiceException("Error parsing response from url: " + url + " Message: " + e.getMessage());
 			} else {
 				throw new ServiceException("Couldn't read/get wfs capabilities response from url: " + url + " Message: " + e.getMessage(), e);
 			}
@@ -80,6 +84,10 @@ public class WFSCapabilitiesService {
     	return e.getMessage() != null && (
     			e.getMessage().contains("Server returned HTTP response code: 401") ||
     				e.getMessage().contains("Server returned HTTP response code: 403"))	;
+    }
+
+    private static boolean isParseException(IOException e) {
+        return e.getMessage() != null && e.getMessage().contains("Error parsing capabilities document");
     }
 
     private static String getUrl(String url, String version) throws ServiceException {

--- a/service-map/src/main/java/fi/nls/oskari/wfs/WFSCapabilitiesService.java
+++ b/service-map/src/main/java/fi/nls/oskari/wfs/WFSCapabilitiesService.java
@@ -1,5 +1,6 @@
 package fi.nls.oskari.wfs;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
@@ -103,6 +104,9 @@ public class WFSCapabilitiesService {
                 return getCapabilitiesWFS3( url, user, pw, systemCRSs);
             }
             return getCapabilitiesWFS( url, version, user, pw, systemCRSs);
+        } catch (JsonParseException e) {
+            // Don't attach JsonParseException as its an IOException which is detected as root cause and wrong error is sent to user
+            throw new ServiceException("Error parsing response from url: " + url + " Message: " + e.getMessage());
         } catch (Exception e) {
             throw new ServiceException ("Failed to get capabilities version: " + version + " from url: " + url, e);
         }
@@ -160,6 +164,7 @@ public class WFSCapabilitiesService {
         // Do we need to parse title from WFS3Content.links
         return result;
     }
+
     private static OskariLayer toOskariLayer(String layerName, String title, String version,
                                              String url, String user, String pw) {
         final OskariLayer ml = new OskariLayer();


### PR DESCRIPTION
Admin requesting for layer capabilities when adding layers will now get an error code based on the problem:

- 401 if credentials were wrong
- 408 if there was a timeout connecting to the service
- 400 for other connection issues
- 417 if the response from the service was not what we expected/parsing problem
- 500 for a generic no go