### PR TITLE
Upgraded to Spring 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,12 +49,12 @@
         <fi.nls.oskari.service.version>${project.version}</fi.nls.oskari.service.version>
         <flyway.version>4.2.0</flyway.version>
 
-        <spring.version>4.3.26.RELEASE</spring.version>
-        <spring-security.version>4.2.14.RELEASE</spring-security.version>
-        <spring.session.version>1.3.5.RELEASE</spring.session.version>
+        <spring.version>5.2.7.RELEASE</spring.version>
+        <spring-security.version>5.3.2.RELEASE</spring-security.version>
+        <spring.session.version>2.3.0.RELEASE</spring.session.version>
 
         <javax.servlet.version>3.1.0</javax.servlet.version>
-        <javax.servlet.jsp.version>2.0</javax.servlet.jsp.version>
+        <javax.servlet.jsp.version>2.3.3</javax.servlet.jsp.version>
         <javax.servlet.jstl.version>1.2</javax.servlet.jstl.version>
         <javax.xml.version>1.0</javax.xml.version>
         <vecmath.version>1.5.2</vecmath.version>
@@ -77,7 +77,7 @@
         <woodstox.version>5.1.0</woodstox.version>
         <jsonld-java.version>0.3</jsonld-java.version>
         <xmlunit.version>1.6</xmlunit.version>
-        <jedis.version>2.10.2</jedis.version>
+        <jedis.version>3.3.0</jedis.version>
         <jackson.version>2.11.0</jackson.version>
 
         <fi.mml.capabilities.version>1.3.0</fi.mml.capabilities.version>
@@ -543,7 +543,7 @@
             </dependency>
             <dependency>
                 <groupId>org.springframework.session</groupId>
-                <artifactId>spring-session</artifactId>
+                <artifactId>spring-session-core</artifactId>
                 <version>${spring.session.version}</version>
             </dependency>
             <dependency>
@@ -580,7 +580,7 @@
             </dependency>
             <dependency>
                 <groupId>javax.servlet.jsp</groupId>
-                <artifactId>jsp-api</artifactId>
+                <artifactId>javax.servlet.jsp-api</artifactId>
                 <version>${javax.servlet.jsp.version}</version>
                 <scope>provided</scope>
             </dependency>

--- a/servlet-map/pom.xml
+++ b/servlet-map/pom.xml
@@ -50,7 +50,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.session</groupId>
-            <artifactId>spring-session</artifactId>
+            <artifactId>spring-session-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.session</groupId>

--- a/servlet-map/src/main/java/fi/nls/oskari/spring/SpringInitializer.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/spring/SpringInitializer.java
@@ -24,7 +24,7 @@ public class SpringInitializer extends AbstractHttpSessionApplicationInitializer
     private Logger log = LogFactory.getLogger(SpringInitializer.class);
 
     @Override
-    public void onStartup(ServletContext servletContext) throws ServletException {
+    public void onStartup(ServletContext servletContext) {
         // IMPORTANT! read properties at startup - needed for profile selection
         WebappHelper.loadProperties();
         // re-init logger so we get the one configured in properties


### PR DESCRIPTION
- Spring Framework 5.2.7
- Spring Security 5.3.2
- Spring Session 2.3.0
- Jedis 3.3.0 (as required by Spring Session Data Redis)
- JSP API 2.3.3

Note: Java EE 7 based server is now the minimum requirement (Tomcat 8.5/Jetty 9.4 or newer)

This is part of bringing Java 11 (and beyond) support to Oskari.