### PR TITLE
Ignore cached capabilities if more than 5 minutes old

### DIFF
--- a/service-map/src/main/java/fi/nls/oskari/service/capabilities/CapabilitiesCacheService.java
+++ b/service-map/src/main/java/fi/nls/oskari/service/capabilities/CapabilitiesCacheService.java
@@ -67,6 +67,10 @@ public abstract class CapabilitiesCacheService extends OskariComponent {
         if (caps != null) {
             return caps;
         }
+        return getCapabilitiesFromService(url, type, version, user, pass);
+    }
+    // Always skip cached for example when adding layers
+    public OskariLayerCapabilities getCapabilitiesFromService(String url, String type, String version, String user, String pass) throws ServiceException {
         String data = getFromService(url, type, version, user, pass);
         return getDraft(url, type, version, data);
     }

--- a/service-map/src/main/java/fi/nls/oskari/service/capabilities/OskariLayerCapabilities.java
+++ b/service-map/src/main/java/fi/nls/oskari/service/capabilities/OskariLayerCapabilities.java
@@ -1,6 +1,7 @@
 package fi.nls.oskari.service.capabilities;
 
 import java.sql.Timestamp;
+import java.util.concurrent.TimeUnit;
 
 public class OskariLayerCapabilities {
 
@@ -63,6 +64,16 @@ public class OskariLayerCapabilities {
 
     public Timestamp getUpdated() {
         return updated;
+    }
+
+    public boolean isOlderThan(long updatedMoreRecentlyThanMs) {
+        if (created == null) {
+            return false;
+        }
+        if (updated == null) {
+            return created.getTime() + updatedMoreRecentlyThanMs < System.currentTimeMillis();
+        }
+        return updated.getTime() + updatedMoreRecentlyThanMs < System.currentTimeMillis();
     }
 
     @Override

--- a/service-map/src/main/java/fi/nls/oskari/service/capabilities/OskariLayerCapabilities.java
+++ b/service-map/src/main/java/fi/nls/oskari/service/capabilities/OskariLayerCapabilities.java
@@ -1,7 +1,6 @@
 package fi.nls.oskari.service.capabilities;
 
 import java.sql.Timestamp;
-import java.util.concurrent.TimeUnit;
 
 public class OskariLayerCapabilities {
 


### PR DESCRIPTION
Would be a good opportunity to make the capabilities service api cleaner. Instead of this little update. 

Fixes an issue where when adding a layer using admin-layereditor the admin might get layers based on a cached capabilities response (that might be several years old).