### PR TITLE
Skip capabilities update on migrations for localhost

### DIFF
--- a/content-resources/src/main/java/org/oskari/helpers/AppSetupHelper.java
+++ b/content-resources/src/main/java/org/oskari/helpers/AppSetupHelper.java
@@ -43,6 +43,7 @@ public class AppSetupHelper {
 
             final long viewId = viewService.addView(view);
             log.info("Added view from file:", viewfile, "/viewId is:", viewId, "/uuid is:", view.getUuid());
+            // TODO: only call refreshLayerCapabilities() if we added an appsetup with NEW projection
             // update supported SRS for layers after possibly new projection on appsetup/view
             LayerHelper.refreshLayerCapabilities();
             return viewId;

--- a/content-resources/src/main/java/org/oskari/helpers/LayerHelper.java
+++ b/content-resources/src/main/java/org/oskari/helpers/LayerHelper.java
@@ -74,6 +74,10 @@ public class LayerHelper {
      */
     protected static void refreshLayerCapabilities() {
         for (OskariLayer layer : layerService.findAll()) {
+            if (layer.getUrl().startsWith("http://localhost:")) {
+                // skip localhost servers as the service is starting when this is called and geoserver will not answer
+                continue;
+            }
             try {
                 LayerCapabilitiesHelper.updateCapabilities(layer);
                 layerService.update(layer);


### PR DESCRIPTION
As server is starting -> calls aren't answered and log is spammed with unnecessary errors. This was added for individual layers earlier but the real log spammer is when layer capabilities are updated as a whole for new appsetups. This fixes the issue when adding appsetups in migrations.