### PR TITLE
Fix unsupported srs on empty database initialization

### DIFF
--- a/content-resources/src/main/java/fi/nls/oskari/db/LayerHelper.java
+++ b/content-resources/src/main/java/fi/nls/oskari/db/LayerHelper.java
@@ -65,4 +65,19 @@ public class LayerHelper {
         }
     }
 
+    /**
+     * So we can get updated "supported SRS" for layers after inserting a new appsetup with possibly new projection
+     * @throws ServiceException
+     */
+    protected static void refreshLayerCapabilities() {
+        for (OskariLayer layer : layerService.findAll()) {
+            try {
+                LayerCapabilitiesHelper.updateCapabilities(layer);
+                layerService.update(layer);
+            } catch (Exception e) {
+                log.warn(e,"Couldn't update capabilities for layer:", layer.getUrl(), layer.getName());
+            }
+        }
+    }
+
 }

--- a/content-resources/src/main/java/fi/nls/oskari/db/ViewHelper.java
+++ b/content-resources/src/main/java/fi/nls/oskari/db/ViewHelper.java
@@ -46,6 +46,8 @@ public class ViewHelper {
 
             final long viewId = viewService.addView(view);
             log.info("Added view from file:", viewfile, "/viewId is:", viewId, "/uuid is:", view.getUuid());
+            // update supported SRS for layers after possibly new projection on appsetup/view
+            LayerHelper.refreshLayerCapabilities();
             return viewId;
         } catch (Exception ex) {
             log.error(ex, "Unable to insert view! ");

--- a/service-map/src/main/java/fi/mml/map/mapwindow/service/wms/WebMapServiceV1_3_0_Impl.java
+++ b/service-map/src/main/java/fi/mml/map/mapwindow/service/wms/WebMapServiceV1_3_0_Impl.java
@@ -188,6 +188,13 @@ public class WebMapServiceV1_3_0_Impl extends AbstractWebMapService {
     }
 
     private String bboxToWGS84WKT (BoundingBox bbox) throws FactoryException, TransformException {
+        if ("true".equalsIgnoreCase(System.getProperty("org.geotools.referencing.forceXY"))) {
+            // With geoserver on the same Java sandbox hacking the coordinate order for things
+            // there is a good chance that the coordinate order will get mixed here
+            // since coverage data is more nice-to-have than essential we are better off skipping this metadata
+            // https://docs.geotools.org/latest/userguide/library/referencing/order.html
+            return null;
+        }
         CoordinateReferenceSystem sourceCRS = CRS.decode(bbox.getCRS());
         CoordinateReferenceSystem wgs84  = CRS.decode("EPSG:4326", true);
         ReferencedEnvelope env = new ReferencedEnvelope (bbox.getMinx(), bbox.getMaxx(),bbox.getMiny(), bbox.getMaxy(), sourceCRS);


### PR DESCRIPTION
- Refresh supported SRS information for all layers after an appsetup is added (as it might have new projection that layers might support)
- Skip layer coverage information if GeoServer is running on the same servlet container as it will be affecting coordinate order for transforms.

Fixes an issue on sample-server-extension where initial application setup first inserts an appsetup with EPSG:3857, then a layer, then an appsetup with EPSG:3067. The layer inserted in between had a configuration saying EPSG:3067 was not supported as any projections not used on the instance when layer is added will be dropped from supported SRS so the list doesn't get unwieldy.

Also fixes an issue where the layer for EPSG:3067 had coverage bbox transformed to completely wrong place due to having GeoServer (and because of https://docs.geotools.org/latest/userguide/library/referencing/order.html)  on the same Jetty (as it is the case with the sample download app)