### PR TITLE
Capabilities update on db init

### DIFF
--- a/content-resources/src/main/java/fi/nls/oskari/db/LayerHelper.java
+++ b/content-resources/src/main/java/fi/nls/oskari/db/LayerHelper.java
@@ -28,7 +28,6 @@ public class LayerHelper {
     public static int setupLayer(final String layerfile) throws IOException {
         final String jsonStr = IOHelper.readString(DBHandler.getInputStreamFromResource("/json/layers/" + layerfile));
         MapLayer layer = LayerAdminJSONHelper.readJSON(jsonStr);
-        // TODO: validate parsed layer?
         final List<OskariLayer> dbLayers = layerService.findByUrlAndName(layer.getUrl(), layer.getName());
         if(!dbLayers.isEmpty()) {
             if(dbLayers.size() > 1) {
@@ -37,6 +36,7 @@ public class LayerHelper {
             return dbLayers.get(0).getId();
         } else {
             // layer doesn't exist, insert it
+            // fromJSON validates parsed layer and throws IllegalArgumentException if layer is not valid
             final OskariLayer oskariLayer = LayerAdminJSONHelper.fromJSON(layer);
             // add info from capabilities
             try {

--- a/content-resources/src/main/java/fi/nls/oskari/db/LayerHelper.java
+++ b/content-resources/src/main/java/fi/nls/oskari/db/LayerHelper.java
@@ -45,7 +45,7 @@ public class LayerHelper {
                 log.warn(e,"Error updating capabilities for service from", oskariLayer.getUrl());
                 if (OskariLayer.TYPE_WMTS.equals(oskariLayer.getType())) {
                     log.warn("The WMTS-layer", oskariLayer.getName(),
-                            "will worker slower than normal with capabilities/tilegrids not cached. Try caching the capabilities later using the admin UI.");
+                            "might work slower than normal with capabilities/tilegrids not cached. Try caching the capabilities later using the admin UI.");
                 }
             }
             // insert to db

--- a/control-base/src/main/java/fi/nls/oskari/control/layer/GetLayerCapabilitiesHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/GetLayerCapabilitiesHandler.java
@@ -6,9 +6,12 @@ import fi.nls.oskari.control.ActionException;
 import fi.nls.oskari.control.ActionHandler;
 import fi.nls.oskari.control.ActionParameters;
 import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.service.OskariComponentManager;
 import fi.nls.oskari.service.ServiceException;
 import fi.nls.oskari.service.capabilities.CapabilitiesCacheService;
+import fi.nls.oskari.service.capabilities.OskariLayerCapabilities;
 import fi.nls.oskari.util.ResponseHelper;
 
 import javax.servlet.http.HttpServletResponse;
@@ -24,6 +27,7 @@ import java.nio.charset.StandardCharsets;
 @OskariActionRoute("GetLayerCapabilities")
 public class GetLayerCapabilitiesHandler extends ActionHandler {
 
+    private static final Logger LOG = LogFactory.getLogger(GetLayerCapabilitiesHandler.class);
     private CapabilitiesCacheService capabilitiesService;
     private PermissionHelper permissionHelper;
 
@@ -58,8 +62,12 @@ public class GetLayerCapabilitiesHandler extends ActionHandler {
 
     private String getCapabilities(OskariLayer layer) throws ActionException {
         try {
+            OskariLayerCapabilities caps = capabilitiesService.getCapabilities(layer);
             // Do not cache this. We don't check whether or not we can parse this response
-            return capabilitiesService.getCapabilities(layer).getData();
+            if (caps.getId() == null) {
+                LOG.info("Capabilities for layer", layer.getId(), "are not cached. Update them using the admin UI.");
+            }
+            return caps.getData();
         } catch (ServiceException ex) {
             throw new ActionException("Error reading capabilities", ex);
         }


### PR DESCRIPTION
Adding layers with LayerHelper after this is basically the same thing as adding them using the admin UI. The only thing missing was that capabilities for layers were not fetched/cached and for example WMTS-layers might have run slower depending on the service.