### PR TITLE
Pxweb parse data model

### DIFF
--- a/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/parser/PxwebIndicatorsParser.java
+++ b/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/parser/PxwebIndicatorsParser.java
@@ -82,13 +82,11 @@ public class PxwebIndicatorsParser {
                         ind.setId(indicatorId);
                         indicatorMap.put(indicatorId, ind);
                         indicators.add(ind);
-                    }
-                    ind.addName(lang, item.text);
-                    if (ind.getDataModel() == null) {
                         // only populate model for first (== primary) language as it doesn't support localized labels for variables/selectors
-                        // TODO: add "mergeModels(lang, model)" that would populate localized labels for variables
                         ind.setDataModel(getModel(table));
                     }
+                    ind.addName(lang, item.text);
+                    // TODO: add "mergeModels(lang, model)" that would populate localized labels for variable
                 } catch (IOException e) {
                     LOG.error(e, "Error getting indicators from Pxweb datasource:", config.getUrl());
                 }


### PR DESCRIPTION
I don't know how these parsers should work for different languages but at least there was a bug in setting datamodel. getDataModel doesn't return null so the model wasn't never populated from table.

https://github.com/oskariorg/oskari-server/blob/develop/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/data/StatisticalIndicator.java#L120