### PR TITLE
Avoid NPEs in OskariStyle handling in service-print

### DIFF
--- a/service-base/src/main/java/fi/nls/oskari/util/JSONHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/JSONHelper.java
@@ -8,6 +8,7 @@ import org.json.JSONObject;
 import org.json.JSONTokener;
 
 import java.util.*;
+import java.util.function.Supplier;
 
 
 public class JSONHelper {
@@ -71,6 +72,10 @@ public class JSONHelper {
             log.info("Couldn't get JSONObject from ", content, " with key =", key);
             return null;
         }
+    }
+    public static final JSONObject optJSONObject(final JSONObject content, String key, Supplier<JSONObject> fallback) {
+        JSONObject ret = content != null ? content.optJSONObject(key) : null;
+        return ret != null ? ret : fallback.get();
     }
     public static final Object get(final JSONObject content, String key) {
         if(content == null) {

--- a/service-base/src/main/java/fi/nls/oskari/util/JSONHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/JSONHelper.java
@@ -8,7 +8,6 @@ import org.json.JSONObject;
 import org.json.JSONTokener;
 
 import java.util.*;
-import java.util.function.Supplier;
 
 
 public class JSONHelper {
@@ -72,10 +71,6 @@ public class JSONHelper {
             log.info("Couldn't get JSONObject from ", content, " with key =", key);
             return null;
         }
-    }
-    public static final JSONObject optJSONObject(final JSONObject content, String key, Supplier<JSONObject> fallback) {
-        JSONObject ret = content != null ? content.optJSONObject(key) : null;
-        return ret != null ? ret : fallback.get();
     }
     public static final Object get(final JSONObject content, String key) {
         if(content == null) {

--- a/service-print/src/main/java/org/oskari/print/request/PDPrintStyle.java
+++ b/service-print/src/main/java/org/oskari/print/request/PDPrintStyle.java
@@ -3,90 +3,80 @@ package org.oskari.print.request;
 import java.awt.Color;
 import java.io.IOException;
 import java.util.List;
+import java.util.function.Function;
 
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
 import org.apache.pdfbox.pdmodel.font.PDFont;
 import org.apache.pdfbox.pdmodel.font.PDType1Font;
 import org.apache.pdfbox.pdmodel.graphics.color.PDColor;
+import org.apache.pdfbox.pdmodel.graphics.color.PDDeviceRGB;
 import org.apache.pdfbox.pdmodel.graphics.form.PDFormXObject;
 import org.oskari.print.util.PDFBoxUtil;
-import org.oskari.print.util.StyleUtil;
 
 public class PDPrintStyle {
+
     public static final PDFont FONT = PDType1Font.HELVETICA;
     public static final PDFont FONT_BOLD = PDType1Font.HELVETICA_BOLD;
     public static final float FONT_SIZE = 12f;
     public static final float FONT_SIZE_SCALE = 10f;
     public static final float FONT_SIZE_TIMESERIES = 10f;
 
-    private Color lineColor;
-    private float [] linePattern;
-    private Color fillColor;
     private float lineWidth;
-    private int lineJoin;
-    private int lineCap;
-    private PDColor fillPattern;
+    private LineJoin lineJoin;
+    private LineCap lineCap;
+    private LinePattern linePattern;
+    private PDColor strokeColor;
+    private PDColor fillColor;
     private PDFormXObject icon;
     private List<String> labelProperty;
     private LabelAlign labelAlign;
 
     public PDPrintStyle () {
         lineWidth = 1f;
+        lineJoin = LineJoin.miter;
+        lineCap = LineCap.butt;
+        linePattern = LinePattern.solid;
     }
 
-    public Color getLineColor() {
-        return lineColor;
-    }
-
-    public void setLineColor(Color lineColor) {
-        this.lineColor = lineColor;
-    }
-
-    public float[] getLinePattern() {
-        return linePattern;
-    }
-
-    public void setLinePattern(float[] linePattern) {
-        this.linePattern = linePattern;
-    }
-
-    public Color getFillColor() {
-        return fillColor;
-    }
-
-    public void setFillColor(Color fillColor) {
-        this.fillColor = fillColor;
-    }
-
-    public float getLineWidth() {
-        return lineWidth;
+    public void apply(PDPageContentStream stream) throws IOException {
+        stream.setLineWidth(lineWidth);
+        stream.setLineJoinStyle(lineJoin.code);
+        stream.setLineCapStyle(lineCap.code);
+        stream.setLineDashPattern(linePattern.f.apply(lineWidth), 0);
+        if (strokeColor != null) {
+            stream.setStrokingColor(strokeColor);
+        }
+        if (fillColor != null) {
+            stream.setNonStrokingColor(fillColor);
+        }
     }
 
     public void setLineWidth(float lineWidth) {
         this.lineWidth = lineWidth;
     }
 
-    public PDColor getFillPattern() {
-        return fillPattern;
-    }
-
-    public void setFillPattern(PDColor fillPattern) {
-        this.fillPattern = fillPattern;
-    }
-
-    public int getLineJoin() {
-        return lineJoin;
-    }
-
-    public void setLineJoin(int lineJoin) {
+    public void setLineJoin(LineJoin lineJoin) {
         this.lineJoin = lineJoin;
     }
 
-    public int getLineCap() {
-        return lineCap;
+    public void setLineCap(LineCap lineCap) {
+        this.lineCap = lineCap;
     }
 
-    public void setLineCap(int lineCap) {
-        this.lineCap = lineCap;
+    public void setLinePattern(LinePattern linePattern) {
+        this.linePattern = linePattern;
+    }
+
+    public void setStrokeColor(PDColor strokeColor) {
+        this.strokeColor = strokeColor;
+    }
+
+    public void setFillColor(PDColor fillColor) {
+        this.fillColor = fillColor;
+    }
+
+    public void setFillColor(Color color) {
+        setFillColor(toRGBColor(color));
     }
 
     public PDFormXObject getIcon() {
@@ -104,27 +94,37 @@ public class PDPrintStyle {
     public void setLabelProperty(List<String> labelProperty) {
         this.labelProperty = labelProperty;
     }
-    public LabelAlign getLabelAlign () {
+
+    public LabelAlign getLabelAlign() {
         return labelAlign;
     }
-    public void setLabelAlign (LabelAlign labelAlign) {
+
+    public void setLabelAlign(LabelAlign labelAlign) {
         this.labelAlign = labelAlign;
     }
 
-    public boolean hasFillPattern () {
-        return fillPattern != null;
+    public boolean hasLineColor() {
+        return strokeColor != null;
     }
-    public boolean hasLinePattern () {
-        return linePattern != null;
-    }
-    public boolean hasFillColor () {
+
+    public boolean hasFillColor() {
         return fillColor != null;
     }
-    public boolean hasLineColor () {
-        return lineColor != null;
-    }
+
     public boolean hasLabels () {
         return labelProperty != null && !labelProperty.isEmpty();
+    }
+
+    private static PDColor toRGBColor(Color color) {
+        if (color == null) {
+            return null;
+        }
+        float[] components = new float[] {
+                color.getRed() / 255f,
+                color.getGreen() / 255f,
+                color.getBlue() / 255f
+        };
+        return new PDColor(components, PDDeviceRGB.INSTANCE);
     }
 
     public static class LabelAlign {
@@ -171,6 +171,74 @@ public class PDPrintStyle {
         public float getLabelY () {
             return offsetY;
         }
+    }
+
+    public enum LineCap {
+
+        butt(0),
+        round(1),
+        square(2);
+
+        public final int code;
+
+        private LineCap(int code) {
+            this.code = code;
+        }
+
+        public static LineCap get(String key) {
+            try {
+                return valueOf(key);
+            } catch (Exception ignore) {
+                return null;
+            }
+        }
+    }
+
+    public enum LineJoin {
+
+        mitre(0),
+        miter(0),
+        round(1),
+        bevel(2);
+
+        public final int code;
+
+        private LineJoin(int code) {
+            this.code = code;
+        }
+
+        public static LineJoin get(String key) {
+            try {
+                return valueOf(key);
+            } catch (Exception ignore) {
+                return null;
+            }
+        }
+    }
+
+    public enum LinePattern {
+
+        solid(width -> new float[] { 0 }),
+        dash(width -> new float[] { 5, 4 + width }),
+        dashdot(width -> new float[] { 1, 1 + width }),
+        dot(width -> new float[] { 1, 1 + width }),
+        longdash(width -> new float[] { 10, 4 + width }),
+        longdashdot(width -> new float[] { 5, 1 + width, 1, 1 + width });
+
+        public final Function<Float, float[]> f;
+
+        private LinePattern(Function<Float, float[]> f) {
+            this.f = f;
+        }
+
+        public static LinePattern get(String key) {
+            try {
+                return valueOf(key);
+            } catch (Exception ignore) {
+                return null;
+            }
+        }
+
     }
 
 }

--- a/service-print/src/main/java/org/oskari/print/request/PrintVectorRule.java
+++ b/service-print/src/main/java/org/oskari/print/request/PrintVectorRule.java
@@ -3,43 +3,21 @@ package org.oskari.print.request;
 import org.opengis.filter.Filter;
 
 public class PrintVectorRule {
-    public enum RuleType  {
-        POINT,
-        LINE,
-        POLYGON
-    }
 
-    private RuleType type;
-    private Filter filter;
-    private PDPrintStyle style;
+    private final Filter filter;
+    private final PDPrintStyle style;
 
-    public PrintVectorRule (RuleType type, Filter filter, PDPrintStyle style) {
-        this.type = type;
+    public PrintVectorRule(Filter filter, PDPrintStyle style) {
         this.filter = filter;
         this.style = style;
-    }
-
-    public RuleType getType() {
-        return type;
-    }
-
-    public void setType(RuleType type) {
-        this.type = type;
     }
 
     public Filter getFilter() {
         return filter;
     }
 
-    public void setFilter(Filter filter) {
-        this.filter = filter;
-    }
-
     public PDPrintStyle getStyle() {
         return style;
     }
 
-    public void setStyle(PDPrintStyle style) {
-        this.style = style;
-    }
 }

--- a/service-print/src/main/java/org/oskari/print/util/StyleUtil.java
+++ b/service-print/src/main/java/org/oskari/print/util/StyleUtil.java
@@ -6,9 +6,10 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
-import fi.nls.oskari.util.IOHelper;
 import org.apache.batik.transcoder.TranscoderException;
 import org.apache.batik.transcoder.TranscoderInput;
 import org.apache.batik.transcoder.TranscoderOutput;
@@ -17,102 +18,140 @@ import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.multipdf.LayerUtility;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
-import org.apache.pdfbox.pdmodel.graphics.form.PDFormXObject;
 import org.apache.pdfbox.pdmodel.PDPatternContentStream;
 import org.apache.pdfbox.pdmodel.PDResources;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.apache.pdfbox.pdmodel.graphics.color.PDColor;
 import org.apache.pdfbox.pdmodel.graphics.color.PDDeviceRGB;
 import org.apache.pdfbox.pdmodel.graphics.color.PDPattern;
+import org.apache.pdfbox.pdmodel.graphics.form.PDFormXObject;
 import org.apache.pdfbox.pdmodel.graphics.pattern.PDTilingPattern;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.oskari.print.PDF;
 import org.oskari.print.request.PDPrintStyle;
+import org.oskari.print.request.PDPrintStyle.LineCap;
+import org.oskari.print.request.PDPrintStyle.LineJoin;
+import org.oskari.print.request.PDPrintStyle.LinePattern;
+
+import fi.nls.oskari.util.IOHelper;
 import fi.nls.oskari.util.JSONHelper;
 
 public class StyleUtil {
+
     private static final String SVG_MARKERS_JSON = "svg-markers.json";
     private static final String ICON_STROKE_COLOR = "#b4b4b4";
     private static final float ICON_SIZE = 32f;
     private static final double ICON_OFFSET = ICON_SIZE/2.0;
-    public static final float [] LINE_PATTERN_SOLID = new float[0];
 
-    public static final Map<String, Integer> LINE_CAP_STYLE  = new HashMap<String, Integer>() {{
-        put("butt",0);
-        put("round", 1);
-        put("square", 2);
-    }};
-    public static final Map<String, Integer> LINE_JOIN_STYLE  = new HashMap<String, Integer>() {{
-        put("mitre",0);
-        put("miter",0);
-        put("round", 1);
-        put("bevel", 2);
-    }};
     public static final Map<String, PDPrintStyle.LabelAlign> LABEL_ALIGN_MAP = new HashMap<String, PDPrintStyle.LabelAlign>() {{
         put("markers", new PDPrintStyle.LabelAlign("left", 12f, 8f));
     }};
 
     public static PDPrintStyle getLineStyle (JSONObject oskariStyle) {
-        PDPrintStyle style = new PDPrintStyle();
-        JSONObject stroke = JSONHelper.optJSONObject(oskariStyle, "stroke", () -> new JSONObject());
-        setStrokeStyle(style, stroke);
-        // polygon doesn't have cap style
-        setLabelStyle(style, oskariStyle);
-        style.setLineCap(LINE_CAP_STYLE.getOrDefault(JSONHelper.optString(stroke,"lineCap"), 0));
+        JSONObject stroke = oskariStyle.optJSONObject("stroke");
 
+        PDPrintStyle style = new PDPrintStyle();
+        setStrokeStyle(style, stroke);
+        setLabelStyle(style, oskariStyle);
         return style;
     }
+
     public static PDPrintStyle getPolygonStyle (JSONObject oskariStyle, PDResources resources) throws IOException {
-        PDPrintStyle style = new PDPrintStyle();
-        JSONObject stroke = JSONHelper.optJSONObject(oskariStyle, "stroke", () -> new JSONObject());
-        JSONObject strokeArea = JSONHelper.optJSONObject(stroke, "area", () -> new JSONObject());
-        setStrokeStyle(style, strokeArea);
-
-        JSONObject fill = JSONHelper.optJSONObject(oskariStyle, "fill", () -> new JSONObject());
-        JSONObject fillArea = JSONHelper.optJSONObject(fill, "area", () -> new JSONObject());
-        int pattern = fillArea.optInt("pattern");
-        Color color = ColorUtil.parseColor(JSONHelper.optString(fill,"color"));
-        style.setFillColor(color);
-
-        if (pattern >= 0 && pattern <= 3 && color != null) {
-            style.setFillPattern(createFillPattern(resources, pattern, color));
+        JSONObject stroke = oskariStyle.optJSONObject("stroke");
+        if (stroke != null) {
+            stroke = stroke.optJSONObject("area");
         }
+
+        PDPrintStyle style = new PDPrintStyle();
+        setStrokeStyle(style, stroke);
+        setFillStyle(style, oskariStyle, resources);
         setLabelStyle(style, oskariStyle);
         return style;
     }
 
     public static PDPrintStyle getPointStyle (JSONObject oskariStyle, PDDocument doc) throws IOException {
         PDPrintStyle style = new PDPrintStyle();
-        JSONObject image = JSONHelper.optJSONObject(oskariStyle, "image", () -> new JSONObject());
-        int shape = image.optInt("shape", 5); // External icons not supported
-        JSONObject imageFill = JSONHelper.optJSONObject(image, "fill", () -> new JSONObject());
-        String fillColor = JSONHelper.optString(imageFill, "color");
-        style.setFillColor(ColorUtil.parseColor(fillColor));
-        int size = image.optInt("size", 3);
-        style.setIcon(getIcon(doc, shape, fillColor, size));
+        setImageStyle(style, oskariStyle, doc);
         setLabelStyle(style, oskariStyle);
         return style;
     }
-    private static void setStrokeStyle (PDPrintStyle style, JSONObject json) {
-        float width = (float) json.optDouble("width", 1);
-        String lineDash = JSONHelper.optString(json,"lineDash");
-        style.setLineWidth(width);
-        style.setLineJoin(LINE_JOIN_STYLE.getOrDefault(JSONHelper.optString(json,"lineJoin"), 0));
-        style.setLinePattern(getStrokeDash(lineDash, width));
-        style.setLineColor(ColorUtil.parseColor(JSONHelper.optString(json,"color")));
+
+    private static void setStrokeStyle(PDPrintStyle style, JSONObject stroke) {
+        if (stroke == null) {
+            return;
+        }
+
+        float lineWidth = (float) stroke.optDouble("width", -1);
+        if (lineWidth > 0) {
+            style.setLineWidth(lineWidth);
+        }
+        LineJoin lineJoin = LineJoin.get(JSONHelper.optString(stroke, "lineJoin"));
+        if (lineJoin != null) {
+            style.setLineJoin(lineJoin);
+        }
+        LineCap lineCap = LineCap.get(JSONHelper.optString(stroke, "lineCap"));
+        if (lineCap != null) {
+            style.setLineCap(lineCap);
+        }
+        LinePattern linePattern = LinePattern.get(JSONHelper.optString(stroke, "lineDash"));
+        if (linePattern != null) {
+            style.setLinePattern(linePattern);
+        }
+        Color color = ColorUtil.parseColor(JSONHelper.optString(stroke, "color"));
+        if (color != null) {
+            style.setFillColor(color);
+        }
     }
+
+    private static void setFillStyle(PDPrintStyle style, JSONObject oskariStyle, PDResources resources) throws IOException {
+        JSONObject fill = oskariStyle.optJSONObject("fill");
+        if (fill == null) {
+            return;
+        }
+
+        Color color = ColorUtil.parseColor(JSONHelper.optString(fill, "color"));
+        if (color == null) {
+            return;
+        }
+        JSONObject fillArea = fill.optJSONObject("area");
+        int pattern = fillArea != null ? fillArea.optInt("pattern", -1) : -1;
+        if (pattern >= 0 && pattern <= 3) {
+            style.setFillColor(createFillPattern(resources, pattern, color));
+        } else {
+            style.setFillColor(color);
+        }
+    }
+
+    private static void setImageStyle(PDPrintStyle style, JSONObject oskariStyle, PDDocument doc) throws IOException {
+        JSONObject image = oskariStyle.optJSONObject("image");
+        if (image == null) {
+            return;
+        }
+
+        JSONObject fill = image.optJSONObject("fill");
+        String color = fill != null ? JSONHelper.optString(fill, "color") : null;
+        if (color == null) {
+            return;
+        }
+        style.setFillColor(ColorUtil.parseColor(color));
+
+        int shape = image.optInt("shape", 5); // External icons not supported
+        int size = image.optInt("size", 3);
+        style.setIcon(getIcon(doc, shape, color, size));
+    }
+
     private static void setLabelStyle (PDPrintStyle style, JSONObject oskariStyle) {
         JSONObject text = JSONHelper.getJSONObject(oskariStyle, "text");
-        if (text == null) return;
+        if (text == null) {
+            return;
+        }
         Object labelProperty = text.opt("labelProperty");
-        if (labelProperty instanceof  JSONArray) {
+        if (labelProperty instanceof JSONArray) {
             style.setLabelProperty(JSONHelper.getArrayAsList((JSONArray) labelProperty));
-        } else if (labelProperty instanceof  String){
-            List <String> propList = new ArrayList();
-            propList.add((String) labelProperty);
-            style.setLabelProperty(propList);
+        } else if (labelProperty instanceof String){
+            style.setLabelProperty(Collections.singletonList((String) labelProperty));
         }
         int offsetX = text.optInt("offsetX", 0);
         int offsetY = text.optInt("offsetY", 0);
@@ -142,27 +181,6 @@ public class StyleUtil {
         }
     }
 
-    private static  float[] getStrokeDash (String dash, float strokeWidth) {
-        float [] pattern;
-        switch (dash) {
-            case "dash":
-                pattern = new float[]{5, 4 + strokeWidth};
-                break;
-            case "dashdot":
-            case "dot":
-                pattern = new float[]{1, 1 + strokeWidth};
-                break;
-            case "longdash":
-                pattern = new float[]{10, 4 + strokeWidth};
-                break;
-            case "longdashdot":
-                pattern = new float[]{5, 1 + strokeWidth,  1, 1 + strokeWidth};
-                break;
-            default:
-                pattern = LINE_PATTERN_SOLID;
-        }
-        return pattern;
-    }
     private static PDFormXObject createIcon (PDDocument doc, JSONObject marker, String fillColor, int size) throws JSONException, IOException, TranscoderException {
         String markerData = JSONHelper.getString(marker, "data").replace("$fill", fillColor).replace("$stroke", ICON_STROKE_COLOR);
         double scale = size < 1 || size > 5 ? 1 : 0.6 +  size /10.0;
@@ -211,7 +229,7 @@ public class StyleUtil {
             // Set color, draw diagonal line + 2 more diagonals so that corners look good
             pcs.setStrokingColor(fillColor);
             pcs.setLineWidth(lineWidth);
-            pcs.setLineCapStyle(LINE_CAP_STYLE.get("square"));
+            pcs.setLineCapStyle(LineCap.square.code);
             float limit = isHorizontal ? numberOfStripes : numberOfStripes * 2;
             for (int i = 0 ; i < limit; i ++) {
                 float transition = i * bandWidth+ bandWidth/2;


### PR DESCRIPTION
Current code can't handle incomplete OskariStyle JSON. Add a bit of code to avoid null pointer exceptions.