### PR TITLE
Clean up appsetup/bundle methods

### DIFF
--- a/content-resources/src/main/java/org/oskari/helpers/AppSetupHelper.java
+++ b/content-resources/src/main/java/org/oskari/helpers/AppSetupHelper.java
@@ -48,7 +48,7 @@ public class AppSetupHelper {
             LayerHelper.refreshLayerCapabilities();
             return viewId;
         } catch (Exception ex) {
-            log.error(ex, "Unable to insert appsetup! ");
+            log.error( "Unable to insert appsetup! Msg: ", ex.getMessage());
             throw new ServiceRuntimeException("Unable to insert appsetup", ex);
         }
     }
@@ -348,8 +348,8 @@ public class AppSetupHelper {
 
     private static View createView(Connection conn, final JSONObject viewJSON)
             throws Exception {
+        final View view = new View();
         try {
-            final View view = new View();
             view.setCreator(ConversionHelper.getLong(viewJSON.optString("creator"), -1));
             view.setIsPublic(viewJSON.optBoolean("public", false));
             view.setOnlyForUuId(viewJSON.optBoolean("onlyUuid", true));
@@ -358,11 +358,15 @@ public class AppSetupHelper {
             view.setIsDefault(viewJSON.optBoolean("default"));
             final JSONObject oskari = JSONHelper.getJSONObject(viewJSON, "oskari");
             view.setPage(oskari.getString("page"));
-            view.setDevelopmentPath(oskari.getString("development_prefix"));
             view.setApplication(oskari.getString("application"));
+        } catch (Exception ex) {
+            log.error( "Unable to construct view (metadata missing)! Msg:", ex.getMessage());
+            throw ex;
+        }
 
-            setupLayers(viewJSON);
+        setupLayers(viewJSON);
 
+        try{
             final JSONArray bundles = viewJSON.getJSONArray("bundles");
             for (int i = 0; i < bundles.length(); ++i) {
                 final JSONObject bJSON = bundles.getJSONObject(i);
@@ -385,9 +389,9 @@ public class AppSetupHelper {
             }
             return view;
         } catch (Exception ex) {
-            log.error(ex, "Unable to insert view! ");
+            log.error("Unable to construct view (problem with bundles)! Msg:", ex.getMessage());
+            throw ex;
         }
-        return null;
     }
 
     private static void replaceSelectedLayers(final Bundle mapfull, final Set<Integer> idSet) {

--- a/control-admin/src/test/java/fi/nls/oskari/control/admin/ViewsHandlerTest.java
+++ b/control-admin/src/test/java/fi/nls/oskari/control/admin/ViewsHandlerTest.java
@@ -179,7 +179,6 @@ public class ViewsHandlerTest extends JSONActionRouteTest {
         view.setOnlyForUuId(false);
         view.setApplication("foo");
         view.setPage("bar");
-        view.setDevelopmentPath("baz");
         return view;
     }
 

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/view/Bundle.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/view/Bundle.java
@@ -12,7 +12,6 @@ public class Bundle implements Comparable, Serializable {
 
     private String state;
     private String config;
-    private String startup = null;
     private String name;
     private String bundleinstance;
 
@@ -26,7 +25,6 @@ public class Bundle implements Comparable, Serializable {
                 "seqNo    = '" + seqNo +"'\n" +
                 "state    = '" + state +"'\n" +
                 "config   = '" + config +"'\n" +
-                "startup  = '" + startup +"'\n" +
                 "bundleinstance  = '" + bundleinstance +"'\n" +
                 "name     = '" + name +"'\n";
 
@@ -116,8 +114,6 @@ public class Bundle implements Comparable, Serializable {
         return builder.toString();
     }
 
-    public void setStartup(String startup) {/* always null in DB */}
-
     /**
      * Returns the "bundleid" as known by frontend
      * @return
@@ -146,7 +142,6 @@ public class Bundle implements Comparable, Serializable {
         b.setBundleId(getBundleId()); // db id
         b.setName(getName()); // bundleid as known by client
         b.setBundleinstance(getBundleinstance());
-        b.setStartup(getStartup());
         b.setConfig(getConfig());
         b.setState(getState());
         b.setSeqNo(getSeqNo());

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/view/View.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/view/View.java
@@ -95,7 +95,6 @@ public class View implements Serializable {
 
     private String application = "full-map"; // app name
     private String page = "view"; // JSP
-    private String developmentPath = "/applications";
     private long creator = -1;
     private boolean isPublic = false;
     private boolean isDefault = false;
@@ -122,14 +121,6 @@ public class View implements Serializable {
 
     public String getLang() { return this.lang; }
     public void setLang(String lang) { this.lang = lang; }
-
-    public String getDevelopmentPath() {
-        return developmentPath;
-    }
-
-    public void setDevelopmentPath(String developmentPath) {
-        this.developmentPath = developmentPath;
-    }
 
     public String getType() { return this.type; }
     public void setType(String type) { this.type = type; }
@@ -257,7 +248,6 @@ public class View implements Serializable {
         view.setName(getName());
         view.setDescription(getDescription());
         view.setType(getType());
-        view.setDevelopmentPath(getDevelopmentPath());
         view.setApplication(getApplication());
         view.setIsPublic(isPublic());
         view.setLang(getLang());

--- a/service-map/src/main/java/fi/nls/oskari/map/view/AppSetupServiceMybatisImpl.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/view/AppSetupServiceMybatisImpl.java
@@ -336,7 +336,6 @@ public class AppSetupServiceMybatisImpl extends ViewService {
         params.put("bundle_id", bundle.getBundleId());
 
         params.put("seqno", bundle.getSeqNo());
-        params.put("startup", bundle.getStartup());
         params.put("config", bundle.getConfig());
         params.put("state", bundle.getState());
         params.put("bundleinstance", bundle.getBundleinstance());

--- a/service-map/src/main/java/fi/nls/oskari/map/view/util/ViewHelper.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/view/util/ViewHelper.java
@@ -147,7 +147,6 @@ public class ViewHelper {
         viewJSON.put("metadata", view.getMetadata());
         viewJSON.put("application", view.getApplication());
         viewJSON.put("page", view.getPage());
-        viewJSON.put("developmentPath", view.getDevelopmentPath());
         viewJSON.put("bundles", createBundles(bundleService, view.getBundles()));
         return viewJSON;
     }
@@ -193,11 +192,9 @@ public class ViewHelper {
             final JSONObject oskari = viewJSON.getJSONObject("oskari");
             view.setApplication(oskari.getString("application"));
             view.setPage(oskari.getString("page"));
-            view.setDevelopmentPath(oskari.getString("development_prefix"));
         } else {
             view.setApplication(viewJSON.getString("application"));
             view.setPage(viewJSON.getString("page"));
-            view.setDevelopmentPath(viewJSON.getString("developmentPath"));
         }
 
         addBundles(bundleService, view, viewJSON.getJSONArray("bundles"));
@@ -220,9 +217,6 @@ public class ViewHelper {
             }
             if (bJSON.has("instance")) {
                 bundle.setBundleinstance(bJSON.getString("instance"));
-            }
-            if (bJSON.has("startup")) {
-                bundle.setStartup(bJSON.getJSONObject("startup").toString());
             }
             if (bJSON.has("config")) {
                 bundle.setConfig(bJSON.getJSONObject("config").toString());

--- a/service-map/src/test/java/fi/nls/oskari/map/view/util/ViewHelperTest.java
+++ b/service-map/src/test/java/fi/nls/oskari/map/view/util/ViewHelperTest.java
@@ -74,7 +74,6 @@ public class ViewHelperTest {
         assertEquals(false, view.isOnlyForUuId());
         assertEquals("servlet", view.getApplication());
         assertEquals("index", view.getPage());
-        assertEquals("/applications/sample", view.getDevelopmentPath());
 
         List<Bundle> bundles = view.getBundles();
         assertNotNull(bundles);
@@ -97,7 +96,6 @@ public class ViewHelperTest {
         view1.setOnlyForUuId(false);
         view1.setApplication("foo");
         view1.setPage("bar");
-        view1.setDevelopmentPath("baz");
         view1.addBundle(randomBundle);
 
         JSONObject viewJSON = ViewHelper.viewToJson(bundleService, view1);
@@ -110,7 +108,6 @@ public class ViewHelperTest {
         assertEquals(view1.isOnlyForUuId(), view2.isOnlyForUuId());
         assertEquals(view1.getApplication(), view2.getApplication());
         assertEquals(view1.getPage(), view2.getPage());
-        assertEquals(view1.getDevelopmentPath(), view2.getDevelopmentPath());
 
         List<Bundle> bundles1 = view1.getBundles();
         List<Bundle> bundles2 = view2.getBundles();

--- a/servlet-map/src/main/java/fi/nls/oskari/MapController.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/MapController.java
@@ -173,7 +173,7 @@ public class MapController {
 
 
         log.debug("Serving view with id:", view.getId());
-        log.debug("View:", view.getDevelopmentPath(), "/", view.getApplication(), "/", view.getPage());
+        log.debug("View:", view.getApplication(), "/", view.getPage());
         model.addAttribute("viewId", view.getId());
         model.addAttribute("appsetupId", view.getId());
         model.addAttribute("appsetupUUID", view.getUuid());


### PR DESCRIPTION
Remove most references to bundle.startup as it hans't done anything for a while now. Remove appsetup.devPath since it was removed in Oskari 2.0 but appsetup json files are still required to have that key without this change.

Also try to make appsetup problems cleaner/less spammy when initializing content.