### PR TITLE
Make layer input validation more generic

### DIFF
--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerAdminHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerAdminHandler.java
@@ -196,7 +196,7 @@ public class LayerAdminHandler extends AbstractLayerAdminHandler {
         OskariLayer ml;
         try {
             ml = LayerAdminJSONHelper.fromJSON(layer);
-        } catch (ServiceRuntimeException e) {
+        } catch (IllegalArgumentException e) {
             // validation failed -> params/payload was faulty. Thrown exception tells reason but wrapping it in
             // ActionParamsException so its handled better with logging/user messaging etc
             throw new ActionParamsException(e.getMessage(), e);
@@ -297,7 +297,7 @@ public class LayerAdminHandler extends AbstractLayerAdminHandler {
             ml.setOptions(new JSONObject(layer.getOptions()));
         }
 
-        ml.setGfiContent(getOrDefaultStr(LayerValidator.cleanGFIContent(layer.getGfi_content()), ml.getGfiContent()));
+        ml.setGfiContent(getOrDefaultStr(LayerValidator.sanitizeGFIContent(layer.getGfi_content()), ml.getGfiContent()));
         ml.setGfiXslt(getOrDefaultStr(layer.getGfi_xslt(), ml.getGfiXslt()));
         ml.setGfiType(getOrDefaultStr(layer.getGfi_type(), ml.getGfiType()));
 

--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/ServiceCapabilitiesHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/ServiceCapabilitiesHandler.java
@@ -81,7 +81,7 @@ public class ServiceCapabilitiesHandler extends AbstractLayerAdminHandler {
     }
 
     private ServiceCapabilitiesResult getLayersFromService(ActionParameters params) throws ServiceException, ActionException {
-        final String url = LayerValidator.validateUrl(params.getRequiredParam(PARAM_CAPABILITIES_URL));
+        final String url = LayerValidator.sanitizeUrl(params.getRequiredParam(PARAM_CAPABILITIES_URL));
         final String type = params.getRequiredParam(PARAM_TYPE);
         final String version = params.getRequiredParam(PARAM_VERSION);
         final String username = params.getHttpParam(PARAM_USERNAME, "");

--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/ServiceCapabilitiesHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/ServiceCapabilitiesHandler.java
@@ -90,11 +90,6 @@ public class ServiceCapabilitiesHandler extends AbstractLayerAdminHandler {
         return LayerCapabilitiesHelper.getCapabilitiesResults(url, type, version, username, password, currentSrs);
     }
 
-    private boolean isServiceUnauthrorizedException(Throwable t) {
-        return getRootCause(t) instanceof ServiceUnauthorizedException;
-
-    }
-
     private Throwable getRootCause(Throwable e) {
         if (e == null) {
             return null;

--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/ServiceCapabilitiesHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/ServiceCapabilitiesHandler.java
@@ -6,7 +6,6 @@ import fi.nls.oskari.annotation.OskariActionRoute;
 import fi.nls.oskari.control.ActionDeniedException;
 import fi.nls.oskari.control.ActionException;
 import fi.nls.oskari.control.ActionParameters;
-import fi.nls.oskari.control.ActionParamsException;
 import fi.nls.oskari.service.ServiceException;
 import fi.nls.oskari.service.ServiceUnauthorizedException;
 import fi.nls.oskari.util.PropertyUtil;
@@ -18,9 +17,7 @@ import org.oskari.maplayer.model.ServiceCapabilitiesResult;
 import javax.servlet.http.HttpServletResponse;
 import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.SocketTimeoutException;
-import java.net.URL;
 
 @OskariActionRoute("ServiceCapabilities")
 public class ServiceCapabilitiesHandler extends AbstractLayerAdminHandler {
@@ -30,7 +27,6 @@ public class ServiceCapabilitiesHandler extends AbstractLayerAdminHandler {
     private static final String PARAM_USERNAME = "user";
     private static final String PARAM_PASSWORD = "pw";
     private static final String PARAM_TYPE = "type";
-    private static final String ERROR_INVALID_FIELD_VALUE = "invalid_field_value";
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     static {

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/OskariLayer.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/OskariLayer.java
@@ -24,6 +24,7 @@ public class OskariLayer extends JSONLocalizedNameAndTitle implements Comparable
     public static final String TYPE_ARCGIS_CACHE = "arcgislayer";
 
     public static final String TYPE_3DTILES = "tiles3dlayer";
+    public static final String TYPE_BINGLAYER = "bingmapslayer";
     public static final String TYPE_VECTOR_TILE = "vectortilelayer";
 
     private int id = -1;

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/OskariLayer.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/OskariLayer.java
@@ -18,7 +18,11 @@ public class OskariLayer extends JSONLocalizedNameAndTitle implements Comparable
     public static final String TYPE_STATS = "statslayer";
     public static final String TYPE_ANALYSIS = "analysislayer";
     public static final String TYPE_USERLAYER = "userlayer";
+    // "ArcGIS rest"
     public static final String TYPE_ARCGIS93 = "arcgis93layer";
+    // "ArcGIS image cache"
+    public static final String TYPE_ARCGIS_CACHE = "arcgislayer";
+
     public static final String TYPE_3DTILES = "tiles3dlayer";
     public static final String TYPE_VECTOR_TILE = "vectortilelayer";
 

--- a/service-map/src/main/java/org/oskari/maplayer/admin/LayerAdminJSONHelper.java
+++ b/service-map/src/main/java/org/oskari/maplayer/admin/LayerAdminJSONHelper.java
@@ -40,7 +40,7 @@ public class LayerAdminJSONHelper {
     }
 
     public static OskariLayer fromJSON(MapLayer model) {
-        LayerValidator.validateLayerInput(model);
+        LayerValidator.validateAndSanitizeLayerInput(model);
         OskariLayer layer = new OskariLayer();
         Integer id = model.getId();
         if (id != null) {

--- a/service-map/src/main/java/org/oskari/maplayer/admin/LayerAdminJSONHelper.java
+++ b/service-map/src/main/java/org/oskari/maplayer/admin/LayerAdminJSONHelper.java
@@ -40,7 +40,7 @@ public class LayerAdminJSONHelper {
     }
 
     public static OskariLayer fromJSON(MapLayer model) {
-        // TODO: add more validation for values
+        LayerValidator.validateLayerInput(model);
         OskariLayer layer = new OskariLayer();
         Integer id = model.getId();
         if (id != null) {
@@ -48,20 +48,12 @@ public class LayerAdminJSONHelper {
             layer.setId(model.getId());
         }
         layer.setType(model.getType());
-        // TODO: mark mandatory fields/layer type in a more generic fashion
-        // TODO: relay mandatory field info to frontend for UI so frontend can show what is mandatory
-        //  and validate before server is even called
-        if (!"tiles3dlayer".equals(layer.getType())) {
-            layer.setUrl(LayerValidator.validateUrl(model.getUrl()));
-        }
+        layer.setUrl(model.getUrl());
         layer.setUsername(model.getUsername());
         layer.setPassword(model.getPassword());
-        if (model.getVersion() != null) {
-            // version has non-null requirement in db (empty string is ok)
-            layer.setVersion(model.getVersion());
-        }
+        layer.setVersion(model.getVersion());
         layer.setName(model.getName());
-        layer.setLocale(new JSONObject(LayerValidator.validateLocale(model.getLocale())));
+        layer.setLocale(new JSONObject(model.getLocale()));
 
         layer.setSrs_name(model.getSrs());
         layer.setOpacity(model.getOpacity());
@@ -83,7 +75,7 @@ public class LayerAdminJSONHelper {
 
         layer.setGfiType(model.getGfi_type());
         layer.setGfiXslt(model.getGfi_xslt());
-        layer.setGfiContent(LayerValidator.cleanGFIContent(model.getGfi_content()));
+        layer.setGfiContent(model.getGfi_content());
 
         layer.setBaseMap(model.isBase_map());
         layer.setRealtime(model.isRealtime());

--- a/service-map/src/main/java/org/oskari/maplayer/admin/LayerValidator.java
+++ b/service-map/src/main/java/org/oskari/maplayer/admin/LayerValidator.java
@@ -1,17 +1,28 @@
 package org.oskari.maplayer.admin;
 
+import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.service.ServiceRuntimeException;
 import fi.nls.oskari.util.ConversionHelper;
 import fi.nls.oskari.util.IOHelper;
 import fi.nls.oskari.util.PropertyUtil;
+import org.oskari.maplayer.model.MapLayer;
 import org.oskari.util.HtmlHelper;
 
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.lang.reflect.Method;
 import java.util.*;
 import java.util.stream.Collectors;
 
 public class LayerValidator {
+
+    private static Map<String, Set<String>> MANDATORY_FIELDS = new HashMap<>();
+    static {
+        MANDATORY_FIELDS.put(OskariLayer.TYPE_WMS, ConversionHelper.asSet("name", "url", "version"));
+        MANDATORY_FIELDS.put(OskariLayer.TYPE_WFS, ConversionHelper.asSet("name", "url", "version"));
+        MANDATORY_FIELDS.put(OskariLayer.TYPE_WMTS, ConversionHelper.asSet("name", "url", "version"));
+        MANDATORY_FIELDS.put(OskariLayer.TYPE_VECTOR_TILE, ConversionHelper.asSet("url"));
+        MANDATORY_FIELDS.put(OskariLayer.TYPE_ARCGIS93, ConversionHelper.asSet("url"));
+        //MANDATORY_FIELDS.put(OskariLayer.TYPE_3DTILES, ConversionHelper.asSet("url"));
+    }
 
     private static final Set<String> RESERVED_PARAMS = ConversionHelper.asSet("service", "request", "version");
 
@@ -71,4 +82,66 @@ public class LayerValidator {
         return HtmlHelper.cleanHTMLString(gfiContent, tags, attributes, protocols);
     }
 
+    // TODO: relay mandatory field info to frontend for UI so frontend can show what is mandatory
+    //  and validate before server is even called
+    public static Set<String> getMandatoryFields(String type) {
+        if (type == null || !MANDATORY_FIELDS.containsKey(type)) {
+            return Collections.emptySet();
+        }
+        return MANDATORY_FIELDS.get(type);
+    }
+
+    /**
+     * Validates input to be saved as a maplayer to the databse
+     * Note! Might modify values in input object like URL!!!!!
+     * @param input
+     * @throws ServiceRuntimeException if input is not valid and can't be automatically fixed
+     */
+    public static void validateLayerInput(MapLayer input) throws ServiceRuntimeException {
+        // TODO: add more validation for values
+        if (!hasValue(input.getType())) {
+            throw new ServiceRuntimeException("Required field missing 'type'");
+        }
+
+        Set<String> mandatoryFields = getMandatoryFields(input.getType());
+        for (String field: mandatoryFields) {
+            if (!hasValue(input, field)) {
+                throw new ServiceRuntimeException("Required field missing '" + field + "'");
+            }
+        }
+        if (mandatoryFields.contains("url")) {
+            // if url is mandatory -> validate that it's usable
+            input.setUrl(LayerValidator.validateUrl(input.getUrl()));
+        }
+        // at least default language must have name for any layer type
+        input.setLocale(LayerValidator.validateLocale(input.getLocale()));
+        // Run HTML-content through JSOUP
+        input.setGfi_content(LayerValidator.cleanGFIContent(input.getGfi_content()));
+    }
+
+    /**
+     * Tries to find a getter for field through reflection and assumes it returns a string.
+     * throws an exception if value is not set or is empty or getter can't be called.
+     * @param input maplayer input for initial db or admin functionality
+     * @param field name of the field to search for "url" for getUrl() etc. case-insensitive
+     * @return
+     */
+    private static boolean hasValue(MapLayer input, String field) {
+        for (Method m : MapLayer.class.getDeclaredMethods()) {
+            if (!m.getName().toLowerCase().equals("get" + field.toLowerCase())) {
+                continue;
+            }
+            try {
+                String value = (String) m.invoke(input);
+                return hasValue(value);
+            } catch (Exception e) {
+                throw new ServiceRuntimeException("Unable to call getter for " + field, e);
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasValue(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
 }

--- a/service-map/src/main/java/org/oskari/maplayer/admin/LayerValidator.java
+++ b/service-map/src/main/java/org/oskari/maplayer/admin/LayerValidator.java
@@ -156,6 +156,9 @@ public class LayerValidator {
      * @return
      */
     private static boolean hasValue(MapLayer input, String field) {
+        if (input == null || field == null) {
+            return false;
+        }
         String[] fieldPath = field.split("\\.");
         for (Method m : MapLayer.class.getDeclaredMethods()) {
             if (!m.getName().toLowerCase().equals("get" + fieldPath[0].toLowerCase())) {
@@ -180,6 +183,9 @@ public class LayerValidator {
      * @return
      */
     protected static String[] shiftArray(String[] original) {
+        if (original == null || original.length == 0) {
+            return null;
+        }
         return Arrays.copyOfRange(original, 1, original.length);
     }
 

--- a/service-map/src/test/java/org/oskari/maplayer/admin/LayerValidatorTest.java
+++ b/service-map/src/test/java/org/oskari/maplayer/admin/LayerValidatorTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import org.oskari.maplayer.model.MapLayer;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.*;
 
@@ -76,11 +77,50 @@ public class LayerValidatorTest {
             assertEquals("Name missing for default language: en", e.getMessage());
         }
 
+        input.setLocale(createValidLocaleForLayer());
+        LayerValidator.validateAndSanitizeLayerInput(input);
+    }
+    @Test
+    public void validateBingLayer() {
+        MapLayer input = new MapLayer();
+        input.setType(OskariLayer.TYPE_BINGLAYER);
+        try {
+            LayerValidator.validateAndSanitizeLayerInput(input);
+        } catch (IllegalArgumentException e) {
+            assertEquals("Required field missing 'options.apiKey'", e.getMessage());
+        }
+        input.setOptions(new HashMap<>());
+        try {
+            LayerValidator.validateAndSanitizeLayerInput(input);
+        } catch (IllegalArgumentException e) {
+            assertEquals("Required field missing 'options.apiKey'", e.getMessage());
+        }
+
+        input.setLocale(createValidLocaleForLayer());
+
+        HashMap jee = new HashMap<>();
+        jee.put("apiKey", "testing");
+        input.setOptions(jee);
+        LayerValidator.validateAndSanitizeLayerInput(input);
+    }
+
+    @Test
+    public void testShift() {
+        String path = "testing.like.there's.no.tomorrow";
+        String[] original = path.split("\\.");
+        String[] rest = LayerValidator.shiftArray(original);
+        for (int i = 1; i < original.length; i++) {
+            assertEquals(original[i], rest[0]);
+            rest = LayerValidator.shiftArray(rest);
+        }
+        assertEquals("Rest should be empty", rest.length, 0);
+    }
+
+    private Map<String, Map<String, String>> createValidLocaleForLayer() {
         HashMap locale = new HashMap<>();
         HashMap en = new HashMap<>();
         en.put("name", "testing");
         locale.put("en", en);
-        input.setLocale(locale);
-        LayerValidator.validateAndSanitizeLayerInput(input);
+        return locale;
     }
 }

--- a/service-map/src/test/java/org/oskari/maplayer/admin/LayerValidatorTest.java
+++ b/service-map/src/test/java/org/oskari/maplayer/admin/LayerValidatorTest.java
@@ -1,9 +1,12 @@
 package org.oskari.maplayer.admin;
 
+import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.service.ServiceRuntimeException;
 import org.junit.Test;
+import org.oskari.maplayer.model.MapLayer;
 
 import java.net.URL;
+import java.util.HashMap;
 
 import static org.junit.Assert.*;
 
@@ -28,5 +31,57 @@ public class LayerValidatorTest {
         String url = "sgashahah";
         String validated = LayerValidator.validateUrl(url);
         fail("Should have thrown exception");
+    }
+
+    @Test
+    public void validateWMSLayer() {
+        MapLayer input = new MapLayer();
+        try {
+            LayerValidator.validateLayerInput(input);
+        } catch (ServiceRuntimeException e) {
+            assertEquals("Required field missing 'type'", e.getMessage());
+        }
+
+        input.setType(OskariLayer.TYPE_WMS);
+        try {
+            LayerValidator.validateLayerInput(input);
+        } catch (ServiceRuntimeException e) {
+            assertEquals("Required field missing 'name'", e.getMessage());
+        }
+        input.setName("testing");
+        try {
+            LayerValidator.validateLayerInput(input);
+        } catch (ServiceRuntimeException e) {
+            assertEquals("Required field missing 'url'", e.getMessage());
+        }
+
+        input.setUrl("http://oskari.org/testing");
+        try {
+            LayerValidator.validateLayerInput(input);
+        } catch (ServiceRuntimeException e) {
+            assertEquals("Required field missing 'version'", e.getMessage());
+        }
+
+        input.setVersion("1.1.0");
+        try {
+            LayerValidator.validateLayerInput(input);
+        } catch (ServiceRuntimeException e) {
+            //
+            assertEquals("Localization for layer names missing", e.getMessage());
+        }
+        input.setLocale(new HashMap<>());
+        try {
+            LayerValidator.validateLayerInput(input);
+        } catch (ServiceRuntimeException e) {
+            // Localization for layer names missing
+            assertEquals("Name missing for default language: en", e.getMessage());
+        }
+
+        HashMap locale = new HashMap<>();
+        HashMap en = new HashMap<>();
+        en.put("name", "testing");
+        locale.put("en", en);
+        input.setLocale(locale);
+        LayerValidator.validateLayerInput(input);
     }
 }

--- a/service-map/src/test/java/org/oskari/maplayer/admin/LayerValidatorTest.java
+++ b/service-map/src/test/java/org/oskari/maplayer/admin/LayerValidatorTest.java
@@ -5,7 +5,6 @@ import fi.nls.oskari.service.ServiceRuntimeException;
 import org.junit.Test;
 import org.oskari.maplayer.model.MapLayer;
 
-import java.net.URL;
 import java.util.HashMap;
 
 import static org.junit.Assert.*;
@@ -15,21 +14,21 @@ public class LayerValidatorTest {
     @Test
     public void validateUrl() {
         String url = "https://api.maptiler.com/tiles/v3/{z}/{x}/{y}.pbf";
-        String validated = LayerValidator.validateUrl(url);
+        String validated = LayerValidator.sanitizeUrl(url);
         assertEquals("URL should be unchanged", url, validated);
     }
 
     @Test
     public void validateUrlNull() {
         String url = null;
-        String validated = LayerValidator.validateUrl(url);
+        String validated = LayerValidator.sanitizeUrl(url);
         assertNull("URL should be unchanged", validated);
     }
 
-    @Test(expected = ServiceRuntimeException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void validateUrlNonvalid() {
         String url = "sgashahah";
-        String validated = LayerValidator.validateUrl(url);
+        String validated = LayerValidator.sanitizeUrl(url);
         fail("Should have thrown exception");
     }
 
@@ -37,42 +36,42 @@ public class LayerValidatorTest {
     public void validateWMSLayer() {
         MapLayer input = new MapLayer();
         try {
-            LayerValidator.validateLayerInput(input);
-        } catch (ServiceRuntimeException e) {
+            LayerValidator.validateAndSanitizeLayerInput(input);
+        } catch (IllegalArgumentException e) {
             assertEquals("Required field missing 'type'", e.getMessage());
         }
 
         input.setType(OskariLayer.TYPE_WMS);
         try {
-            LayerValidator.validateLayerInput(input);
-        } catch (ServiceRuntimeException e) {
+            LayerValidator.validateAndSanitizeLayerInput(input);
+        } catch (IllegalArgumentException e) {
             assertEquals("Required field missing 'name'", e.getMessage());
         }
         input.setName("testing");
         try {
-            LayerValidator.validateLayerInput(input);
-        } catch (ServiceRuntimeException e) {
+            LayerValidator.validateAndSanitizeLayerInput(input);
+        } catch (IllegalArgumentException e) {
             assertEquals("Required field missing 'url'", e.getMessage());
         }
 
         input.setUrl("http://oskari.org/testing");
         try {
-            LayerValidator.validateLayerInput(input);
-        } catch (ServiceRuntimeException e) {
+            LayerValidator.validateAndSanitizeLayerInput(input);
+        } catch (IllegalArgumentException e) {
             assertEquals("Required field missing 'version'", e.getMessage());
         }
 
         input.setVersion("1.1.0");
         try {
-            LayerValidator.validateLayerInput(input);
-        } catch (ServiceRuntimeException e) {
+            LayerValidator.validateAndSanitizeLayerInput(input);
+        } catch (IllegalArgumentException e) {
             //
             assertEquals("Localization for layer names missing", e.getMessage());
         }
         input.setLocale(new HashMap<>());
         try {
-            LayerValidator.validateLayerInput(input);
-        } catch (ServiceRuntimeException e) {
+            LayerValidator.validateAndSanitizeLayerInput(input);
+        } catch (IllegalArgumentException e) {
             // Localization for layer names missing
             assertEquals("Name missing for default language: en", e.getMessage());
         }
@@ -82,6 +81,6 @@ public class LayerValidatorTest {
         en.put("name", "testing");
         locale.put("en", en);
         input.setLocale(locale);
-        LayerValidator.validateLayerInput(input);
+        LayerValidator.validateAndSanitizeLayerInput(input);
     }
 }


### PR DESCRIPTION
By using reflection to check the input. The goal is to relay LayerValidator.getMandatoryFields(String type) to frontend so the user/admin can be notified about mandatory field based on layer type and hopefully store this metadata in one place (not spread between server/frontend/UI-texts).