### PR TITLE
Fix UNSD plugin groupId for consistency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,7 @@
                 <version>${oskari.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.oskari.service</groupId>
+                <groupId>org.oskari</groupId>
                 <artifactId>service-statistics-unsd</artifactId>
                 <version>${oskari.version}</version>
             </dependency>


### PR DESCRIPTION
The actual module has groupId `org.oskari` but the managed dependencies still used `org.oskari.service`.