### PR TITLE
Rename handler in preparation of adding more metadata

### DIFF
--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerAdminMetadataHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerAdminMetadataHandler.java
@@ -24,8 +24,8 @@ import fi.nls.oskari.service.UserService;
 import fi.nls.oskari.util.JSONHelper;
 import fi.nls.oskari.util.ResponseHelper;
 
-@OskariActionRoute("GetAllRolesAndPermissionTypes")
-public class GetAllRolesAndPermissionTypesHandler extends RestActionHandler {
+@OskariActionRoute("LayerAdminMetadata")
+public class LayerAdminMetadataHandler extends RestActionHandler {
     
     private UserService userService = null;
     private PermissionService permissionsService = null;

--- a/control-admin/src/test/java/fi/nls/oskari/control/admin/LayerAdminMetadataHandlerTest.java
+++ b/control-admin/src/test/java/fi/nls/oskari/control/admin/LayerAdminMetadataHandlerTest.java
@@ -26,9 +26,9 @@ import fi.nls.test.util.ResourceHelper;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({UserService.class, OskariComponentManager.class})
-public class GetAllRolesAndPermissionTypesHandlerTest extends JSONActionRouteTest {
+public class LayerAdminMetadataHandlerTest extends JSONActionRouteTest {
     
-    final private static GetAllRolesAndPermissionTypesHandler handler = new GetAllRolesAndPermissionTypesHandler();
+    final private static LayerAdminMetadataHandler handler = new LayerAdminMetadataHandler();
     
     @BeforeClass
     public static void setup() throws ServiceException {


### PR DESCRIPTION
Currently returns roles and permissions types configured for the instance. Plan is to use the same route to return information about mandatory fields and possibly even the fields that need to be shown to admin for each layer type.