### PR TITLE
Remember to close PDDocuments

### DIFF
--- a/service-print/src/main/java/org/oskari/print/util/StyleUtil.java
+++ b/service-print/src/main/java/org/oskari/print/util/StyleUtil.java
@@ -167,10 +167,10 @@ public class StyleUtil {
         PDFTranscoder transcoder = new PDFTranscoder();
         TranscoderInput in = new TranscoderInput(new ByteArrayInputStream(markerData.getBytes()));
 
-        try (ByteArrayOutputStream os = new ByteArrayOutputStream()){
-            TranscoderOutput out = new TranscoderOutput(os);
-            transcoder.transcode(in, out);
-            PDDocument tempDoc = PDDocument.load(os.toByteArray());
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        TranscoderOutput out = new TranscoderOutput(os);
+        transcoder.transcode(in, out);
+        try (PDDocument tempDoc = PDDocument.load(os.toByteArray())) {
             PDPage page = tempDoc.getPage(0);
 
             double d = page.getBBox().getHeight() / ICON_SIZE;


### PR DESCRIPTION
Currently the temporary document is not properly closed which creates unnecessary warnings.
`org.apache.pdfbox.cos.COSDocument finalize WARNING: Warning: You did not close a PDF Document`
Luckily we don't actually leak resources as this gets handled by the finalize method in https://github.com/apache/pdfbox/blob/2.0.16/pdfbox/src/main/java/org/apache/pdfbox/cos/COSDocument.java#L514