### PR TITLE
Downgrade Jedis as spring session is not compatible with latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <woodstox.version>5.1.0</woodstox.version>
         <jsonld-java.version>0.3</jsonld-java.version>
         <xmlunit.version>1.6</xmlunit.version>
-        <jedis.version>3.2.0</jedis.version>
+        <jedis.version>2.10.2</jedis.version>
         <jackson.version>2.10.3</jackson.version>
 
         <fi.mml.capabilities.version>1.3.0</fi.mml.capabilities.version>

--- a/servlet-map/src/main/java/fi/nls/oskari/spring/session/RedisSessionConfig.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/spring/session/RedisSessionConfig.java
@@ -5,10 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
-import org.springframework.session.data.redis.RedisFlushMode;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
-import org.springframework.session.web.http.CookieSerializer;
-import org.springframework.session.web.http.DefaultCookieSerializer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
 // TODO: Check if maxInactiveIntervalInSeconds can be configured


### PR DESCRIPTION
Jedis was updated in #542 but starting the app after the upgrade with redis session saving results in an error for missing class. The spring session/data redis combination version that we can use with spring 4 doesn't support the latest Jedis version so it needs to be downgraded from 3.2.0 to 2.10.2.