### PR TITLE
Add default value to workaround incomplete/faulty style JSON

### DIFF
--- a/service-print/src/main/java/org/oskari/print/util/StyleUtil.java
+++ b/service-print/src/main/java/org/oskari/print/util/StyleUtil.java
@@ -60,7 +60,7 @@ public class StyleUtil {
         JSONObject stroke = JSONHelper.getJSONObject(oskariStyle, "stroke");
         setStrokeStyle(style, stroke);
         // polygon doesn't have cap style
-        style.setLineCap(LINE_CAP_STYLE.get(JSONHelper.optString(stroke,"lineCap")));
+        style.setLineCap(LINE_CAP_STYLE.getOrDefault(JSONHelper.optString(stroke,"lineCap"), 0));
         style.setLabelProperty(getLabelStyle(oskariStyle));
         return style;
     }

--- a/service-print/src/main/java/org/oskari/print/util/StyleUtil.java
+++ b/service-print/src/main/java/org/oskari/print/util/StyleUtil.java
@@ -96,7 +96,7 @@ public class StyleUtil {
         float width = (float) json.optDouble("width", 1);
         String lineDash = JSONHelper.optString(json,"lineDash");
         style.setLineWidth(width);
-        style.setLineJoin(LINE_JOIN_STYLE.get(JSONHelper.optString(json,"lineJoin")));
+        style.setLineJoin(LINE_JOIN_STYLE.getOrDefault(JSONHelper.optString(json,"lineJoin"), 0));
         style.setLinePattern(getStrokeDash(lineDash, width));
         style.setLineColor(ColorUtil.parseColor(JSONHelper.optString(json,"color")));
     }


### PR DESCRIPTION
Currently null/missing/unexpected value for lineJoin and lineCap results in NPE and no printout for the user. This fixes the issue by adding a default values.