### PR TITLE
Move layer cache closer to DB level

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/layer/PermissionHelper.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/PermissionHelper.java
@@ -4,8 +4,6 @@ import org.oskari.permissions.PermissionService;
 import org.oskari.permissions.model.PermissionType;
 import org.oskari.permissions.model.Resource;
 
-import fi.nls.oskari.cache.Cache;
-import fi.nls.oskari.cache.CacheManager;
 import fi.nls.oskari.control.ActionDeniedException;
 import fi.nls.oskari.control.ActionException;
 import fi.nls.oskari.control.ActionParamsException;
@@ -24,8 +22,6 @@ import java.util.Optional;
 public class PermissionHelper {
 
     private static final Logger LOG = LogFactory.getLogger(PermissionHelper.class);
-    private static final String LAYER_CACHE_NAME = "layer_resources";
-    private final Cache<OskariLayer> layerCache = CacheManager.getCache(PermissionHelper.class.getName() + LAYER_CACHE_NAME);
     private OskariLayerService layerService;
     private PermissionService permissionsService;
 
@@ -70,17 +66,7 @@ public class PermissionHelper {
      * @return layer
      */
     private OskariLayer getLayer(final int id) {
-        String cacheKey = Integer.toString(id);
-        OskariLayer layer = layerCache.get(cacheKey);
-        if (layer != null) {
-            return layer;
-        }
-        layer = layerService.find(id);
-        if (layer != null) {
-            LOG.debug("Caching a layer with id ", id);
-            layerCache.put(cacheKey, layer);
-        }
-        return layer;
+        return layerService.find(id);
     }
 
     private Resource getResource(final OskariLayer layer) {

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/OskariLayerServiceMybatisImpl.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/OskariLayerServiceMybatisImpl.java
@@ -11,6 +11,8 @@ import java.util.stream.Collectors;
 
 import javax.sql.DataSource;
 
+import fi.nls.oskari.cache.Cache;
+import fi.nls.oskari.cache.CacheManager;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.SqlSession;
@@ -39,6 +41,7 @@ public class OskariLayerServiceMybatisImpl extends OskariLayerService {
 
     private static DataProviderService dataProviderService = ServiceFactory.getDataProviderService();
     private static OskariLayerGroupLinkService linkService = ServiceFactory.getOskariLayerGroupLinkService();
+    private final Cache<OskariLayer> layerCache = CacheManager.getCache(OskariLayerService.class.getName());
 
     private SqlSessionFactory factory = null;
 
@@ -229,6 +232,24 @@ public class OskariLayerServiceMybatisImpl extends OskariLayerService {
     }
 
     public OskariLayer find(int id) {
+        String cacheKey = Integer.toString(id);
+        OskariLayer layer = layerCache.get(cacheKey);
+        if (layer != null) {
+            return layer;
+        }
+        layer = findFromDB(id);
+        if (layer != null) {
+            LOG.debug("Caching a layer with id ", id);
+            layerCache.put(cacheKey, layer);
+        }
+        return layer;
+    }
+
+    private void flushFromCache(int id) {
+        layerCache.remove(Integer.toString(id));
+    }
+
+    private OskariLayer findFromDB(int id) {
         LOG.debug("find by id: " + id);
         final SqlSession session = factory.openSession();
         try {
@@ -357,12 +378,14 @@ public class OskariLayerServiceMybatisImpl extends OskariLayerService {
         return Collections.emptyMap();
     }
 
+
     public void update(final OskariLayer layer) {
         LOG.debug("update layer");
         final SqlSession session = factory.openSession();
         try {
             final OskariLayerMapper mapper = session.getMapper(OskariLayerMapper.class);
             mapper.update(layer);
+            flushFromCache(layer.getId());
             session.commit();
         } catch (Exception e) {
             throw new RuntimeException("Failed to update", e);
@@ -392,15 +415,12 @@ public class OskariLayerServiceMybatisImpl extends OskariLayerService {
         try {
             final OskariLayerMapper mapper = session.getMapper(OskariLayerMapper.class);
             mapper.delete(id);
+            flushFromCache(id);
             session.commit();
         } catch (Exception e) {
             LOG.error(e, "Couldn't delete with id:", id);
         } finally {
             session.close();
         }
-    }
-
-    public void delete(Map<String, String> parameterMap) {
-        delete(ConversionHelper.getInt(parameterMap.get("id"), -1));
     }
 }


### PR DESCRIPTION
So it can be flushed when layers are updated. Fixes an issue where for example layer attributes were not effective immediately when admin saves a layer with changes.