### PR TITLE
Myplaces default name

### DIFF
--- a/content-resources/src/main/java/flyway/myplaces/V1_0_11__update_baselayer_locale.java
+++ b/content-resources/src/main/java/flyway/myplaces/V1_0_11__update_baselayer_locale.java
@@ -1,0 +1,19 @@
+package flyway.myplaces;
+
+import fi.nls.oskari.domain.map.OskariLayer;
+
+import fi.nls.oskari.geoserver.LayerHelper;
+import fi.nls.oskari.util.JSONHelper;
+import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
+import java.sql.Connection;
+
+public class V1_0_11__update_baselayer_locale implements JdbcMigration {
+
+    private static final String NAME = "oskari:my_places";
+    private static final String LOCALE = "{fi:{name:\"Oma karttataso\"},sv:{name:\"Mitt kartlager\"},en:{name:\"My map layer\"},is:{name:\"Kortalagið mitt\"}}";
+    public void migrate(Connection connection) throws Exception {
+        OskariLayer layer = LayerHelper.getLayerWithName(NAME);
+        layer.setLocale(JSONHelper.createJSONObject(LOCALE));
+        LayerHelper.update(layer);
+    }
+}

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
@@ -35,6 +35,7 @@ public class LayerJSONFormatter {
     protected static final String KEY_SUBTITLE = "subtitle";
     protected static final String KEY_OPTIONS = "options";
     protected static final String KEY_ADMIN = "admin";
+    protected static final String KEY_DATA_PROVIDER = "orgName";
     protected static final String[] STYLE_KEYS ={"name", "title", "legend"};
 
     // There working only plain text and html so ranked up
@@ -119,7 +120,7 @@ public class LayerJSONFormatter {
         JSONHelper.putValue(layerJson, KEY_LOCALIZED_NAME, layer.getName(lang));
         JSONHelper.putValue(layerJson, KEY_SUBTITLE, layer.getTitle(lang));
         if(layer.getGroup() != null) {
-            JSONHelper.putValue(layerJson, "orgName", layer.getGroup().getName(lang));
+            JSONHelper.putValue(layerJson, KEY_DATA_PROVIDER, layer.getGroup().getName(lang));
         }
 
         if(layer.getOpacity() != null && layer.getOpacity() > -1 && layer.getOpacity() <= 100) {

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERDATA.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERDATA.java
@@ -21,7 +21,14 @@ public abstract class LayerJSONFormatterUSERDATA extends LayerJSONFormatterWFS {
         // Override base layer values
         JSONHelper.putValue(layerJson, KEY_TYPE, layer.getType());
         JSONHelper.putValue(layerJson, KEY_ID, layer.getPrefixedId());
-        JSONHelper.putValue(layerJson, KEY_LOCALIZED_NAME, layer.getName());
+        String name = layer.getName();
+        // override default name only if userdatalayer has name
+        if (name != null && !name.isEmpty()) {
+            JSONHelper.putValue(layerJson, KEY_LOCALIZED_NAME, name);
+        }
+        // FIXME: base layer should have correct data provider and title.
+        layerJson.remove(KEY_SUBTITLE);
+        layerJson.remove(KEY_DATA_PROVIDER);
 
         WFSLayerOptions wfsOpts = layer.getWFSLayerOptions();
         wfsOpts.injectBaseLayerOptions(baseLayer.getOptions());


### PR DESCRIPTION
Set default name for myplaces base layer. 

Override default name (comes from base layer) only if UserDataLayer has name. Remove data provider and title from UserDataLayer because base layer may have wrong values. Frontend sets data provider and group if UserDataLayer isn't served as WFS.