### PR TITLE
Print solid stroke

### DIFF
--- a/service-print/src/main/java/org/oskari/print/request/PDPrintStyle.java
+++ b/service-print/src/main/java/org/oskari/print/request/PDPrintStyle.java
@@ -218,7 +218,7 @@ public class PDPrintStyle {
 
     public enum LinePattern {
 
-        solid(width -> new float[] { 0 }),
+        solid(width -> new float[0]),
         dash(width -> new float[] { 5, 4 + width }),
         dashdot(width -> new float[] { 1, 1 + width }),
         dot(width -> new float[] { 1, 1 + width }),


### PR DESCRIPTION
Solid stroke has to be set with empty array to get valid PDF file. Fixes the issue where some readers complain that file isn't valid and doesn't show vector layers.