### PR TITLE
Fix metadata and legend image for admin-layereditor

### DIFF
--- a/service-map/src/main/java/org/oskari/maplayer/admin/LayerAdminJSONHelper.java
+++ b/service-map/src/main/java/org/oskari/maplayer/admin/LayerAdminJSONHelper.java
@@ -114,8 +114,8 @@ public class LayerAdminJSONHelper {
         out.setMinscale(layer.getMinScale());
         out.setMaxscale(layer.getMaxScale());
 
-        layer.setLegendImage(layer.getLegendImage());
-        layer.setMetadataId(layer.getMetadataId());
+        out.setLegend_image(layer.getLegendImage());
+        out.setMetadataid(layer.getMetadataId());
 
         out.setParams(JSONHelper.getObjectAsMap(layer.getParams()));
         out.setAttributes(JSONHelper.getObjectAsMap(layer.getAttributes()));


### PR DESCRIPTION
Metadata and legend image was reset when loading a layer for editing. This fixes the issue.