### PR TITLE
Fix issue with WMS layers that don't have any <Style>

### DIFF
--- a/service-map/src/main/java/fi/mml/map/mapwindow/service/wms/WebMapServiceFactory.java
+++ b/service-map/src/main/java/fi/mml/map/mapwindow/service/wms/WebMapServiceFactory.java
@@ -53,7 +53,7 @@ public class WebMapServiceFactory {
 	    String data = cc.getData();
 
 	    try {
-	        wms = createFromXML(layer.getName(), data);
+	        wms = WebMapServiceFactory.createFromXML(layer.getName(), data);
 	    } catch (WebMapServiceParseException | LayerNotFoundInCapabilitiesException ex) {
 	        // setup empty capabilities so we don't try to parse again before cache flush
 	        wmsCache.put(cacheKey, new WMSCapabilities());
@@ -71,15 +71,9 @@ public class WebMapServiceFactory {
 	    return wms;
 	}
 
-    public static WebMapService createFromXML(final String layerName, final String xml)
-            throws WebMapServiceParseException, LayerNotFoundInCapabilitiesException {
-        if (isVersion1_3_0(xml)) {
-            return new WebMapServiceV1_3_0_Impl("from DataBase", xml, layerName);
-        } else if (isVersion1_1_1(xml)) {
-            return new WebMapServiceV1_1_1_Impl("from DataBase", xml, layerName);
-        } else {
-            throw new WebMapServiceParseException("Could not detect version to be 1.3.0 or 1.1.1");
-        }
+    @Deprecated
+    public static WebMapService createFromXML(final String layerName, final String xml) throws WebMapServiceParseException, LayerNotFoundInCapabilitiesException {
+        return WebMapServiceFactoryHelper.createFromXML(layerName, xml);
     }
 
     public static void flushCache(final int layerId) {
@@ -90,28 +84,21 @@ public class WebMapServiceFactory {
         wmsCache.flush(true);
     }
 
-	/**
-	 * Returns true is data represents a WMS 1.1.1 version
-	 * 
-	 * @param data
-	 * @return
-	 */
-	public static boolean isVersion1_1_1(String data) {
-        return data != null &&
-                data.contains("WMT_MS_Capabilities") &&
-                data.contains("version=\"1.1.1\"");
-	}
+    /**
+     * Returns true if data represents a WMS 1.1.1 version
+     * @deprecated use WebMapServiceFactoryHelper.isVersion1_1_1(String)
+     */
+    @Deprecated
+    public static boolean isVersion1_1_1(String data) {
+        return WebMapServiceFactoryHelper.isVersion1_1_1(data);
+    }
 
-	/**
-	 * Returns true is data represents a WMS 1.3.0 version
-	 * 
-	 * @param data
-	 * @return
-	 */
-	public static boolean isVersion1_3_0(String data) {
-        return data != null &&
-                data.contains("WMS_Capabilities") &&
-                data.contains("version=\"1.3.0\"");
-	}
-
+    /**
+     * Returns true if data represents a WMS 1.3.0 version
+     * @deprecated use WebMapServiceFactoryHelper.isVersion1_3_0(String)
+     */
+    @Deprecated
+    public static boolean isVersion1_3_0(String data) {
+        return WebMapServiceFactoryHelper.isVersion1_3_0(data);
+    }
 }

--- a/service-map/src/main/java/fi/mml/map/mapwindow/service/wms/WebMapServiceFactoryHelper.java
+++ b/service-map/src/main/java/fi/mml/map/mapwindow/service/wms/WebMapServiceFactoryHelper.java
@@ -1,0 +1,34 @@
+package fi.mml.map.mapwindow.service.wms;
+
+public class WebMapServiceFactoryHelper {
+
+    public static WebMapService createFromXML(final String layerName, final String xml)
+            throws WebMapServiceParseException, LayerNotFoundInCapabilitiesException {
+        if (isVersion1_3_0(xml)) {
+            return new WebMapServiceV1_3_0_Impl("from DataBase", xml, layerName);
+        } else if (isVersion1_1_1(xml)) {
+            return new WebMapServiceV1_1_1_Impl("from DataBase", xml, layerName);
+        } else {
+            throw new WebMapServiceParseException("Could not detect version to be 1.3.0 or 1.1.1");
+        }
+    }
+
+    /**
+     * Returns true if data represents a WMS 1.1.1 version
+     */
+    public static boolean isVersion1_1_1(String data) {
+        return data != null &&
+                data.contains("WMT_MS_Capabilities") &&
+                data.contains("version=\"1.1.1\"");
+    }
+
+    /**
+     * Returns true if data represents a WMS 1.3.0 version
+     */
+    public static boolean isVersion1_3_0(String data) {
+        return data != null &&
+                data.contains("WMS_Capabilities") &&
+                data.contains("version=\"1.3.0\"");
+    }
+
+}

--- a/service-map/src/main/java/fi/nls/oskari/service/capabilities/OskariLayerCapabilitiesHelper.java
+++ b/service-map/src/main/java/fi/nls/oskari/service/capabilities/OskariLayerCapabilitiesHelper.java
@@ -76,6 +76,9 @@ public class OskariLayerCapabilitiesHelper {
         if (ml.getId() == -1 && ml.getLegendImage() == null && caps.has(KEY_STYLES)) {
             // Take 1st style name for default - geotools parsing is not always correct
             JSONArray styles = JSONHelper.getJSONArray(caps, KEY_STYLES);
+            if (styles.length() == 0) {
+                return null;
+            }
             JSONObject jstyle = JSONHelper.getJSONObject(styles, 0);
             if (jstyle != null) {
                 style = JSONHelper.getStringFromJSON(jstyle, KEY_NAME, null);

--- a/service-map/src/main/java/org/oskari/maplayer/model/ServiceCapabilitiesResult.java
+++ b/service-map/src/main/java/org/oskari/maplayer/model/ServiceCapabilitiesResult.java
@@ -1,10 +1,13 @@
 package org.oskari.maplayer.model;
 
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.util.PropertyUtil;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -12,6 +15,9 @@ import java.util.stream.Collectors;
  * Used to write JSON for admin functionality when adding layers
  */
 public class ServiceCapabilitiesResult {
+
+    private static final Logger log = LogFactory.getLogger(ServiceCapabilitiesResult.class);
+
     private String title;
     private List<MapLayerAdminOutput> layers;
     private List<String> layersWithErrors;
@@ -48,8 +54,15 @@ public class ServiceCapabilitiesResult {
      * @return
      */
     public Map<String, MapLayerAdminOutput> getLayers() {
+        BinaryOperator<MapLayerAdminOutput> merge = (a, b) -> {
+            String url = a.getUrl();
+            String name = a.getName();
+            log.warn("Duplicate layer name, service url:", url, "layer name:", name);
+            // Keep the one we already have
+            return a;
+        };
         return layers.stream().collect(
-                Collectors.toMap(MapLayerAdminOutput::getName, Function.identity()));
+                Collectors.toMap(MapLayerAdminOutput::getName, Function.identity(), merge));
     }
 
     public void setLayers(List<MapLayerAdminOutput> layers) {

--- a/service-map/src/test/java/fi/nls/oskari/wms/WMSCapabilitiesServiceTest.java
+++ b/service-map/src/test/java/fi/nls/oskari/wms/WMSCapabilitiesServiceTest.java
@@ -1,0 +1,38 @@
+package fi.nls.oskari.wms;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.geotools.data.ows.Layer;
+import org.geotools.data.ows.WMSCapabilities;
+import org.junit.Test;
+import org.oskari.maplayer.model.ServiceCapabilitiesResultWMS;
+
+import fi.nls.oskari.util.IOHelper;
+
+public class WMSCapabilitiesServiceTest {
+
+    @Test
+    public void testLipas() throws Exception {
+        String xml = IOHelper.readString(getClass().getResourceAsStream("/capabilities_lipas_1_3_0.xml"));
+        WMSCapabilities caps = WMSCapabilitiesService.createCapabilities(xml);
+        List<Layer> layers = WMSCapabilitiesService.getActualLayers(caps)
+                .collect(Collectors.toList());
+        assertEquals(176, layers.size());
+
+        String url = "http://www.test.domain/wms";
+        String version = "1.3.0";
+        String user = null;
+        String pwd = null;
+        Set<String> systemCRSs = new HashSet<>(Arrays.asList("EPSG:3067", "EPSG:4326"));
+        ServiceCapabilitiesResultWMS result = WMSCapabilitiesService.parseCapabilitiesResults(xml, url, version, user, pwd, systemCRSs);
+        // Remove one because lipas_7000_huoltorakennukset appears twice for some reason
+        assertEquals(175, result.getLayers().size());
+    }
+
+}

--- a/service-map/src/test/resources/capabilities_lipas_1_3_0.xml
+++ b/service-map/src/test/resources/capabilities_lipas_1_3_0.xml
@@ -1,0 +1,4426 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<WMS_Capabilities version="1.3.0" updateSequence="1071" xmlns="http://www.opengis.net/wms" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wms http://not.a.real.domain/geoserver/schemas/wms/1.3.0/capabilities_1_3_0.xsd">
+  <Service>
+    <Name>WMS</Name>
+    <Title>GeoServer Web Map Service</Title>
+    <Abstract>A compliant implementation of WMS plus most of the SLD extension (dynamic styling). Can also generate PDF, SVG, KML, GeoRSS</Abstract>
+    <KeywordList>
+      <Keyword>WFS</Keyword>
+      <Keyword>WMS</Keyword>
+      <Keyword>GEOSERVER</Keyword>
+    </KeywordList>
+    <OnlineResource xlink:type="simple" xlink:href="http://geoserver.sourceforge.net/html/index.php"/>
+    <ContactInformation>
+      <ContactPersonPrimary>
+        <ContactPerson>Claudius Ptolomaeus</ContactPerson>
+        <ContactOrganization>The ancient geographes INC</ContactOrganization>
+      </ContactPersonPrimary>
+      <ContactPosition>Chief geographer</ContactPosition>
+      <ContactAddress>
+        <AddressType>Work</AddressType>
+        <Address/>
+        <City>Alexandria</City>
+        <StateOrProvince/>
+        <PostCode/>
+        <Country>Egypt</Country>
+      </ContactAddress>
+      <ContactVoiceTelephone/>
+      <ContactFacsimileTelephone/>
+      <ContactElectronicMailAddress>claudius.ptolomaeus@gmail.com</ContactElectronicMailAddress>
+    </ContactInformation>
+    <Fees>NONE</Fees>
+    <AccessConstraints>NONE</AccessConstraints>
+  </Service>
+  <Capability>
+    <Request>
+      <GetCapabilities>
+        <Format>text/xml</Format>
+        <DCPType>
+          <HTTP>
+            <Get>
+              <OnlineResource xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?SERVICE=WMS&amp;"/>
+            </Get>
+            <Post>
+              <OnlineResource xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?SERVICE=WMS&amp;"/>
+            </Post>
+          </HTTP>
+        </DCPType>
+      </GetCapabilities>
+      <GetMap>
+        <Format>image/png</Format>
+        <Format>application/atom+xml</Format>
+        <Format>application/json;type=utfgrid</Format>
+        <Format>application/pdf</Format>
+        <Format>application/rss+xml</Format>
+        <Format>application/vnd.google-earth.kml+xml</Format>
+        <Format>application/vnd.google-earth.kml+xml;mode=networklink</Format>
+        <Format>application/vnd.google-earth.kmz</Format>
+        <Format>image/geotiff</Format>
+        <Format>image/geotiff8</Format>
+        <Format>image/gif</Format>
+        <Format>image/jpeg</Format>
+        <Format>image/png; mode=8bit</Format>
+        <Format>image/svg+xml</Format>
+        <Format>image/tiff</Format>
+        <Format>image/tiff8</Format>
+        <Format>image/vnd.jpeg-png</Format>
+        <Format>image/vnd.jpeg-png8</Format>
+        <Format>text/html; subtype=openlayers</Format>
+        <Format>text/html; subtype=openlayers2</Format>
+        <Format>text/html; subtype=openlayers3</Format>
+        <DCPType>
+          <HTTP>
+            <Get>
+              <OnlineResource xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?SERVICE=WMS&amp;"/>
+            </Get>
+          </HTTP>
+        </DCPType>
+      </GetMap>
+      <GetFeatureInfo>
+        <Format>text/plain</Format>
+        <Format>application/vnd.ogc.gml</Format>
+        <Format>text/xml</Format>
+        <Format>application/vnd.ogc.gml/3.1.1</Format>
+        <Format>text/xml; subtype=gml/3.1.1</Format>
+        <Format>text/html</Format>
+        <Format>application/json</Format>
+        <DCPType>
+          <HTTP>
+            <Get>
+              <OnlineResource xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?SERVICE=WMS&amp;"/>
+            </Get>
+          </HTTP>
+        </DCPType>
+      </GetFeatureInfo>
+    </Request>
+    <Exception>
+      <Format>XML</Format>
+      <Format>INIMAGE</Format>
+      <Format>BLANK</Format>
+      <Format>JSON</Format>
+    </Exception>
+    <Layer>
+      <Title>GeoServer Web Map Service</Title>
+      <Abstract>A compliant implementation of WMS plus most of the SLD extension (dynamic styling). Can also generate PDF, SVG, KML, GeoRSS</Abstract>
+      <!--All supported EPSG projections:-->
+      <CRS>EPSG:3067</CRS>
+      <CRS>EPSG:4236</CRS>
+      <CRS>CRS:84</CRS>
+      <EX_GeographicBoundingBox>
+        <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+        <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+        <southBoundLatitude>9.709331091734049</southBoundLatitude>
+        <northBoundLatitude>14420.402234976802</northBoundLatitude>
+      </EX_GeographicBoundingBox>
+      <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+      <Layer queryable="1">
+        <Name>lipas_0_virkistyskohteet_ja_palvelut</Name>
+        <Title>lipas_0_virkistyskohteet_ja_palvelut</Title>
+        <Abstract>Layer-Group type layer: lipas_0_virkistyskohteet_ja_palvelut</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_1000_ulkokentat_ja_liikuntapuistot</Name>
+        <Title>lipas_1000_ulkokentat_ja_liikuntapuistot</Title>
+        <Abstract>Layer-Group type layer: lipas_1000_ulkokentat_ja_liikuntapuistot</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_1100_lahiliikunta_ja_liikuntapuistot</Name>
+        <Title>lipas_1100_lahiliikunta_ja_liikuntapuistot</Title>
+        <Abstract>Layer-Group type layer: lipas_1100_lahiliikunta_ja_liikuntapuistot</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_1200_yleisurheilukentat_ja_paikat</Name>
+        <Title>lipas_1200_yleisurheilukentat_ja_paikat</Title>
+        <Abstract>Layer-Group type layer: lipas_1200_yleisurheilukentat_ja_paikat</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_1300_pallokentat</Name>
+        <Title>lipas_1300_pallokentat</Title>
+        <Abstract>Layer-Group type layer: lipas_1300_pallokentat</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_1500_jaaurheilualueet_ja_luonnonjaat</Name>
+        <Title>lipas_1500_jaaurheilualueet_ja_luonnonjaat</Title>
+        <Abstract>Layer-Group type layer: lipas_1500_jaaurheilualueet_ja_luonnonjaat</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_1600_golfkentat</Name>
+        <Title>lipas_1600_golfkentat</Title>
+        <Abstract>Layer-Group type layer: lipas_1600_golfkentat</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_1_virkistys_ja_retkeilyalueet</Name>
+        <Title>lipas_1_virkistys_ja_retkeilyalueet</Title>
+        <Abstract>Layer-Group type layer: lipas_1_virkistys_ja_retkeilyalueet</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_2000_sisaliikuntatilat</Name>
+        <Title>lipas_2000_sisaliikuntatilat</Title>
+        <Abstract>Layer-Group type layer: lipas_2000_sisaliikuntatilat</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_2100_kuntoilukeskukset_ja_liikuntasalit</Name>
+        <Title>lipas_2100_kuntoilukeskukset_ja_liikuntasalit</Title>
+        <Abstract>Layer-Group type layer: lipas_2100_kuntoilukeskukset_ja_liikuntasalit</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_2200_liikuntahallit</Name>
+        <Title>lipas_2200_liikuntahallit</Title>
+        <Abstract>Layer-Group type layer: lipas_2200_liikuntahallit</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_2300_yksittaiset_lajikohtaiset_sisaliikuntapaikat</Name>
+        <Title>lipas_2300_yksittaiset_lajikohtaiset_sisaliikuntapaikat</Title>
+        <Abstract>Layer-Group type layer: lipas_2300_yksittaiset_lajikohtaiset_sisaliikuntapaikat</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_2500_jaahallit</Name>
+        <Title>lipas_2500_jaahallit</Title>
+        <Abstract>Layer-Group type layer: lipas_2500_jaahallit</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_2600_keilahallit</Name>
+        <Title>lipas_2600_keilahallit</Title>
+        <Abstract>Layer-Group type layer: lipas_2600_keilahallit</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_2_retkeilyn_palvelut</Name>
+        <Title>lipas_2_retkeilyn_palvelut</Title>
+        <Abstract>Layer-Group type layer: lipas_2_retkeilyn_palvelut</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_3000_vesiliikuntapaikat</Name>
+        <Title>lipas_3000_vesiliikuntapaikat</Title>
+        <Abstract>Layer-Group type layer: lipas_3000_vesiliikuntapaikat</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_3100_uimaaltaat_hallit_ja_kylpylat</Name>
+        <Title>lipas_3100_uimaaltaat_hallit_ja_kylpylat</Title>
+        <Abstract>Layer-Group type layer: lipas_3100_uimaaltaat_hallit_ja_kylpylat</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_3200_maauimalat_ja_uimarannat</Name>
+        <Title>lipas_3200_maauimalat_ja_uimarannat</Title>
+        <Abstract>Layer-Group type layer: lipas_3200_maauimalat_ja_uimarannat</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_4000_maastoliikuntapaikat</Name>
+        <Title>lipas_4000_maastoliikuntapaikat</Title>
+        <Abstract>Layer-Group type layer: lipas_4000_maastoliikuntapaikat</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_4100_laskettelurinteet_ja_rinnehiihtokeskukset</Name>
+        <Title>lipas_4100_laskettelurinteet_ja_rinnehiihtokeskukset</Title>
+        <Abstract>Layer-Group type layer: lipas_4100_laskettelurinteet_ja_rinnehiihtokeskukset</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_4200_katetut_talviurheilupaikat</Name>
+        <Title>lipas_4200_katetut_talviurheilupaikat</Title>
+        <Abstract>Layer-Group type layer: lipas_4200_katetut_talviurheilupaikat</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_4300_hyppyrimaet</Name>
+        <Title>lipas_4300_hyppyrimaet</Title>
+        <Abstract>Layer-Group type layer: lipas_4300_hyppyrimaet</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_4400_liikunta_ja_ulkoilureitit</Name>
+        <Title>lipas_4400_liikunta_ja_ulkoilureitit</Title>
+        <Abstract>Layer-Group type layer: lipas_4400_liikunta_ja_ulkoilureitit</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_4500_suunnistusalueet</Name>
+        <Title>lipas_4500_suunnistusalueet</Title>
+        <Abstract>Layer-Group type layer: lipas_4500_suunnistusalueet</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_4600_maastohiihtokeskukset</Name>
+        <Title>lipas_4600_maastohiihtokeskukset</Title>
+        <Abstract>Layer-Group type layer: lipas_4600_maastohiihtokeskukset</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_4700_kiipeilypaikat</Name>
+        <Title>lipas_4700_kiipeilypaikat</Title>
+        <Abstract>Layer-Group type layer: lipas_4700_kiipeilypaikat</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_4800_ampumaurheilupaikat</Name>
+        <Title>lipas_4800_ampumaurheilupaikat</Title>
+        <Abstract>Layer-Group type layer: lipas_4800_ampumaurheilupaikat</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_5000_veneily_ilmailu_ja_moottoriurheilu</Name>
+        <Title>lipas_5000_veneily_ilmailu_ja_moottoriurheilu</Title>
+        <Abstract>Layer-Group type layer: lipas_5000_veneily_ilmailu_ja_moottoriurheilu</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_5100_veneurheilupaikat</Name>
+        <Title>lipas_5100_veneurheilupaikat</Title>
+        <Abstract>Layer-Group type layer: lipas_5100_veneurheilupaikat</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_5200_urheiluilmailualueet</Name>
+        <Title>lipas_5200_urheiluilmailualueet</Title>
+        <Abstract>Layer-Group type layer: lipas_5200_urheiluilmailualueet</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_5300_moottoriurheilualueet</Name>
+        <Title>lipas_5300_moottoriurheilualueet</Title>
+        <Abstract>Layer-Group type layer: lipas_5300_moottoriurheilualueet</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_6000_elainurheilualueet</Name>
+        <Title>lipas_6000_elainurheilualueet</Title>
+        <Abstract>Layer-Group type layer: lipas_6000_elainurheilualueet</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_6100_hevosurheilu</Name>
+        <Title>lipas_6100_hevosurheilu</Title>
+        <Abstract>Layer-Group type layer: lipas_6100_hevosurheilu</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_6200_koiraurheilu</Name>
+        <Title>lipas_6200_koiraurheilu</Title>
+        <Abstract>Layer-Group type layer: lipas_6200_koiraurheilu</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_7000_huoltorakennukset</Name>
+        <Title>lipas_7000_huoltorakennukset</Title>
+        <Abstract>Layer-Group type layer: lipas_7000_huoltorakennukset</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_7000_huoltotilat</Name>
+        <Title>lipas_7000_huoltotilat</Title>
+        <Abstract>Layer-Group type layer: lipas_7000_huoltotilat</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-138.2964306833444</westBoundLongitude>
+          <eastBoundLongitude>172.22132727767712</eastBoundLongitude>
+          <southBoundLatitude>9.709331091734049</southBoundLatitude>
+          <northBoundLatitude>14420.402234976802</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-138.2964306833444" miny="9.709331091734049" maxx="172.22132727767712" maxy="14420.402234976802"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+      </Layer>
+      <Layer queryable="1">
+        <Name>lipas_kaikki_kohteet</Name>
+        <Title>lipas_kaikki_kohteet</Title>
+        <Abstract>Kaikki Lipaksen kohteet</Abstract>
+        <KeywordList/>
+        <CRS>EPSG:3067</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>16.267362756434956</westBoundLongitude>
+          <eastBoundLongitude>33.021967032884056</eastBoundLongitude>
+          <southBoundLatitude>59.67741707647288</southBoundLatitude>
+          <northBoundLatitude>70.08390148600903</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="16.267362756434956" miny="59.67741707647288" maxx="33.021967032884056" maxy="70.08390148600903"/>
+        <BoundingBox CRS="EPSG:3067" minx="87424.0775793173" miny="6638331.47211149" maxx="729733.912663529" maxy="7775282.38273566"/>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_101_lahipuisto</Name>
+        <Title>lipas_101_lahipuisto</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_101_lahipuisto</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_alueet_2</Name>
+          <Title>lipas:tyyli_alueet_2</Title>
+          <LegendURL width="233" height="300">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_101_lahipuisto"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_102_ulkoilupuisto</Name>
+        <Title>lipas_102_ulkoilupuisto</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_102_ulkoilupuisto</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_alueet_2</Name>
+          <Title>lipas:tyyli_alueet_2</Title>
+          <LegendURL width="233" height="300">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_102_ulkoilupuisto"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_103_ulkoilualue</Name>
+        <Title>lipas_103_ulkoilualue</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_103_ulkoilualue</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_alueet_2</Name>
+          <Title>lipas:tyyli_alueet_2</Title>
+          <LegendURL width="233" height="300">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_103_ulkoilualue"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_104_retkeilyalue</Name>
+        <Title>lipas_104_retkeilyalue</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_104_retkeilyalue</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_alueet_2</Name>
+          <Title>lipas:tyyli_alueet_2</Title>
+          <LegendURL width="233" height="300">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_104_retkeilyalue"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_106_monikayttoalue</Name>
+        <Title>lipas_106_monikayttoalue</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_106_monikayttoalue</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_alueet_2</Name>
+          <Title>lipas:tyyli_alueet_2</Title>
+          <LegendURL width="233" height="300">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_106_monikayttoalue"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_107_matkailupalveluiden_alue</Name>
+        <Title>lipas_107_matkailupalveluiden_alue</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_107_matkailupalveluiden_alue</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_alueet_2</Name>
+          <Title>lipas:tyyli_alueet_2</Title>
+          <LegendURL width="233" height="300">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_107_matkailupalveluiden_alue"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_108_virkistysmetsa</Name>
+        <Title>lipas_108_virkistysmetsa</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_108_virkistysmetsa</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_alueet_2</Name>
+          <Title>lipas:tyyli_alueet_2</Title>
+          <LegendURL width="233" height="300">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_108_virkistysmetsa"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_109_valtion_retkeilyalue</Name>
+        <Title>lipas_109_valtion_retkeilyalue</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_109_valtion_retkeilyalue</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_alueet_2</Name>
+          <Title>lipas:tyyli_alueet_2</Title>
+          <LegendURL width="233" height="300">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_109_valtion_retkeilyalue"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_110_eramaa_alue</Name>
+        <Title>lipas_110_eramaa_alue</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_110_eramaa_alue</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_alueet_2</Name>
+          <Title>lipas:tyyli_alueet_2</Title>
+          <LegendURL width="233" height="300">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_110_eramaa_alue"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_1110_liikuntapuisto</Name>
+        <Title>lipas_1110_liikuntapuisto</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_1110_liikuntapuisto</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_alueet_2</Name>
+          <Title>lipas:tyyli_alueet_2</Title>
+          <LegendURL width="233" height="300">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_1110_liikuntapuisto"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_111_kansallispuisto</Name>
+        <Title>lipas_111_kansallispuisto</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_111_kansallispuisto</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_alueet_2</Name>
+          <Title>lipas:tyyli_alueet_2</Title>
+          <LegendURL width="233" height="300">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_111_kansallispuisto"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_1120_lahiliikuntapaikka</Name>
+        <Title>lipas_1120_lahiliikuntapaikka</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_1120_lahiliikuntapaikka</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_1120_lahiliikuntapaikka"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_112_muu_luonnonsuojelualue</Name>
+        <Title>lipas_112_muu_luonnonsuojelualue</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_112_muu_luonnonsuojelualue</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_alueet_2</Name>
+          <Title>lipas:tyyli_alueet_2</Title>
+          <LegendURL width="233" height="300">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_112_muu_luonnonsuojelualue"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_1130_ulkokuntoilupaikka</Name>
+        <Title>lipas_1130_ulkokuntoilupaikka</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_1130_ulkokuntoilupaikka</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_1130_ulkokuntoilupaikka"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_1140_parkouralue</Name>
+        <Title>lipas_1140_parkouralue</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_1140_parkouralue</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_1140_parkouralue"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_1150_skeitti_rullaluistelupaikka</Name>
+        <Title>lipas_1150_skeitti_rullaluistelupaikka</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_1150_skeitti_rullaluistelupaikka</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_1150_skeitti_rullaluistelupaikka"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_1160_pyorailualue</Name>
+        <Title>lipas_1160_pyorailualue</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_1160_pyorailualue</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_1160_pyorailualue"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_1170_pyorailurata</Name>
+        <Title>lipas_1170_pyorailurata</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_1170_pyorailurata</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_1170_pyorailurata"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_1180_frisbeegolf_rata</Name>
+        <Title>lipas_1180_frisbeegolf_rata</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_1180_frisbeegolf_rata</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_1180_frisbeegolf_rata"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_1210_yleisurheilun_harjoitusalue</Name>
+        <Title>lipas_1210_yleisurheilun_harjoitusalue</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_1210_yleisurheilun_harjoitusalue</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_1210_yleisurheilun_harjoitusalue"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_1220_yleisurheilukentta</Name>
+        <Title>lipas_1220_yleisurheilukentta</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_1220_yleisurheilukentta</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_1220_yleisurheilukentta"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_1310_koripallokentta</Name>
+        <Title>lipas_1310_koripallokentta</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_1310_koripallokentta</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_1310_koripallokentta"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_1320_lentopallokentta</Name>
+        <Title>lipas_1320_lentopallokentta</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>lipas_1320_lentopallokentta</Keyword>
+          <Keyword>features</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_1320_lentopallokentta"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_1330_beachvolleykentta</Name>
+        <Title>lipas_1330_beachvolleykentta</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_1330_beachvolleykentta</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_1330_beachvolleykentta"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_1340_pallokentta</Name>
+        <Title>lipas_1340_pallokentta</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_1340_pallokentta</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_1340_pallokentta"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_1350_jalkapallostadion</Name>
+        <Title>lipas_1350_jalkapallostadion</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_1350_jalkapallostadion</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_1350_jalkapallostadion"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_1360_pesapallostadion</Name>
+        <Title>lipas_1360_pesapallostadion</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_1360_pesapallostadion</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_1360_pesapallostadion"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_1370_tenniskentta_alue</Name>
+        <Title>lipas_1370_tenniskentta_alue</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_1370_tenniskentta_alue</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_1370_tenniskentta_alue"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_1380_rullakiekkokentta</Name>
+        <Title>lipas_1380_rullakiekkokentta</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_1380_rullakiekkokentta</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_1380_rullakiekkokentta"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_1510_tekojaakentta</Name>
+        <Title>lipas_1510_tekojaakentta</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_1510_tekojaakentta</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_1510_tekojaakentta"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_1520_luistelukentta</Name>
+        <Title>lipas_1520_luistelukentta</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_1520_luistelukentta</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_1520_luistelukentta"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_1530_kaukalo</Name>
+        <Title>lipas_1530_kaukalo</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_1530_kaukalo</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_1530_kaukalo"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_1540_pikaluistelurata</Name>
+        <Title>lipas_1540_pikaluistelurata</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_1540_pikaluistelurata</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_1540_pikaluistelurata"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_1550_luistelureitti</Name>
+        <Title>lipas_1550_luistelureitti</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_1550_luistelureitti</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_1550_luistelureitti"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_1560_alamakiluistelurata</Name>
+        <Title>lipas_1560_alamakiluistelurata</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_1560_alamakiluistelurata</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_1560_alamakiluistelurata"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_1610_golfin_harjoitusalue</Name>
+        <Title>lipas_1610_golfin_harjoitusalue</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_1610_golfin_harjoitusalue</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_1610_golfin_harjoitusalue"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_1620_golfkentta</Name>
+        <Title>lipas_1620_golfkentta</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_1620_golfkentta</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_1620_golfkentta"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_1630_golfin_harjoitushalli</Name>
+        <Title>lipas_1630_golfin_harjoitushalli</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_1630_golfin_harjoitushalli</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_1630_golfin_harjoitushalli"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_1640_ratagolf</Name>
+        <Title>lipas_1640_ratagolf</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_1640_ratagolf</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_1640_ratagolf"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_201_kalastusalue</Name>
+        <Title>lipas_201_kalastusalue</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_201_kalastusalue</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_201_kalastusalue"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_202_telttailu_ja_leiriytyminen</Name>
+        <Title>lipas_202_telttailu_ja_leiriytyminen</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_202_telttailu_ja_leiriytyminen</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_202_telttailu_ja_leiriytyminen"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_203_veneilyn_palvelupaikka</Name>
+        <Title>lipas_203_veneilyn_palvelupaikka</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_203_veneilyn_palvelupaikka</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_203_veneilyn_palvelupaikka"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_204_luontotorni</Name>
+        <Title>lipas_204_luontotorni</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_204_luontotorni</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_204_luontotorni"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_205_rantautumispaikka</Name>
+        <Title>lipas_205_rantautumispaikka</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_205_rantautumispaikka</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_205_rantautumispaikka"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_206_ruoanlaittopaikka</Name>
+        <Title>lipas_206_ruoanlaittopaikka</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_206_ruoanlaittopaikka</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_206_ruoanlaittopaikka"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_207_opastuspiste</Name>
+        <Title>lipas_207_opastuspiste</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_207_opastuspiste</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_207_opastuspiste"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_2110_kuntokeskus</Name>
+        <Title>lipas_2110_kuntokeskus</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_2110_kuntokeskus</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_2110_kuntokeskus"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_2120_kuntosali</Name>
+        <Title>lipas_2120_kuntosali</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_2120_kuntosali</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_2120_kuntosali"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_2130_voimailusali</Name>
+        <Title>lipas_2130_voimailusali</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_2130_voimailusali</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_2130_voimailusali"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_2140_kamppailulajien_sali</Name>
+        <Title>lipas_2140_kamppailulajien_sali</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_2140_kamppailulajien_sali</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_2140_kamppailulajien_sali"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_2150_liikuntasali</Name>
+        <Title>lipas_2150_liikuntasali</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_2150_liikuntasali</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_2150_liikuntasali"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_2210_liikuntahalli</Name>
+        <Title>lipas_2210_liikuntahalli</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_2210_liikuntahalli</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_2210_liikuntahalli"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_2220_monitoimihalli</Name>
+        <Title>lipas_2220_monitoimihalli</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_2220_monitoimihalli</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_2220_monitoimihalli"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_2230_jalkapallohalli</Name>
+        <Title>lipas_2230_jalkapallohalli</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_2230_jalkapallohalli</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_2230_jalkapallohalli"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_2240_saliandyhalli</Name>
+        <Title>lipas_2240_saliandyhalli</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_2240_saliandyhalli</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_2240_saliandyhalli"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_2250_skeittihalli</Name>
+        <Title>lipas_2250_skeittihalli</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_2250_skeittihalli</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_2250_skeittihalli"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_2260_sulkapallohalli</Name>
+        <Title>lipas_2260_sulkapallohalli</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_2260_sulkapallohalli</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_2260_sulkapallohalli"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_2270_squash_halli</Name>
+        <Title>lipas_2270_squash_halli</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_2270_squash_halli</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_2270_squash_halli"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_2280_tennishalli</Name>
+        <Title>lipas_2280_tennishalli</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_2280_tennishalli</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_2280_tennishalli"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_2290_petanque_halli</Name>
+        <Title>lipas_2290_petanque_halli</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_2290_petanque_halli</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_2290_petanque_halli"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_2310_yksittainen_yleisurheilun_suorituspaikka</Name>
+        <Title>lipas_2310_yksittainen_yleisurheilun_suorituspaikka</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_2310_yksittainen_yleisurheilun_suorituspaikka</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_2310_yksittainen_yleisurheilun_suorituspaikka"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_2320_telinevoimistelutila</Name>
+        <Title>lipas_2320_telinevoimistelutila</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_2320_telinevoimistelutila</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_2320_telinevoimistelutila"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_2330_poytatennistila</Name>
+        <Title>lipas_2330_poytatennistila</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_2330_poytatennistila</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_2330_poytatennistila"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_2340_miekkailutila</Name>
+        <Title>lipas_2340_miekkailutila</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_2340_miekkailutila</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_2340_miekkailutila"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_2350_tanssitila</Name>
+        <Title>lipas_2350_tanssitila</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_2350_tanssitila</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_2350_tanssitila"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_2360_sisa_ampumarata</Name>
+        <Title>lipas_2360_sisa_ampumarata</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_2360_sisa_ampumarata</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_2360_sisa_ampumarata"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_2370_sisakiipeilyseina</Name>
+        <Title>lipas_2370_sisakiipeilyseina</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_2370_sisakiipeilyseina</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_2370_sisakiipeilyseina"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_2380_parkour_sali</Name>
+        <Title>lipas_2380_parkour_sali</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_2380_parkour_sali</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_2380_parkour_sali"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_2510_harjoitusjaahalli</Name>
+        <Title>lipas_2510_harjoitusjaahalli</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_2510_harjoitusjaahalli</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_2510_harjoitusjaahalli"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_2520_kilpajaahalli</Name>
+        <Title>lipas_2520_kilpajaahalli</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_2520_kilpajaahalli</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_2520_kilpajaahalli"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_2530_pikaluisteluhalli</Name>
+        <Title>lipas_2530_pikaluisteluhalli</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_2530_pikaluisteluhalli</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_2530_pikaluisteluhalli"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_2610_keilahalli</Name>
+        <Title>lipas_2610_keilahalli</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_2610_keilahalli</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_2610_keilahalli"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_301_laavu_kota_kammi</Name>
+        <Title>lipas_301_laavu_kota_kammi</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_301_laavu_kota_kammi</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_301_laavu_kota_kammi"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_302_tupa</Name>
+        <Title>lipas_302_tupa</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_302_tupa</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_302_tupa"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_304_ulkoilumaja_hiihtomaja</Name>
+        <Title>lipas_304_ulkoilumaja_hiihtomaja</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_304_ulkoilumaja_hiihtomaja</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_304_ulkoilumaja_hiihtomaja"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_3110_uimahalli</Name>
+        <Title>lipas_3110_uimahalli</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_3110_uimahalli</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_3110_uimahalli"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_3120_uima_allas</Name>
+        <Title>lipas_3120_uima_allas</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_3120_uima_allas</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_3120_uima_allas"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_3130_kylpyla</Name>
+        <Title>lipas_3130_kylpyla</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_3130_kylpyla</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_3130_kylpyla"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_3210_maauimala</Name>
+        <Title>lipas_3210_maauimala</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_3210_maauimala</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_3210_maauimala"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_3220_uimaranta</Name>
+        <Title>lipas_3220_uimaranta</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_3220_uimaranta</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_3220_uimaranta"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_3230_uimapaikka</Name>
+        <Title>lipas_3230_uimapaikka</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_3230_uimapaikka</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_3230_uimapaikka"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_3240_talviuintipaikka</Name>
+        <Title>lipas_3240_talviuintipaikka</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_3240_talviuintipaikka</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_3240_talviuintipaikka"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_4110_laskettelun_suorituspaikat</Name>
+        <Title>lipas_4110_laskettelun_suorituspaikat</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_4110_laskettelun_suorituspaikat</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_4110_laskettelun_suorituspaikat"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_4210_curlingrata</Name>
+        <Title>lipas_4210_curlingrata</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_4210_curlingrata</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_4210_curlingrata"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_4220_hiihtotunneli</Name>
+        <Title>lipas_4220_hiihtotunneli</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>lipas_4220_hiihtotunneli</Keyword>
+          <Keyword>features</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_4220_hiihtotunneli"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_4230_lumilautatunneli</Name>
+        <Title>lipas_4230_lumilautatunneli</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_4230_lumilautatunneli</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_4230_lumilautatunneli"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_4240_lasketteluhalli</Name>
+        <Title>lipas_4240_lasketteluhalli</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_4240_lasketteluhalli</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_4240_lasketteluhalli"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_4310_harjoitushyppyrimaki</Name>
+        <Title>lipas_4310_harjoitushyppyrimaki</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_4310_harjoitushyppyrimaki</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_4310_harjoitushyppyrimaki"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_4320_hyppyrimaki</Name>
+        <Title>lipas_4320_hyppyrimaki</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_4320_hyppyrimaki</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_4320_hyppyrimaki"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_4401_kuntorata</Name>
+        <Title>lipas_4401_kuntorata</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_4401_kuntorata</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_reitit</Name>
+          <Title>lipas:tyyli_reitit</Title>
+          <LegendURL width="209" height="260">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_4401_kuntorata"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_4402_latu</Name>
+        <Title>lipas_4402_latu</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_4402_latu</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_reitit</Name>
+          <Title>lipas:tyyli_reitit</Title>
+          <LegendURL width="209" height="260">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_4402_latu"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_4403_kavelyreitti</Name>
+        <Title>lipas_4403_kavelyreitti</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_4403_kavelyreitti</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_reitit</Name>
+          <Title>lipas:tyyli_reitit</Title>
+          <LegendURL width="209" height="260">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_4403_kavelyreitti"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_4404_luontopolku</Name>
+        <Title>lipas_4404_luontopolku</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_4404_luontopolku</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_reitit</Name>
+          <Title>lipas:tyyli_reitit</Title>
+          <LegendURL width="209" height="260">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_4404_luontopolku"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_4405_retkeilyreitti</Name>
+        <Title>lipas_4405_retkeilyreitti</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>lipas_4405_retkeilyreitti</Keyword>
+          <Keyword>features</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_reitit</Name>
+          <Title>lipas:tyyli_reitit</Title>
+          <LegendURL width="209" height="260">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_4405_retkeilyreitti"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_4411_maastopyorailyreitti</Name>
+        <Title>lipas_4411_maastopyorailyreitti</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_4411_maastopyorailyreitti</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_reitit</Name>
+          <Title>lipas:tyyli_reitit</Title>
+          <LegendURL width="209" height="260">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_4411_maastopyorailyreitti"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_4412_pyorailyreitti</Name>
+        <Title>lipas_4412_pyorailyreitti</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_4412_pyorailyreitti</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_reitit</Name>
+          <Title>lipas:tyyli_reitit</Title>
+          <LegendURL width="209" height="260">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_4412_pyorailyreitti"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_4421_moottorikelkkareitti</Name>
+        <Title>lipas_4421_moottorikelkkareitti</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_4421_moottorikelkkareitti</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_reitit</Name>
+          <Title>lipas:tyyli_reitit</Title>
+          <LegendURL width="209" height="260">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_4421_moottorikelkkareitti"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_4422_moottorikelkkaura</Name>
+        <Title>lipas_4422_moottorikelkkaura</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_4422_moottorikelkkaura</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_reitit</Name>
+          <Title>lipas:tyyli_reitit</Title>
+          <LegendURL width="209" height="260">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_4422_moottorikelkkaura"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_4430_hevosreitti</Name>
+        <Title>lipas_4430_hevosreitti</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_4430_hevosreitti</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_reitit</Name>
+          <Title>lipas:tyyli_reitit</Title>
+          <LegendURL width="209" height="260">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_4430_hevosreitti"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_4440_koirahiihtolatu</Name>
+        <Title>lipas_4440_koirahiihtolatu</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_4440_koirahiihtolatu</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_reitit</Name>
+          <Title>lipas:tyyli_reitit</Title>
+          <LegendURL width="209" height="260">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_4440_koirahiihtolatu"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_4451_melontareitti</Name>
+        <Title>lipas_4451_melontareitti</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_4451_melontareitti</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_reitit</Name>
+          <Title>lipas:tyyli_reitit</Title>
+          <LegendURL width="209" height="260">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_4451_melontareitti"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_4452_vesiretkeilyreitti</Name>
+        <Title>lipas_4452_vesiretkeilyreitti</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_4452_vesiretkeilyreitti</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_reitit</Name>
+          <Title>lipas:tyyli_reitit</Title>
+          <LegendURL width="209" height="260">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_4452_vesiretkeilyreitti"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_4510_suunnistusalue</Name>
+        <Title>lipas_4510_suunnistusalue</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_4510_suunnistusalue</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_alueet_2</Name>
+          <Title>lipas:tyyli_alueet_2</Title>
+          <LegendURL width="233" height="300">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_4510_suunnistusalue"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_4520_hiihtosuunnistusalue</Name>
+        <Title>lipas_4520_hiihtosuunnistusalue</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_4520_hiihtosuunnistusalue</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_alueet_2</Name>
+          <Title>lipas:tyyli_alueet_2</Title>
+          <LegendURL width="233" height="300">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_4520_hiihtosuunnistusalue"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_4530_pyorasuunnistusalue</Name>
+        <Title>lipas_4530_pyorasuunnistusalue</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_4530_pyorasuunnistusalue</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_alueet_2</Name>
+          <Title>lipas:tyyli_alueet_2</Title>
+          <LegendURL width="233" height="300">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_4530_pyorasuunnistusalue"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_4610_ampumahiihdon_harjoittelualue</Name>
+        <Title>lipas_4610_ampumahiihdon_harjoittelualue</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_4610_ampumahiihdon_harjoittelualue</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_4610_ampumahiihdon_harjoittelualue"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_4620_ampumahiihtokeskus</Name>
+        <Title>lipas_4620_ampumahiihtokeskus</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>lipas_4620_ampumahiihtokeskus</Keyword>
+          <Keyword>features</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_4620_ampumahiihtokeskus"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_4630_kilpahiihtokeskus</Name>
+        <Title>lipas_4630_kilpahiihtokeskus</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_4630_kilpahiihtokeskus</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_4630_kilpahiihtokeskus"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_4640_hiihtomaa</Name>
+        <Title>lipas_4640_hiihtomaa</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_4640_hiihtomaa</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_4640_hiihtomaa"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_4710_ulkokiipeilyseina</Name>
+        <Title>lipas_4710_ulkokiipeilyseina</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_4710_ulkokiipeilyseina</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_4710_ulkokiipeilyseina"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_4720_kiipeilykallio</Name>
+        <Title>lipas_4720_kiipeilykallio</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>lipas_4720_kiipeilykallio</Keyword>
+          <Keyword>features</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_4720_kiipeilykallio"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_4810_ampumarata</Name>
+        <Title>lipas_4810_ampumarata</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_4810_ampumarata</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_4810_ampumarata"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_4820_ampumaurheilukeskus</Name>
+        <Title>lipas_4820_ampumaurheilukeskus</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_4820_ampumaurheilukeskus</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_4820_ampumaurheilukeskus"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_4830_jousiammuntarata</Name>
+        <Title>lipas_4830_jousiammuntarata</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_4830_jousiammuntarata</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_4830_jousiammuntarata"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_4840_jousiammuntamaastorata</Name>
+        <Title>lipas_4840_jousiammuntamaastorata</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_4840_jousiammuntamaastorata</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_4840_jousiammuntamaastorata"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_5110_soutustadion</Name>
+        <Title>lipas_5110_soutustadion</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_5110_soutustadion</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_5110_soutustadion"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_5120_purjehdusalue</Name>
+        <Title>lipas_5120_purjehdusalue</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_5120_purjehdusalue</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_5120_purjehdusalue"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_5130_moottirveneurheilualue</Name>
+        <Title>lipas_5130_moottirveneurheilualue</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_5130_moottirveneurheilualue</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_5130_moottirveneurheilualue"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_5140_vesihiihtoalue</Name>
+        <Title>lipas_5140_vesihiihtoalue</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_5140_vesihiihtoalue</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_5140_vesihiihtoalue"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_5150_koskimelontakeskus</Name>
+        <Title>lipas_5150_koskimelontakeskus</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>lipas_5150_koskimelontakeskus</Keyword>
+          <Keyword>features</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_5150_koskimelontakeskus"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_5160_soudun_ja_melonnan_sisaharjoittelutila</Name>
+        <Title>lipas_5160_soudun_ja_melonnan_sisaharjoittelutila</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_5160_soudun_ja_melonnan_sisaharjoittelutila</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_5160_soudun_ja_melonnan_sisaharjoittelutila"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_5210_urheiluilmailualue</Name>
+        <Title>lipas_5210_urheiluilmailualue</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_5210_urheiluilmailualue</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_5210_urheiluilmailualue"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_5310_moottoriurheilukeskus</Name>
+        <Title>lipas_5310_moottoriurheilukeskus</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_5310_moottoriurheilukeskus</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_5310_moottoriurheilukeskus"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_5320_moottoripyorailualue</Name>
+        <Title>lipas_5320_moottoripyorailualue</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_5320_moottoripyorailualue</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_5320_moottoripyorailualue"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_5330_moottorirata</Name>
+        <Title>lipas_5330_moottorirata</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_5330_moottorirata</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_5330_moottorirata"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_5340_karting_rata</Name>
+        <Title>lipas_5340_karting_rata</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>lipas_5340_karting_rata</Keyword>
+          <Keyword>features</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_5340_karting_rata"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_5350_kiihdytysrata</Name>
+        <Title>lipas_5350_kiihdytysrata</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_5350_kiihdytysrata</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_5350_kiihdytysrata"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_5360_jokamies_ja_rallicross_rata</Name>
+        <Title>lipas_5360_jokamies_ja_rallicross_rata</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_5360_jokamies_ja_rallicross_rata</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_5360_jokamies_ja_rallicross_rata"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_5370_jaaspeedway_rata</Name>
+        <Title>lipas_5370_jaaspeedway_rata</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>lipas_5370_jaaspeedway_rata</Keyword>
+          <Keyword>features</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_5370_jaaspeedway_rata"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_6110_ratsastuskentta</Name>
+        <Title>lipas_6110_ratsastuskentta</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_6110_ratsastuskentta</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_6110_ratsastuskentta"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_6120_ratsastusmaneesi</Name>
+        <Title>lipas_6120_ratsastusmaneesi</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_6120_ratsastusmaneesi</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_6120_ratsastusmaneesi"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_6130_esteratsastuskentta</Name>
+        <Title>lipas_6130_esteratsastuskentta</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_6130_esteratsastuskentta</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_6130_esteratsastuskentta"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_6140_ravirata</Name>
+        <Title>lipas_6140_ravirata</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_6140_ravirata</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_6140_ravirata"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_6210_koiraurheilualue</Name>
+        <Title>lipas_6210_koiraurheilualue</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_6210_koiraurheilualue</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_6210_koiraurheilualue"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_6220_koiraurheiluhalli</Name>
+        <Title>lipas_6220_koiraurheiluhalli</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>lipas_6220_koiraurheiluhalli</Keyword>
+          <Keyword>features</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_6220_koiraurheiluhalli"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_7000_huoltorakennukset</Name>
+        <Title>lipas_7000_huoltorakennukset</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>lipas_7000_huoltorakennukset</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-6.381538627062841</westBoundLongitude>
+          <eastBoundLongitude>55.61796449437093</eastBoundLongitude>
+          <southBoundLatitude>60.381538627062845</southBoundLatitude>
+          <northBoundLatitude>75.58257023372553</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="-6.381538627062841" miny="60.381538627062845" maxx="55.61796449437093" maxy="75.58257023372553"/>
+        <BoundingBox CRS="EPSG:3067" minx="-548576.0" miny="1548576.0" maxx="6291456.0" maxy="8388608.0"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_7000_huoltorakennukset"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_kaikki_alueet</Name>
+        <Title>lipas_kaikki_alueet</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>alueet</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>23.11633051690517</westBoundLongitude>
+          <eastBoundLongitude>29.259187444496458</eastBoundLongitude>
+          <southBoundLatitude>59.173084029035316</southBoundLatitude>
+          <northBoundLatitude>65.31594095662659</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="23.11633051690517" miny="59.173084029035316" maxx="29.259187444496458" maxy="65.31594095662659"/>
+        <BoundingBox CRS="EPSG:3067" minx="316631.004014732" miny="6645750.81459302" maxx="605365.109519806" maxy="7161732.44483066"/>
+        <Style>
+          <Name>lipas:tyyli_alueet_2</Name>
+          <Title>lipas:tyyli_alueet_2</Title>
+          <LegendURL width="233" height="300">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_kaikki_alueet"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_kaikki_pisteet</Name>
+        <Title>lipas_kaikki_pisteet</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>pisteet</Keyword>
+          <Keyword>features</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>15.021777994913297</westBoundLongitude>
+          <eastBoundLongitude>34.26755179440572</eastBoundLongitude>
+          <southBoundLatitude>55.25777238077261</southBoundLatitude>
+          <northBoundLatitude>74.50354618026502</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="15.021777994913297" miny="55.25777238077261" maxx="34.26755179440572" maxy="74.50354618026502"/>
+        <BoundingBox CRS="EPSG:3067" minx="87424.0775793173" miny="6638331.47211149" maxx="729733.912663529" maxy="7775282.38273566"/>
+        <Style>
+          <Name>lipas:tyyli_pisteet</Name>
+          <Title>lipas:tyyli_pisteet</Title>
+          <LegendURL width="324" height="2160">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_kaikki_pisteet"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>lipas_kaikki_reitit</Name>
+        <Title>lipas_kaikki_reitit</Title>
+        <Abstract/>
+        <KeywordList>
+          <Keyword>features</Keyword>
+          <Keyword>reitit</Keyword>
+        </KeywordList>
+        <CRS>EPSG:3067</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>16.255181925916855</westBoundLongitude>
+          <eastBoundLongitude>32.92531108445746</eastBoundLongitude>
+          <southBoundLatitude>56.500891533189</southBoundLatitude>
+          <northBoundLatitude>73.17102069172961</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" minx="16.255181925916855" miny="56.500891533189" maxx="32.92531108445746" maxy="73.17102069172961"/>
+        <BoundingBox CRS="EPSG:3067" minx="89742.3638506016" miny="6648833.81548444" maxx="721706.920386512" maxy="7754598.75525577"/>
+        <Style>
+          <Name>lipas:tyyli_reitit</Name>
+          <Title>lipas:tyyli_reitit</Title>
+          <LegendURL width="209" height="260">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://not.a.real.domain/geoserver/lipas/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=lipas_kaikki_reitit"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+    </Layer>
+  </Capability>
+</WMS_Capabilities>


### PR DESCRIPTION
OskariLayerCapabilitiesHelper can't handle layers with absolutely no style. Fix that.
In addition instead of failing to handle service with layers duplicate ids just log the issue as a warning.