### PR TITLE
Use common helper in test-resources instead of replicating code

### DIFF
--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/ManageRolesHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/ManageRolesHandler.java
@@ -99,8 +99,10 @@ public class ManageRolesHandler extends RestActionHandler {
     private JSONObject roles2JsonArray(Role[] roles) throws JSONException {
 
         final JSONArray roleValues = new JSONArray();
-        for(Role role : roles){
-            roleValues.put(role2Json(role));
+        if (roles != null) {
+            for(Role role : roles){
+                roleValues.put(role2Json(role));
+            }
         }
 
         final JSONObject response = new JSONObject();

--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/SystemViewsHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/SystemViewsHandler.java
@@ -72,16 +72,18 @@ public class SystemViewsHandler extends RestActionHandler {
         } catch (ServiceException e) {
             throw new ActionException("Couldn't get roles listing", e);
         }
-        for (Role role : roles) {
-            final JSONObject json = new JSONObject();
-            JSONHelper.putValue(json, PARAM_ID, role.getId());
-            JSONHelper.putValue(json, "name", role.getName());
+        if (roles != null) {
+            for (Role role : roles) {
+                final JSONObject json = new JSONObject();
+                JSONHelper.putValue(json, PARAM_ID, role.getId());
+                JSONHelper.putValue(json, "name", role.getName());
 
-            final long viewId = viewService.getDefaultViewIdForRole(role.getName());
-            if (viewId != globalDefaultViewId) {
-                JSONHelper.putValue(json, "viewId", viewId);
+                final long viewId = viewService.getDefaultViewIdForRole(role.getName());
+                if (viewId != globalDefaultViewId) {
+                    JSONHelper.putValue(json, "viewId", viewId);
+                }
+                list.put(json);
             }
-            list.put(json);
         }
 
         JSONHelper.putValue(response, "roles", list);

--- a/control-admin/src/test/java/fi/nls/oskari/control/admin/UserCredentialsTest.java
+++ b/control-admin/src/test/java/fi/nls/oskari/control/admin/UserCredentialsTest.java
@@ -45,7 +45,10 @@ public class UserCredentialsTest extends JSONActionRouteTest {
                 {CacheHandler.class},
                 {ManageRolesHandler.class},
                 {SystemViewsHandler.class},
-                {UsersHandler.class}
+                {UsersHandler.class},
+                // LayerAdminHandler decides permission based on layer id
+                //{LayerAdminHandler.class},
+                {LayerAdminMetadataHandler.class}
         });
     }
 

--- a/control-admin/src/test/java/fi/nls/oskari/control/admin/UserCredentialsTest.java
+++ b/control-admin/src/test/java/fi/nls/oskari/control/admin/UserCredentialsTest.java
@@ -45,10 +45,7 @@ public class UserCredentialsTest extends JSONActionRouteTest {
                 {CacheHandler.class},
                 {ManageRolesHandler.class},
                 {SystemViewsHandler.class},
-                {UsersHandler.class},
-                // LayerAdminHandler decides permission based on layer id
-                //{LayerAdminHandler.class},
-                {LayerAdminMetadataHandler.class}
+                {UsersHandler.class}
         });
     }
 

--- a/control-base/src/test/java/fi/nls/oskari/control/data/ResetRemainingSessionTimeHandlerTest.java
+++ b/control-base/src/test/java/fi/nls/oskari/control/data/ResetRemainingSessionTimeHandlerTest.java
@@ -30,6 +30,7 @@ public class ResetRemainingSessionTimeHandlerTest extends JSONActionRouteTest {
         
         PowerMockito.mockStatic(System.class);
         when(System.currentTimeMillis()).thenReturn(NOW);
+        doReturn(params.getRequest().getSession()).when(params.getRequest()).getSession(false);
         when(params.getRequest().getSession().getMaxInactiveInterval()).thenReturn(MAX_INACTIVE_INTERVAL);
         when(params.getRequest().getSession().getLastAccessedTime()).thenReturn(FIVE_SECONDS_AGO);
         handler.handleAction(params);

--- a/shared-test-resources/src/main/java/fi/nls/test/control/JSONActionRouteTest.java
+++ b/shared-test-resources/src/main/java/fi/nls/test/control/JSONActionRouteTest.java
@@ -90,29 +90,9 @@ public class JSONActionRouteTest {
     public ActionParameters createActionParams(final Map<String, String> parameters, final User user, final InputStream payload) {
         final ActionParameters params = new ActionParameters();
         // request params
-        HttpServletRequest req = mock(HttpServletRequest.class);
-        for(String key : parameters.keySet()) {
-            when(req.getParameter(key)).thenReturn(parameters.get(key));
-        }
-
-        // mock the session
-        HttpSession session = mock(HttpSession.class);
-        doReturn("testkey").when(session).getId();
-        // Return mock session when calling getSession without or with boolean parameter.
-        doReturn(session).when(req).getSession();
-        doReturn(session).when(req).getSession(false);
-
-        doReturn(new Vector(parameters.keySet()).elements()).when(req).getParameterNames();
+        HttpServletRequest req = mockHttpServletRequest("GET", parameters);
         if(!response.toString().isEmpty()) {
             fail("Creating new ActionParams, but response already has content: " + response.toString());
-        }
-        // mock possible payload inputstream
-        if(payload != null) {
-            try {
-                ServletInputStream wrapper = new MockServletInputStream(payload);
-                doReturn(wrapper).when(req).getInputStream();
-            }
-            catch (IOException ignored ) {}
         }
         // response handler
         HttpServletResponse resp = mock(HttpServletResponse.class);
@@ -148,7 +128,7 @@ public class JSONActionRouteTest {
         HttpServletRequest req = mock(HttpServletRequest.class);
 
         if (parameters != null) {
-            doReturn(new Vector<String>(parameters.keySet()).elements()).when(req).getParameterNames();
+            doReturn(new Vector<>(parameters.keySet()).elements()).when(req).getParameterNames();
             for (String key : parameters.keySet()) {
                 when(req.getParameter(key)).thenReturn(parameters.get(key));
             }


### PR DESCRIPTION
Use mockHttpServletRequest() in JSONActionRouteTest instead of duplicating code. Other changes needed to be done because of this change.