### PR TITLE
Add factory function for Bundle creation

### DIFF
--- a/service-base/src/main/java/fi/nls/oskari/domain/map/view/Bundle.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/view/Bundle.java
@@ -18,6 +18,12 @@ public class Bundle implements Comparable, Serializable {
     private JSONObject configJSON;
     private JSONObject stateJSON;
 
+    public static Bundle forName(String name) {
+        Bundle b = new Bundle();
+        b.setName(name);
+        return b;
+    }
+
     public String toString() {
         return
                 "bundleId = '" + bundleId +"'\n" +


### PR DESCRIPTION
It's usual to see a flyway migration that wants to add a bundle to an appsetup and with this change we can remove a couple of lines of boilerplate code from migrations. Convenience for developers etc