### PR TITLE
Allow registering bundle without Bundle import

### DIFF
--- a/content-resources/src/main/java/org/oskari/helpers/BundleHelper.java
+++ b/content-resources/src/main/java/org/oskari/helpers/BundleHelper.java
@@ -36,6 +36,10 @@ public class BundleHelper {
         return getRegisteredBundle(conn, name) != null;
     }
 
+    public static void registerBundle(Connection conn, String name) throws SQLException {
+        registerBundle(conn, new Bundle(name));
+    }
+
     public static void registerBundle(Connection conn, Bundle bundle) throws SQLException {
         if (isBundleRegistered(conn, bundle.getName())) {
             // already registered


### PR DESCRIPTION
So application migrations are easier to update in the future once we start renaming packages from fi.nls.oskari -> org.oskari.