### PR TITLE
Excel export

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/util/XLSXStreamer.java
+++ b/control-base/src/main/java/fi/nls/oskari/util/XLSXStreamer.java
@@ -59,31 +59,23 @@ public class XLSXStreamer implements TabularFileStreamer {
 
     private void fillCell(Cell cell, Object value) {
         if (value == null) {
-            cell.setCellType(CellType.BLANK);
+            cell.setBlank();
         } else if (value instanceof String) {
-            cell.setCellType(CellType.STRING);
             cell.setCellValue((String)value);
         } else if (value instanceof Double) {
-            cell.setCellType(CellType.NUMERIC);
             cell.setCellValue((Double)value);
         } else if (value instanceof Float) {
-            cell.setCellType(CellType.NUMERIC);
             cell.setCellValue((Float)value);
         } else if (value instanceof Integer) {
-            cell.setCellType(CellType.NUMERIC);
             cell.setCellValue((Integer)value);
         } else if (value instanceof Long) {
-            cell.setCellType(CellType.NUMERIC);
             cell.setCellValue((Long)value);
         } else if (value instanceof Short) {
-            cell.setCellType(CellType.NUMERIC);
             cell.setCellValue((Short) value);
         } else if (value instanceof Boolean) {
-            cell.setCellType(CellType.BOOLEAN);
             cell.setCellValue((Boolean)value);
         } else {
             // Object or an Array...
-            cell.setCellType(CellType.STRING);
             cell.setCellValue(value.toString());
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <quartz-scheduler.version>2.3.2</quartz-scheduler.version>
 
         <xerces.version>2.12.0</xerces.version>
-        <xmlbeans.version>2.6.0</xmlbeans.version>
+        <xmlbeans.version>3.1.0</xmlbeans.version>
         <geotools.version>19.2</geotools.version>
         <geotools.major>19</geotools.major>
         <jts.version>1.14.0</jts.version>


### PR DESCRIPTION
Update xmlbeans for apache poi-ooxml. setCellType is deprecated and will be removed for 5.0 version. Using setCellValue(double/String/boolean) or setBlank() should be enough to get desired result.

http://poi.apache.org/components/
can be used at runtime with any version of XMLBeans from 3.0.0 or newer
we recommend that you use XMLBeans 3.1.0 with Apache POI