### PR TITLE
Support OAPIF layers in LayerCapabilitiesHelper.updateCapabilities(OskariLayer)

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/layer/GetWSCapabilitiesHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/GetWSCapabilitiesHandler.java
@@ -135,7 +135,7 @@ public class GetWSCapabilitiesHandler extends ActionHandler {
         for (String lang : PropertyUtil.getSupportedLanguages()) {
             layer.setName(lang, title);
         }
-        OskariLayerCapabilitiesHelper.setPropertiesFromCapabilitiesWFS(service, layer, systemCRSs);
+        OskariLayerCapabilitiesHelper.setPropertiesFromCapabilitiesOAPIF(service, layer, systemCRSs);
         return layer;
     }
     private static JSONObject wfsLayerToJSON(OskariLayer layer, String crs, String user, String pw) {

--- a/control-base/src/main/java/fi/nls/oskari/control/layer/SaveLayerHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/SaveLayerHandler.java
@@ -467,12 +467,7 @@ public class SaveLayerHandler extends AbstractLayerAdminHandler {
         ml.setVersion(params.getHttpParam(PARAM_VERSION, params.getHttpParam(PARAM_WFS_VERSION, ml.getVersion())));
 
         try {
-            if (WFS3_0_0_VERSION.equals(ml.getVersion())) {
-                WFS3Service service = WFS3Service.fromURL(ml.getUrl(), ml.getUsername(), ml.getPassword());
-                OskariLayerCapabilitiesHelper.setPropertiesFromCapabilitiesWFS(service, ml, systemCRSs);
-            } else {
-                LayerCapabilitiesHelper.updateCapabilities(ml);
-            }
+            LayerCapabilitiesHelper.updateCapabilities(ml);
         } catch (Exception e) {
             LOG.warn("Couldn't update capabilities for WFS (" + ml.getVersion() + ") layer:", ml.getName(), e.getMessage());
         }

--- a/service-admin/src/main/java/org/oskari/admin/LayerCapabilitiesHelper.java
+++ b/service-admin/src/main/java/org/oskari/admin/LayerCapabilitiesHelper.java
@@ -18,6 +18,7 @@ import org.oskari.maplayer.admin.LayerAdminJSONHelper;
 import org.oskari.maplayer.model.ServiceCapabilitiesResult;
 import org.oskari.maplayer.model.ServiceCapabilitiesResultWMS;
 import org.oskari.maplayer.model.ServiceCapabilitiesResultWMTS;
+import org.oskari.service.wfs3.WFS3Service;
 
 import java.util.Arrays;
 import java.util.List;
@@ -65,12 +66,10 @@ public class LayerCapabilitiesHelper {
         return url;
     }
 
-    // not used currently but this seems The place for this
     public static void updateCapabilities(OskariLayer ml) throws ServiceException {
         switch (ml.getType()) {
             case OskariLayer.TYPE_WFS:
-                WFSDataStore wfs = WFSCapabilitiesService.getDataStore(ml);
-                OskariLayerCapabilitiesHelper.setPropertiesFromCapabilitiesWFS(wfs, ml, getSystemCRSs());
+                updateCapabilitiesWFS(ml);
                 break;
             case OskariLayer.TYPE_WMS:
                 WebMapService wms = wmsCapabilities.updateCapabilities(ml);
@@ -80,6 +79,16 @@ public class LayerCapabilitiesHelper {
                 WMTSCapabilities wmts = wmtsCapabilities.updateCapabilities(ml);
                 OskariLayerCapabilitiesHelper.setPropertiesFromCapabilitiesWMTS(wmts, ml, getSystemCRSs());
                 break;
+        }
+    }
+
+    private static void updateCapabilitiesWFS(OskariLayer ml) throws ServiceException {
+        if (CapabilitiesConstants.WFS3_VERSION.equals(ml.getVersion())) {
+            WFS3Service service = WFSCapabilitiesService.getCapabilitiesOAPIF(ml.getUrl(), ml.getUsername(), ml.getPassword());
+            OskariLayerCapabilitiesHelper.setPropertiesFromCapabilitiesOAPIF(service, ml, getSystemCRSs());
+        } else {
+            WFSDataStore wfs = WFSCapabilitiesService.getDataStore(ml);
+            OskariLayerCapabilitiesHelper.setPropertiesFromCapabilitiesWFS(wfs, ml, getSystemCRSs());
         }
     }
 

--- a/service-map/src/main/java/fi/nls/oskari/service/capabilities/OskariLayerCapabilitiesHelper.java
+++ b/service-map/src/main/java/fi/nls/oskari/service/capabilities/OskariLayerCapabilitiesHelper.java
@@ -127,26 +127,25 @@ public class OskariLayerCapabilitiesHelper {
 
     public static void setPropertiesFromCapabilitiesWFS(WFSDataStore data, OskariLayer ml,
                                                         Set<String> systemCRSs) throws ServiceException {
-
         try {
             SimpleFeatureSource source = data.getFeatureSource(ml.getName());
             WFSGetCapabilities capa = data.getWfsClient().getCapabilities();
             setPropertiesFromCapabilitiesWFS(capa, source, ml, systemCRSs);
-        }catch (IOException e) {
+        } catch (IOException e) {
             throw new IllegalArgumentException("Can't find layer: " + ml.getName());
         }
-
     }
+
     public static void setPropertiesFromCapabilitiesWFS(WFSGetCapabilities capa, SimpleFeatureSource source, OskariLayer ml,
                                                         Set<String> systemCRSs) throws ServiceException {
         ml.setCapabilities(LayerJSONFormatterWFS.createCapabilitiesJSON(capa, source, systemCRSs));
         ml.setCapabilitiesLastUpdated(new Date());
-
     }
-    public static void setPropertiesFromCapabilitiesWFS(WFS3Service service, OskariLayer ml,
-                                                        Set<String> systemCRSs) {
 
+    public static void setPropertiesFromCapabilitiesOAPIF(WFS3Service service, OskariLayer ml,
+                                                        Set<String> systemCRSs) {
         ml.setCapabilities(LayerJSONFormatterWFS.createCapabilitiesJSON(service, ml.getName(), systemCRSs));
         ml.setCapabilitiesLastUpdated(new Date());
     }
+
 }


### PR DESCRIPTION
Fix an issue with updating the capabilities of OAPIF layer(s). Currently saving works because it goes through `SaveLayerHandler` which has special handling for OAPIF layers. Move that logic down to LayerCapabilitiesHelper.