### PR TITLE
Support partial role update

### DIFF
--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerAdminHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerAdminHandler.java
@@ -176,10 +176,6 @@ public class LayerAdminHandler extends AbstractLayerAdminHandler {
 
         mapLayerService.update(ml);
 
-        // TODO: removes all permissions but non-admins don't send all permissions back
-        // Should we remove just the permissions that we get from frontend?
-        MapLayerPermissionsHelper.removePermissions(ml.getId());
-
         return result;
     }
 

--- a/service-admin/src/main/java/org/oskari/admin/MapLayerPermissionsHelper.java
+++ b/service-admin/src/main/java/org/oskari/admin/MapLayerPermissionsHelper.java
@@ -16,23 +16,31 @@ import java.util.Set;
 public class MapLayerPermissionsHelper {
 
     /*
+    Removes permissions for roles that are referenced in permissions parameter and updates them.
+    To remove permissions from a role send an empty array:
     "role_permissions": {
         "Guest" : ["VIEW_LAYER"],
         "User" : ["VIEW_LAYER"],
-        "Administrator" : ["VIEW_LAYER"]
+        "Administrator" : []
     }
+
+    Permissions for any roles that are NOT referenced will be kept as is (allows non-admins to modify).
     */
     public static void setLayerPermissions(int layerId, Map<String, Set<String>> permissions) {
         if (permissions == null || permissions.isEmpty()) {
-            // TODO: should we clear the layer permissions here for consistency?
             return;
         }
-        final Resource res = new Resource();
+
+        Resource res = getPermissionService()
+                .findResource(ResourceType.maplayer, Integer.toString(layerId))
+                .orElse(new Resource());
         res.setType(ResourceType.maplayer);
         res.setMapping(Integer.toString(layerId));
+        Set<String> roleNames = permissions.keySet();
+        removePermissionsForRoles(res, roleNames);
 
         MybatisRoleService roleService = getRoleService();
-        for (String roleName : permissions.keySet()) {
+        for (String roleName : roleNames) {
             final Role role = roleService.findRoleByName(roleName);
             if (role == null) {
                 // log.warn("Couldn't find matching role in DB:", roleName, "- Skipping!");
@@ -43,6 +51,9 @@ public class MapLayerPermissionsHelper {
                 continue;
             }
             for (String type : permissionTypes) {
+                if (type == null || type.trim().isEmpty()) {
+                    continue;
+                }
                 final Permission permission = new Permission();
                 permission.setExternalType(PermissionExternalType.ROLE);
                 permission.setExternalId((int) role.getId());
@@ -51,6 +62,25 @@ public class MapLayerPermissionsHelper {
             }
         }
         getPermissionService().saveResource(res);
+    }
+
+    /**
+     * Removes any existing role based permissions from resource
+     * @param resource
+     * @param roleNames names of roles that need to be purged
+     */
+    private static void removePermissionsForRoles(Resource resource, Set<String> roleNames) {
+        if (resource == null || roleNames == null) {
+            return;
+        }
+        MybatisRoleService roleService = getRoleService();
+        for (String roleName : roleNames) {
+            final Role role = roleService.findRoleByName(roleName);
+            if (role == null) {
+                continue;
+            }
+            resource.removePermissionsForExternalType(PermissionExternalType.ROLE, (int) role.getId());
+        }
     }
 
     public static void removePermissions(final int layerId) {

--- a/service-permissions/src/main/java/org/oskari/permissions/model/Resource.java
+++ b/service-permissions/src/main/java/org/oskari/permissions/model/Resource.java
@@ -128,6 +128,10 @@ public class Resource {
         getPermissions().removeIf(p -> p.isOfType(permissionType) && p.getExternalType().equals(idType) && p.getExternalId() == externalId);
     }
 
+    public void removePermissionsForExternalType(PermissionExternalType idType, int externalId) {
+        getPermissions().removeIf(p -> p.getExternalType().equals(idType) && p.getExternalId() == externalId);
+    }
+
     public void removePermissionsFromAllUsers(String permissionType) {
         getPermissions().removeIf(p -> p.isOfType(permissionType));
     }


### PR DESCRIPTION
Update the new admin functionality backend so that it doesn't wipe all permissions from the layer when updating before adding the permission set that was sent from the browser. Instead it only changes permissions for roles that were referenced in the payload from the client.

This enables admin functionality for non-admin users that do not see all the roles in the system by not overwriting everything but just updating permissions for the referenced roles.