### PR TITLE
Allow print to use all types of layers

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/data/GetPrintHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/data/GetPrintHandler.java
@@ -305,6 +305,25 @@ public class GetPrintHandler extends AbstractWFSFeaturesHandler {
         return printLayer;
     }
 
+    /**
+     * Override findMaplayer from AbstractWFSFeaturesHandler since that one requires the layer to be WFS and print is ok
+     * with having other types as well
+     * @param id
+     * @param user
+     * @return
+     * @throws ActionException
+     */
+    @Override
+    protected OskariLayer findMapLayer(String id, User user) throws ActionException {
+        int layerId;
+        try {
+            layerId = Integer.parseInt(id);
+        } catch (NumberFormatException e) {
+            throw new ActionParamsException(ERR_INVALID_ID);
+        }
+        return permissionHelper.getLayer(layerId, user);
+    }
+
     private int getOpacity(Integer requestedOpacity, Integer layersDefaultOpacity) {
         int opacity;
         if (requestedOpacity != null) {

--- a/control-base/src/main/java/fi/nls/oskari/control/feature/AbstractWFSFeaturesHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/feature/AbstractWFSFeaturesHandler.java
@@ -73,7 +73,7 @@ public abstract class AbstractWFSFeaturesHandler extends ActionHandler {
         return layer;
     }
 
-    private OskariLayer findMapLayer(String id, User user) throws ActionException {
+    protected OskariLayer findMapLayer(String id, User user) throws ActionException {
         int layerId;
         try {
             layerId = Integer.parseInt(id);


### PR DESCRIPTION
#603 added a requirement for AbstractWFSFeaturesHandler to only use WFS-layers which makes sense. However GetPrintHandler extends AbstractWFSFeaturesHandler and is also interested in finding other types of layers as well.

Without this change printing is only allowed for vector layers.