### PR TITLE
Clean up AbstractWFSFeaturesHandler

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/feature/AbstractWFSFeaturesHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/feature/AbstractWFSFeaturesHandler.java
@@ -58,30 +58,42 @@ public abstract class AbstractWFSFeaturesHandler extends ActionHandler {
     }
 
     protected OskariLayer findLayer(String id, User user, Optional<UserLayerService> processor) throws ActionException {
-        int layerId = getLayerId(id, processor);
+        return processor.isPresent()
+                ? findUserLayer(id, user, processor.get())
+                : findMapLayer(id, user);
+    }
+
+    private OskariLayer findUserLayer(String id, User user, UserLayerService processor) throws ActionException {
+        int layerId = processor.getBaselayerId();
         OskariLayer layer = permissionHelper.getLayer(layerId, user);
-        if (!OskariLayer.TYPE_WFS.equals(layer.getType())) {
-            return layer;
-        }
-        if (processor.isPresent() && !processor.get().hasViewPermission(id, user)) {
+        requireWFSLayer(layer);
+        if (!processor.hasViewPermission(id, user)) {
             throw new ActionDeniedException("User doesn't have permissions for requested layer");
         }
         return layer;
     }
 
+    private OskariLayer findMapLayer(String id, User user) throws ActionException {
+        int layerId;
+        try {
+            layerId = Integer.parseInt(id);
+        } catch (NumberFormatException e) {
+            throw new ActionParamsException(ERR_INVALID_ID);
+        }
+        OskariLayer layer = permissionHelper.getLayer(layerId, user);
+        requireWFSLayer(layer);
+        return layer;
+    }
+
+    /**
+     * @deprecated this method is included in {@link #findLayer(String, User, Optional)}
+     * and will be marked private in a future release
+     */
+    @Deprecated
     protected void requireWFSLayer(OskariLayer layer) throws ActionParamsException {
         if (!OskariLayer.TYPE_WFS.equals(layer.getType())) {
             throw new ActionParamsException(ERR_LAYER_TYPE_NOT_WFS);
         }
     }
-    
-    private int getLayerId(String id, Optional<UserLayerService> processor) throws ActionParamsException {
-        try {
-            return processor.map(UserLayerService::getBaselayerId)
-                    .orElseGet(() -> Integer.parseInt(id));
-        } catch (NumberFormatException e) {
-            throw new ActionParamsException(ERR_INVALID_ID);
-        }
-    }
-    
+
 }

--- a/control-base/src/main/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandler.java
@@ -55,7 +55,6 @@ public class GetWFSFeaturesHandler extends AbstractWFSFeaturesHandler {
 
         Optional<UserLayerService> contentProcessor = getUserContentProsessor(id);
         OskariLayer layer = findLayer(id, params.getUser(), contentProcessor);
-        requireWFSLayer(layer);
 
         String targetSRS = params.getHttpParam(ActionConstants.PARAM_SRS, "EPSG:3857");
         CoordinateReferenceSystem targetCRS;

--- a/control-mvt/src/main/java/org/oskari/control/mvt/GetLocalizedPropertyNamesHandler.java
+++ b/control-mvt/src/main/java/org/oskari/control/mvt/GetLocalizedPropertyNamesHandler.java
@@ -30,7 +30,6 @@ public class GetLocalizedPropertyNamesHandler extends AbstractWFSFeaturesHandler
         final String layerId = params.getRequiredParam(ActionConstants.PARAM_ID);
         Optional<UserLayerService> contentProcessor = getUserContentProsessor(layerId);
         OskariLayer layer = findLayer(layerId, params.getUser(), contentProcessor);
-        requireWFSLayer(layer);
 
         String language = params.getHttpParam(ActionConstants.PARAM_LANGUAGE, PropertyUtil.getDefaultLanguage());
         WFSLayerAttributes attributes = new WFSLayerAttributes(layer.getAttributes());

--- a/control-mvt/src/main/java/org/oskari/control/mvt/GetWFSVectorTileHandler.java
+++ b/control-mvt/src/main/java/org/oskari/control/mvt/GetWFSVectorTileHandler.java
@@ -103,7 +103,6 @@ public class GetWFSVectorTileHandler extends AbstractWFSFeaturesHandler {
 
         final Optional<UserLayerService> contentProcessor = getUserContentProsessor(id);
         final OskariLayer layer = findLayer(id, params.getUser(), contentProcessor);
-        requireWFSLayer(layer);
 
         final WFSTileGrid gridFromProps = tileGridProperties.getTileGrid(srs.toUpperCase());
         final WFSTileGrid grid = gridFromProps != null ? gridFromProps : KNOWN_TILE_GRIDS.get(srs.toUpperCase());


### PR DESCRIPTION
Remove `if (!OskariLayer.TYPE_WFS.equals(layer.getType())) { return layer; }` block that always ends up in an exception. Include `AbstractWFSFeaturesHandler#requireWFSLayer` function calls to `AbstractWFSFeaturesHandler#findLayer` so that inherited classes don't have to remember to call it. Split the logic of finding the layer into to more separate branches for improved readability.