### PR TITLE
Setup dataproviderId when setting dataprovider for layer

### DIFF
--- a/service-base/src/main/java/fi/nls/oskari/domain/map/OskariLayer.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/OskariLayer.java
@@ -101,6 +101,7 @@ public class OskariLayer extends JSONLocalizedNameAndTitle implements Comparable
         dataProviders.clear();
         if (dataProvider != null) {
             dataProviders.add(dataProvider);
+            setDataproviderId(dataProvider.getId());
         }
     }
     public void removeDataprovider(final int id) {


### PR DESCRIPTION
Mybatis uses the id field on insert/update so it needs to be set to get the right things in the database. Fixes an issue where calling setDataProvider() on OskariLayer worked differently than calling addDataProvider().