### PR TITLE
Revert "Migrations in single transaction"

### DIFF
--- a/content-resources/src/main/java/fi/nls/oskari/db/FlywaydbMigrator.java
+++ b/content-resources/src/main/java/fi/nls/oskari/db/FlywaydbMigrator.java
@@ -27,9 +27,6 @@ public class FlywaydbMigrator {
         flyway.setDataSource(datasource);
         flyway.setTable(getStatusTableName(moduleName));
         flyway.setLocations(getScriptLocations(moduleName));
-        // runs all pending migrations in single transaction so users don't get in to a situation where the database
-        // is half but not fully migrated to the new version
-        flyway.setGroup(true);
         if (flyway.info().current() == null) {
             flyway.setBaselineVersionAsString("0.1");
             flyway.baseline();


### PR DESCRIPTION
Reverts oskariorg/oskari-server#572

This breaks the empty database initialization. Problematic migrations are:
- flyway/oskari/V1_37_1__publisher2_migration
- flyway/oskari/V1_39_1__migrate_publish_template_ol3

which both can be skipped but after that there's a problem with the json setup files with inserting layers and not finding the referenced dataprovider.

So reverting the change for now.