### PR TITLE
Rename common helper method and add string version

### DIFF
--- a/MigrationGuide.md
+++ b/MigrationGuide.md
@@ -83,6 +83,11 @@ FlywayHelper.addBundleWithDefaults() -> AppSetupHelper.addBundleToApp()
 FlywayHelper.getBundleFromView() -> AppSetupHelper.getAppBundle()
 ```
 
+Added a new helper for easily adding a new bundle to the usual appsetup types (USER and DEFAULT):
+```
+AppSetupHelper.addBundleToApps(connection, bundlename)
+```
+
 ### Spring framework upgraded
 
 If you have application-specific code that uses Spring you might need to adapt them to the 5.x version.

--- a/content-resources/src/main/java/org/oskari/helpers/AppSetupHelper.java
+++ b/content-resources/src/main/java/org/oskari/helpers/AppSetupHelper.java
@@ -278,12 +278,24 @@ public class AppSetupHelper {
     }
 
     /**
+     * Adds a bundle to all apps referenced by getSetupsForUserAndDefaultType(conn)
+     * @param connection
+     * @param bundlename
+     * @throws SQLException
+     */
+    public static void addBundleToApps(Connection connection, String bundlename)
+            throws SQLException {
+        List<Long> appsetupIds = AppSetupHelper.getSetupsForUserAndDefaultType(connection);
+        addOrUpdateBundleInApps(connection, new Bundle(bundlename), appsetupIds);
+    }
+
+    /**
      * Adds or updates a bundle to all apps referenced by getSetupsForUserAndDefaultType(conn)
      * @param connection
      * @param bundle
      * @throws SQLException
      */
-    public static void addBundleToDefaultAndUserApps(Connection connection, Bundle bundle)
+    public static void addBundleToApps(Connection connection, Bundle bundle)
             throws SQLException {
         List<Long> appsetupIds = AppSetupHelper.getSetupsForUserAndDefaultType(connection);
         addOrUpdateBundleInApps(connection, bundle, appsetupIds);
@@ -295,7 +307,7 @@ public class AppSetupHelper {
      * @param bundle
      * @throws SQLException
      */
-    public static void addBundleToDefaultAndUserApps(Connection connection, Bundle bundle, String application)
+    public static void addBundleToApps(Connection connection, Bundle bundle, String application)
             throws SQLException {
         List<Long> appsetupIds = AppSetupHelper.getSetupsForUserAndDefaultType(connection, application);
         addOrUpdateBundleInApps(connection, bundle, appsetupIds);


### PR DESCRIPTION
String version so Bundle class import isn't needed in most migrations and we can change the package for it easier the next time (fi.nls -> org.oskari etc).

Now applications can add a new bundle to the usually targeted appsetups with:
```
AppSetupHelper.addBundleToApps(connection, bundlename)
```