### PR TITLE
Remove deprecated Spring class reference

### DIFF
--- a/servlet-map/src/main/java/fi/nls/oskari/spring/SpringConfig.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/spring/SpringConfig.java
@@ -18,10 +18,7 @@ import org.springframework.context.support.ReloadableResourceBundleMessageSource
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.LocaleResolver;
 import org.springframework.web.servlet.ViewResolver;
-import org.springframework.web.servlet.config.annotation.EnableWebMvc;
-import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
-import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+import org.springframework.web.servlet.config.annotation.*;
 import org.springframework.web.servlet.i18n.CookieLocaleResolver;
 import org.springframework.web.servlet.i18n.LocaleChangeInterceptor;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
@@ -43,7 +40,7 @@ import java.util.Locale;
 @ComponentScan(
         excludeFilters = @ComponentScan.Filter(type= FilterType.ASSIGNABLE_TYPE, value={SpringConfig.class}),
         basePackages="fi.nls.oskari, org.oskari")
-public class SpringConfig extends WebMvcConfigurerAdapter implements ApplicationListener<ContextRefreshedEvent> {
+public class SpringConfig implements WebMvcConfigurer, ApplicationListener<ContextRefreshedEvent> {
 
     private static final Logger LOG = LogFactory.getLogger(SpringConfig.class);
 

--- a/servlet-map/src/main/java/fi/nls/oskari/spring/session/RedisSessionConfig.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/spring/session/RedisSessionConfig.java
@@ -4,6 +4,7 @@ import fi.nls.oskari.util.PropertyUtil;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
@@ -18,10 +19,10 @@ public class RedisSessionConfig extends WebMvcConfigurerAdapter {
 
     @Bean
     public JedisConnectionFactory connectionFactory() {
-        JedisConnectionFactory jedis = new JedisConnectionFactory();
-        jedis.setHostName(PropertyUtil.get("redis.hostname", "127.0.0.1"));
-        jedis.setPort(PropertyUtil.getOptional("redis.port", 6379));
-        jedis.setUsePool(true);
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(
+                PropertyUtil.get("redis.hostname", "127.0.0.1"),
+                PropertyUtil.getOptional("redis.port", 6379));
+        JedisConnectionFactory jedis = new JedisConnectionFactory(config);
         return jedis;
     }
 }


### PR DESCRIPTION
WebMvcConfigurerAdapter is no longer needed with default implementations for methods on WebMvcConfigurer.