### PR TITLE
Migrations in single transaction

### DIFF
--- a/content-resources/src/main/java/fi/nls/oskari/db/FlywaydbMigrator.java
+++ b/content-resources/src/main/java/fi/nls/oskari/db/FlywaydbMigrator.java
@@ -27,6 +27,9 @@ public class FlywaydbMigrator {
         flyway.setDataSource(datasource);
         flyway.setTable(getStatusTableName(moduleName));
         flyway.setLocations(getScriptLocations(moduleName));
+        // runs all pending migrations in single transaction so users don't get in to a situation where the database
+        // is half but not fully migrated to the new version
+        flyway.setGroup(true);
         if (flyway.info().current() == null) {
             flyway.setBaselineVersionAsString("0.1");
             flyway.baseline();


### PR DESCRIPTION
Sets pending migrations to be run in single transaction so users don't end up with half-migrated databases: https://github.com/flyway/flyway/issues/181