### PR TITLE
Normalize metadataid

### DIFF
--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/ServiceCapabilitiesHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/ServiceCapabilitiesHandler.java
@@ -6,6 +6,8 @@ import fi.nls.oskari.annotation.OskariActionRoute;
 import fi.nls.oskari.control.ActionDeniedException;
 import fi.nls.oskari.control.ActionException;
 import fi.nls.oskari.control.ActionParameters;
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.service.ServiceException;
 import fi.nls.oskari.service.ServiceUnauthorizedException;
 import fi.nls.oskari.util.PropertyUtil;
@@ -28,6 +30,7 @@ public class ServiceCapabilitiesHandler extends AbstractLayerAdminHandler {
     private static final String PARAM_PASSWORD = "pw";
     private static final String PARAM_TYPE = "type";
 
+    private static final Logger LOG = LogFactory.getLogger(ServiceCapabilitiesHandler.class);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     static {
         OBJECT_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
@@ -71,6 +74,7 @@ public class ServiceCapabilitiesHandler extends AbstractLayerAdminHandler {
             } else if (rootcause instanceof XMLStreamException || rootcause instanceof ServiceException) {
                 ResponseHelper.writeError(params, e.getMessage(), HttpServletResponse.SC_EXPECTATION_FAILED);
             } else {
+                LOG.error(e, "Couldn't determine fail reason");
                 ResponseHelper.writeError(params, e.getMessage());
             }
         }

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
@@ -219,7 +219,7 @@ public class LayerJSONFormatter {
     }
 
     // This is solution of transition for dataUrl and for dataUrl_uuid
-    protected static String getFixedDataUrl(String metadataId) {
+    public static String getFixedDataUrl(String metadataId) {
         if(metadataId == null || metadataId.isEmpty()) {
             return null;
         }

--- a/service-map/src/main/java/fi/nls/oskari/wms/WMSCapabilitiesService.java
+++ b/service-map/src/main/java/fi/nls/oskari/wms/WMSCapabilitiesService.java
@@ -6,6 +6,7 @@ import fi.mml.map.mapwindow.service.wms.WebMapServiceFactoryHelper;
 import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.map.layer.formatters.LayerJSONFormatter;
 import fi.nls.oskari.service.ServiceException;
 import fi.nls.oskari.service.capabilities.CapabilitiesCacheService;
 import fi.nls.oskari.service.capabilities.CapabilitiesConstants;
@@ -178,6 +179,7 @@ public class WMSCapabilitiesService {
                 oskariLayer.setMetadataId(meta.get(0).getUrl().toString());
             }
         }
+        oskariLayer.setMetadataId(LayerJSONFormatter.getFixedDataUrl(oskariLayer.getMetadataId()));
 
         try {
             // TODO: could we use (to get rid of capabilitiesXML):


### PR DESCRIPTION
When getting service capabilties. Fixes an issue where whole URL is used as metadataid when the db-field for it is restricted to 200 characters and URL might be longer. As we only support having one CSW-service configured we might as well remove everything but the metadata id.