### PR TITLE
Replace Bundle.forName() with constructor

### DIFF
--- a/service-base/src/main/java/fi/nls/oskari/domain/map/view/Bundle.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/view/Bundle.java
@@ -18,10 +18,10 @@ public class Bundle implements Comparable, Serializable {
     private JSONObject configJSON;
     private JSONObject stateJSON;
 
-    public static Bundle forName(String name) {
-        Bundle b = new Bundle();
-        b.setName(name);
-        return b;
+    public Bundle() { }
+
+    public Bundle(String name) {
+        setName(name);
     }
 
     public String toString() {


### PR DESCRIPTION
To make it clear it's only a new instance and defaults based on the name are not loaded from database etc.

Replaces #633 

After this you can replace:
```
Bundle bundle = new Bundle();
bundle.setName("myBundle");
BundleHelper.registerBundle(bundle, connection);
```
with `BundleHelper.registerBundle(new Bundle("myBundle"), connection);` in Flyway migrations when registering new bundles.