### PR TITLE
Attach an IOException as cause so end user gets appropriate message

### DIFF
--- a/service-map/src/main/java/fi/nls/oskari/service/capabilities/CapabilitiesCacheService.java
+++ b/service-map/src/main/java/fi/nls/oskari/service/capabilities/CapabilitiesCacheService.java
@@ -102,7 +102,8 @@ public abstract class CapabilitiesCacheService extends OskariComponent {
                 throw new ServiceUnauthorizedException("Wrong credentials for service");
             }
             if (sc != HttpURLConnection.HTTP_OK) {
-                throw new ServiceException("Unexpected Status code: " + sc);
+                String msg = "Unexpected status code: " + sc  + " from: " + request;
+                throw new ServiceException(msg, new IOException(msg));
             }
 
             String contentType = conn.getContentType();


### PR DESCRIPTION
As user is told about a parsing error if plain ServiceException is the root cause.