### PR TITLE
Upgrade Flyway

### DIFF
--- a/content-resources/pom.xml
+++ b/content-resources/pom.xml
@@ -49,11 +49,6 @@
                         <version>${commons-dbcp2.version}</version>
                     </dependency>
                     <dependency>
-                        <groupId>hsqldb</groupId>
-                        <artifactId>hsqldb</artifactId>
-                        <version>1.8.0.7</version>
-                    </dependency>
-                    <dependency>
                         <groupId>org.postgresql</groupId>
                         <artifactId>postgresql</artifactId>
                         <version>${postgresql.version}</version>
@@ -119,7 +114,6 @@
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
-            <version>3.2.1</version>
         </dependency>
         <dependency>
             <groupId>fi.nls.oskari</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <jdk.version>1.8</jdk.version>
         <fi.nls.oskari.version>${project.version}</fi.nls.oskari.version>
         <fi.nls.oskari.service.version>${project.version}</fi.nls.oskari.service.version>
-        <flyway.version>3.2.1</flyway.version>
+        <flyway.version>4.2.0</flyway.version>
 
         <spring.version>4.3.26.RELEASE</spring.version>
         <spring-security.version>4.2.14.RELEASE</spring-security.version>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <jdk.version>1.8</jdk.version>
         <fi.nls.oskari.version>${project.version}</fi.nls.oskari.version>
         <fi.nls.oskari.service.version>${project.version}</fi.nls.oskari.service.version>
+        <flyway.version>3.2.1</flyway.version>
 
         <spring.version>4.3.26.RELEASE</spring.version>
         <spring-security.version>4.2.14.RELEASE</spring-security.version>
@@ -63,7 +64,6 @@
         <commons-httpclient.version>3.1</commons-httpclient.version>
         <commons-codec.version>1.7</commons-codec.version>
         <commons-fileupload.version>1.4</commons-fileupload.version>
-        <commons-dbcp.version>1.4</commons-dbcp.version>
         <commons-dbcp2.version>2.0.1</commons-dbcp2.version>
 
         <staxon.version>1.2</staxon.version>
@@ -463,6 +463,33 @@
                 <version>${fi.nls.oskari.version}</version>
             </dependency>
 
+
+            <!-- Database -->
+            <dependency>
+                <groupId>org.flywaydb</groupId>
+                <artifactId>flyway-core</artifactId>
+                <version>${flyway.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.postgresql</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>${postgresql.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-dbcp2</artifactId>
+                <version>${commons-dbcp2.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.h2database</groupId>
+                <artifactId>h2</artifactId>
+                <version>${h2database.version}</version>
+            </dependency>
+
+
             <!-- Spring -->
             <dependency>
                 <groupId>org.springframework.security.extensions</groupId>
@@ -596,12 +623,6 @@
                 <version>${commons-codec.version}</version>
             </dependency>
 
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-dbcp2</artifactId>
-                <version>${commons-dbcp2.version}</version>
-            </dependency>
-
             <!-- metrics -->
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>
@@ -667,18 +688,6 @@
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
                 <version>${jetty.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.postgresql</groupId>
-                <artifactId>postgresql</artifactId>
-                <version>${postgresql.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.h2database</groupId>
-                <artifactId>h2</artifactId>
-                <version>${h2database.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
In preparation to support more recent Postgres versions we need to upgrade the Flyway library. However we need to do this in steps because 5.x does not support the status table structure before migrating it with 4.2.0 (https://flywaydb.org/documentation/releaseNotes#5.0.0). Going forward to more recent Flyway versions to actually get the support for more recent Postgres we need to advice users to migrate Oskari-based apps to a specific version that has Flyway 4.2.0 included BEFORE upgrading to a more recent Oskari version.

This is the first step.

The Flyway upgrade goes through the status tables and migrates them to the new schema. You might need to add the autorepair-flag to oskari-ext.properties for the migration to go through: 

    db.flyway.autorepair=true

Also if status tables refer to migrations that have since been removed from the codebase (bad practice but it happens) you might not be able to migrate without further manual steps. Here's an example of the application database having a reference to a removed migration in oskari_status-table: https://github.com/nls-oskari/kartta.paikkatietoikkuna.fi/pull/133