### PR TITLE
Import Spring dependencies as Bill Of Materials and update.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,9 @@
         <fi.nls.oskari.service.version>${project.version}</fi.nls.oskari.service.version>
         <flyway.version>6.5.5</flyway.version>
 
-        <spring.version>5.2.7.RELEASE</spring.version>
-        <spring-security.version>5.3.2.RELEASE</spring-security.version>
-        <spring.session.version>2.3.0.RELEASE</spring.session.version>
+        <spring.version>5.2.8.RELEASE</spring.version>
+        <spring-security.version>5.3.4.RELEASE</spring-security.version>
+        <spring.session.version>Dragonfruit-RELEASE</spring.session.version>
 
         <javax.servlet.version>3.1.0</javax.servlet.version>
         <javax.servlet.jsp.version>2.3.3</javax.servlet.jsp.version>
@@ -477,69 +477,27 @@
                 <version>${h2database.version}</version>
             </dependency>
 
-
             <!-- Spring -->
             <dependency>
-                <groupId>org.springframework.security.extensions</groupId>
-                <artifactId>spring-security-saml2-core</artifactId>
-                <version>${spring.saml.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.springframework</groupId>
-                <artifactId>spring-webmvc</artifactId>
+                <artifactId>spring-framework-bom</artifactId>
                 <version>${spring.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.springframework.security</groupId>
-                <artifactId>spring-security-web</artifactId>
+                <artifactId>spring-security-bom</artifactId>
                 <version>${spring-security.version}</version>
-                <exclusions>
-                    <!-- exclude aopalliance
-                    Reason: Same classes are included in spring-aop (causing conflict if we have both)
-                    -->
-                    <exclusion>
-                        <groupId>aopalliance</groupId>
-                        <artifactId>aopalliance</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.security</groupId>
-                <artifactId>spring-security-config</artifactId>
-                <version>${spring-security.version}</version>
-                 <exclusions>
-                    <!-- exclude aopalliance
-                    Reason: Same classes are included in spring-aop (causing conflict if we have both)
-                    -->
-                    <exclusion>
-                        <groupId>aopalliance</groupId>
-                        <artifactId>aopalliance</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.security</groupId>
-                <artifactId>spring-security-core</artifactId>
-                <version>${spring-security.version}</version>
-                <exclusions>
-                    <!-- exclude aopalliance
-                    Reason: Same classes are included in spring-aop (causing conflict if we have both)
-                    -->
-                    <exclusion>
-                        <groupId>aopalliance</groupId>
-                        <artifactId>aopalliance</artifactId>
-                    </exclusion>
-                </exclusions>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.springframework.session</groupId>
-                <artifactId>spring-session-core</artifactId>
+                <artifactId>spring-session-bom</artifactId>
                 <version>${spring.session.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.session</groupId>
-                <artifactId>spring-session-data-redis</artifactId>
-                <version>${spring.session.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Import Spring dependencies as Bill Of Materials (BOM). This allows application specific Oskari Server Extensions to include additional Spring Framework/Security/Session libraries without the need to (re)define version numbers.

Also updated Spring to latest patch versions.