### PR TITLE
Allow URL-validator to pass a placeholder url for vectortiles

### DIFF
--- a/content-resources/src/main/java/flyway/userlayer/V1_0_11__populate_userlayer_wkt.java
+++ b/content-resources/src/main/java/flyway/userlayer/V1_0_11__populate_userlayer_wkt.java
@@ -6,11 +6,14 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import fi.nls.oskari.db.DBHandler;
+import fi.nls.oskari.db.DatasourceHelper;
 import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
 
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.util.PropertyUtil;
+
+import javax.sql.DataSource;
 
 public class V1_0_11__populate_userlayer_wkt implements JdbcMigration {
 
@@ -18,7 +21,13 @@ public class V1_0_11__populate_userlayer_wkt implements JdbcMigration {
     private static final int WGS84_SRID = 4326;
 
     public void migrate(Connection connection) throws Exception {
-        String srsName = getSrsName(DBHandler.getConnection());
+        // userlayers _can_ use other db than the default one
+        // -> Use connection to default db for this migration
+        DataSource ds = DatasourceHelper.getInstance().getDataSource();
+        if (ds == null) {
+            ds = DatasourceHelper.getInstance().createDataSource();
+        }
+        String srsName = getSrsName(ds.getConnection());
         if (srsName == null){
             LOG.error("Cannot get srs name for userlayer data");
             throw new IllegalArgumentException("Cannot get srs name for userlayer data");

--- a/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
@@ -897,14 +897,17 @@ public class IOHelper {
      * @return
      */
     public static String removeQueryString(String url) {
+        if (url == null) {
+            return null;
+        }
         try {
-            URI uri = new URI(url);
-            return new URI(uri.getScheme(),
-                    uri.getAuthority(),
-                    uri.getPath(),
-                    null, // Ignore the query part of the input url
-                    uri.getFragment()).toString();
-        } catch (URISyntaxException e) {
+            URL justForTestingSyntaxNotThrowingException = new URL(url);
+            int startIndex = url.indexOf("?");
+            if (startIndex == -1) {
+                return url;
+            }
+            return url.substring(0, startIndex);
+        } catch (MalformedURLException e) {
             throw new ServiceRuntimeException("Malformed URI: " + url, e);
         }
     }

--- a/service-map/src/test/java/org/oskari/maplayer/admin/LayerValidatorTest.java
+++ b/service-map/src/test/java/org/oskari/maplayer/admin/LayerValidatorTest.java
@@ -1,0 +1,32 @@
+package org.oskari.maplayer.admin;
+
+import fi.nls.oskari.service.ServiceRuntimeException;
+import org.junit.Test;
+
+import java.net.URL;
+
+import static org.junit.Assert.*;
+
+public class LayerValidatorTest {
+
+    @Test
+    public void validateUrl() {
+        String url = "https://api.maptiler.com/tiles/v3/{z}/{x}/{y}.pbf";
+        String validated = LayerValidator.validateUrl(url);
+        assertEquals("URL should be unchanged", url, validated);
+    }
+
+    @Test
+    public void validateUrlNull() {
+        String url = null;
+        String validated = LayerValidator.validateUrl(url);
+        assertNull("URL should be unchanged", validated);
+    }
+
+    @Test(expected = ServiceRuntimeException.class)
+    public void validateUrlNonvalid() {
+        String url = "sgashahah";
+        String validated = LayerValidator.validateUrl(url);
+        fail("Should have thrown exception");
+    }
+}


### PR DESCRIPTION
This prevents empty db from populating properly on sample-server-extension. Also fix how userlayer migration fetches a connection to "core db" in a similar way than in #502 was fixed for myplaces.