### PR TITLE
Change coordinate type from string to number in search result

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,7 +2,7 @@
 
 ## 2.0.1
 
-Changes coordinates type from string to double on search channels.
+Changes coordinates type from string to double on search channels and search results.
 Frontend assumes numbers on 2.0 and most of the code casts numbers to strings just for the SearchResultItem setter. 
 
 ## 2.0.0

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 2.0.1
+
+Changes coordinates type from string to double on search channels.
+Frontend assumes numbers on 2.0 and most of the code casts numbers to strings just for the SearchResultItem setter. 
+
 ## 2.0.0
 
 For a full list of changes see: https://github.com/oskariorg/oskari-server/milestone/25?closed=1

--- a/content-resources/pom.xml
+++ b/content-resources/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
 		<artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
 	</parent>
     <artifactId>content-resources</artifactId>
     <packaging>jar</packaging>

--- a/content-resources/pom.xml
+++ b/content-resources/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
 		<artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
 	</parent>
     <artifactId>content-resources</artifactId>
     <packaging>jar</packaging>

--- a/control-admin/pom.xml
+++ b/control-admin/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
 	</parent>
 
     <artifactId>control-admin</artifactId>

--- a/control-admin/pom.xml
+++ b/control-admin/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
 	</parent>
 
     <artifactId>control-admin</artifactId>

--- a/control-base/pom.xml
+++ b/control-base/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
 	</parent>
 
     <artifactId>control-base</artifactId>

--- a/control-base/pom.xml
+++ b/control-base/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
 	</parent>
 
     <artifactId>control-base</artifactId>

--- a/control-example/pom.xml
+++ b/control-example/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
 	</parent>
 
     <artifactId>control-example</artifactId>

--- a/control-example/pom.xml
+++ b/control-example/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
 	</parent>
 
     <artifactId>control-example</artifactId>

--- a/control-mvt/pom.xml
+++ b/control-mvt/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>control-mvt</artifactId>

--- a/control-mvt/pom.xml
+++ b/control-mvt/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
 
     <artifactId>control-mvt</artifactId>

--- a/control-myplaces/pom.xml
+++ b/control-myplaces/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
 	</parent>
 
     <artifactId>control-myplaces</artifactId>

--- a/control-myplaces/pom.xml
+++ b/control-myplaces/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
 	</parent>
 
     <artifactId>control-myplaces</artifactId>

--- a/control-rating/pom.xml
+++ b/control-rating/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/control-rating/pom.xml
+++ b/control-rating/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/control-routing/pom.xml
+++ b/control-routing/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
 	</parent>
 
     <artifactId>control-routing</artifactId>

--- a/control-routing/pom.xml
+++ b/control-routing/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
 	</parent>
 
     <artifactId>control-routing</artifactId>

--- a/control-statistics/pom.xml
+++ b/control-statistics/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
 	</parent>
 
     <artifactId>control-statistics</artifactId>

--- a/control-statistics/pom.xml
+++ b/control-statistics/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
 	</parent>
 
     <artifactId>control-statistics</artifactId>

--- a/control-userlayer/pom.xml
+++ b/control-userlayer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>control-userlayer</artifactId>
 

--- a/control-userlayer/pom.xml
+++ b/control-userlayer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
     <artifactId>control-userlayer</artifactId>
 

--- a/control-users/pom.xml
+++ b/control-users/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
 	</parent>
 
     <artifactId>control-users</artifactId>

--- a/control-users/pom.xml
+++ b/control-users/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
 	</parent>
 
     <artifactId>control-users</artifactId>

--- a/download-basket/pom.xml
+++ b/download-basket/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.oskari</groupId>
 		<artifactId>oskari-server</artifactId>
-		<version>2.1.0-SNAPSHOT</version>
+		<version>2.0.1</version>
 	</parent>
 	<artifactId>download-basket</artifactId>
 	<name>Download Basket</name>

--- a/download-basket/pom.xml
+++ b/download-basket/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.oskari</groupId>
 		<artifactId>oskari-server</artifactId>
-		<version>2.0.0</version>
+		<version>2.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>download-basket</artifactId>
 	<name>Download Basket</name>

--- a/geoserver-ext/geoserver-rest-client/pom.xml
+++ b/geoserver-ext/geoserver-rest-client/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>geoserver-rest-client</artifactId>

--- a/geoserver-ext/geoserver-rest-client/pom.xml
+++ b/geoserver-ext/geoserver-rest-client/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>geoserver-rest-client</artifactId>

--- a/geotools-ext/gt-geojson/pom.xml
+++ b/geotools-ext/gt-geojson/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>gt-geojson</artifactId>

--- a/geotools-ext/gt-geojson/pom.xml
+++ b/geotools-ext/gt-geojson/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>gt-geojson</artifactId>

--- a/geotools-ext/gt-mif/pom.xml
+++ b/geotools-ext/gt-mif/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>gt-mif</artifactId>

--- a/geotools-ext/gt-mif/pom.xml
+++ b/geotools-ext/gt-mif/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>gt-mif</artifactId>

--- a/geotools-ext/gt-xsd-gpx/pom.xml
+++ b/geotools-ext/gt-xsd-gpx/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/geotools-ext/gt-xsd-gpx/pom.xml
+++ b/geotools-ext/gt-xsd-gpx/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/oskari-utils/pom.xml
+++ b/oskari-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>oskari-utils</artifactId>

--- a/oskari-utils/pom.xml
+++ b/oskari-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
 
     <artifactId>oskari-utils</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.oskari</groupId>
     <artifactId>oskari-server</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.0.1</version>
     <packaging>pom</packaging>
 
     <name>Oskari server</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.oskari</groupId>
     <artifactId>oskari-server</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Oskari server</name>

--- a/service-admin/pom.xml
+++ b/service-admin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
 
     <artifactId>service-admin</artifactId>

--- a/service-admin/pom.xml
+++ b/service-admin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-admin</artifactId>

--- a/service-base/pom.xml
+++ b/service-base/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
 	</parent>
 
     <artifactId>service-base</artifactId>

--- a/service-base/pom.xml
+++ b/service-base/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
 	</parent>
 
     <artifactId>service-base</artifactId>

--- a/service-capabilities-update/pom.xml
+++ b/service-capabilities-update/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-capabilities-update</artifactId>

--- a/service-capabilities-update/pom.xml
+++ b/service-capabilities-update/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
 
     <artifactId>service-capabilities-update</artifactId>

--- a/service-control/pom.xml
+++ b/service-control/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
 
     <artifactId>service-control</artifactId>

--- a/service-control/pom.xml
+++ b/service-control/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-control</artifactId>

--- a/service-csw/pom.xml
+++ b/service-csw/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
 
     <artifactId>service-csw</artifactId>

--- a/service-csw/pom.xml
+++ b/service-csw/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-csw</artifactId>

--- a/service-csw/src/main/java/fi/nls/oskari/search/channel/MetadataCatalogueChannelSearchService.java
+++ b/service-csw/src/main/java/fi/nls/oskari/search/channel/MetadataCatalogueChannelSearchService.java
@@ -238,10 +238,10 @@ public class MetadataCatalogueChannelSearchService extends SearchChannel {
         }
         // transform points to map projection and create a WKT bbox
         try {
-            double x1 = Double.parseDouble(item.getWestBoundLongitude());
-            double y1 = Double.parseDouble(item.getSouthBoundLatitude());
-            double x2 = Double.parseDouble(item.getEastBoundLongitude());
-            double y2 = Double.parseDouble(item.getNorthBoundLatitude());
+            double x1 = item.getWestBoundLongitude();
+            double y1 = item.getSouthBoundLatitude();
+            double x2 = item.getEastBoundLongitude();
+            double y2 = item.getNorthBoundLatitude();
 
             GeometryFactory gf = new GeometryFactory();
             CoordinateSequence cs = GeometryHelper.createLinearRing(gf, x1, y1, x2, y2);

--- a/service-feedback-open311/pom.xml
+++ b/service-feedback-open311/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>service-feedback-open311</artifactId>

--- a/service-feedback-open311/pom.xml
+++ b/service-feedback-open311/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>service-feedback-open311</artifactId>

--- a/service-feedback/pom.xml
+++ b/service-feedback/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>service-feedback</artifactId>
     <packaging>jar</packaging>

--- a/service-feedback/pom.xml
+++ b/service-feedback/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
     <artifactId>service-feedback</artifactId>
     <packaging>jar</packaging>

--- a/service-logging/pom.xml
+++ b/service-logging/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service-logging/pom.xml
+++ b/service-logging/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service-map/pom.xml
+++ b/service-map/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
 
     <artifactId>service-map</artifactId>

--- a/service-map/pom.xml
+++ b/service-map/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-map</artifactId>

--- a/service-mvt/pom.xml
+++ b/service-mvt/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-mvt</artifactId>

--- a/service-mvt/pom.xml
+++ b/service-mvt/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
 
     <artifactId>service-mvt</artifactId>

--- a/service-mybatis/pom.xml
+++ b/service-mybatis/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.oskari</groupId>
 		<artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>service-mybatis</artifactId>

--- a/service-mybatis/pom.xml
+++ b/service-mybatis/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.oskari</groupId>
 		<artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
 	</parent>
 
 	<artifactId>service-mybatis</artifactId>

--- a/service-myplaces/pom.xml
+++ b/service-myplaces/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-myplaces</artifactId>

--- a/service-myplaces/pom.xml
+++ b/service-myplaces/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
 
     <artifactId>service-myplaces</artifactId>

--- a/service-permissions/pom.xml
+++ b/service-permissions/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-permissions</artifactId>

--- a/service-permissions/pom.xml
+++ b/service-permissions/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
 
     <artifactId>service-permissions</artifactId>

--- a/service-print/pom.xml
+++ b/service-print/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>service-print</artifactId>
 

--- a/service-print/pom.xml
+++ b/service-print/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
     <artifactId>service-print</artifactId>
 

--- a/service-rating/pom.xml
+++ b/service-rating/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service-rating/pom.xml
+++ b/service-rating/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service-routing/pom.xml
+++ b/service-routing/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
 
     <artifactId>service-routing</artifactId>

--- a/service-routing/pom.xml
+++ b/service-routing/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-routing</artifactId>

--- a/service-scheduler/pom.xml
+++ b/service-scheduler/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
 
     <artifactId>service-scheduler</artifactId>

--- a/service-scheduler/pom.xml
+++ b/service-scheduler/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-scheduler</artifactId>

--- a/service-search-opendata/pom.xml
+++ b/service-search-opendata/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.oskari</groupId>
 		<artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
 	</parent>
 	<artifactId>service-search-opendata</artifactId>
 	<packaging>jar</packaging>

--- a/service-search-opendata/pom.xml
+++ b/service-search-opendata/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.oskari</groupId>
 		<artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>service-search-opendata</artifactId>
 	<packaging>jar</packaging>

--- a/service-search-opendata/src/main/java/fi/nls/oskari/search/What3WordsSearchChannel.java
+++ b/service-search-opendata/src/main/java/fi/nls/oskari/search/What3WordsSearchChannel.java
@@ -199,18 +199,12 @@ public class What3WordsSearchChannel extends SearchChannel {
         item.setTitle(title);
         item.setDescription(title);
         final JSONObject position = JSONHelper.getJSONObject(dataItem, "geometry");
-        final String lat = "" + position.optDouble("lat");
-        final String lon = "" + position.optDouble("lng");
+        final double lat = position.optDouble("lat");
+        final double lon = position.optDouble("lng");
 
         // convert to map projection
-        final Point point = ProjectionHelper.transformPoint(
-                ConversionHelper.getDouble(lon, -1),
-                ConversionHelper.getDouble(lat, -1),
-                sourceCrs,
-                targetCrs);
+        final Point point = ProjectionHelper.transformPoint(lon, lat, sourceCrs, targetCrs);
         if(point == null) {
-            item.setLon("");
-            item.setLat("");
             return null;
         }
 

--- a/service-search-opendata/src/test/java/fi/nls/oskari/search/What3WordsSearchChannelTest.java
+++ b/service-search-opendata/src/test/java/fi/nls/oskari/search/What3WordsSearchChannelTest.java
@@ -34,8 +34,8 @@ public class What3WordsSearchChannelTest {
         JSONObject json = ResourceHelper.readJSONResource("What3Words-success.json", this);
         SearchResultItem item = channel.parseResult(json, "EPSG:3067");
         assertEquals("Title", item.getTitle(), "carting.pint.invent");
-        assertEquals("Lat", item.getLat(), "6675293.715526561");
-        assertEquals("Lon", item.getLon(), "385547.65760422836");
+        assertEquals("Lat", item.getLat(), 6675293.715526561, 0.1);
+        assertEquals("Lon", item.getLon(), 385547.65760422836, 0.1);
     }
 
     @Test

--- a/service-search-wfs/pom.xml
+++ b/service-search-wfs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.oskari</groupId>
 		<artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
 	</parent>
 
 	<artifactId>service-search-wfs</artifactId>

--- a/service-search-wfs/pom.xml
+++ b/service-search-wfs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.oskari</groupId>
 		<artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>service-search-wfs</artifactId>

--- a/service-search-wfs/src/main/java/fi/nls/oskari/search/channel/WFSSearchChannel.java
+++ b/service-search-wfs/src/main/java/fi/nls/oskari/search/channel/WFSSearchChannel.java
@@ -216,7 +216,7 @@ public class WFSSearchChannel extends SearchChannel {
                 setupDefaults(item);
                 item.setTitle(getTitle(featureJSON));
 
-                if(featureJSON.has("geometry")) {
+                if (featureJSON.has("geometry")) {
                     JSONObject featuresObj_geometry = featureJSON.getJSONObject("geometry");
 
                     String geomType = featuresObj_geometry.getString("type").toUpperCase();
@@ -224,33 +224,33 @@ public class WFSSearchChannel extends SearchChannel {
                     if (geomType.equals(GT_GEOM_POLYGON)) {
                         Polygon polygon = geom.readPolygon(featuresObj_geometry.toString());
                         item.addValue(PARAM_GEOMETRY, WKTHelper.getWKT(polygon));
-                        item.setLat(Double.toString(polygon.getCentroid().getCoordinate().y));
-                        item.setLon(Double.toString(polygon.getCentroid().getCoordinate().x));
+                        item.setLat(polygon.getCentroid().getCoordinate().y);
+                        item.setLon(polygon.getCentroid().getCoordinate().x);
                     } else if (geomType.equals(GT_GEOM_LINESTRING)) {
                         LineString lineGeom = geom.readLine(featuresObj_geometry.toString());
                         item.addValue(PARAM_GEOMETRY, WKTHelper.getWKT(lineGeom));
-                        item.setLat(Double.toString(lineGeom.getCentroid().getCoordinate().y));
-                        item.setLon(Double.toString(lineGeom.getCentroid().getCoordinate().x));
+                        item.setLat(lineGeom.getCentroid().getCoordinate().y);
+                        item.setLon(lineGeom.getCentroid().getCoordinate().x);
                     } else if (geomType.equals(GT_GEOM_POINT)) {
                         org.locationtech.jts.geom.Point pointGeom = geom.readPoint(featuresObj_geometry.toString());
                         item.addValue(PARAM_GEOMETRY, WKTHelper.getWKT(pointGeom));
-                        item.setLat(Double.toString(pointGeom.getCentroid().getCoordinate().y));
-                        item.setLon(Double.toString(pointGeom.getCentroid().getCoordinate().x));
+                        item.setLat(pointGeom.getCentroid().getCoordinate().y);
+                        item.setLon(pointGeom.getCentroid().getCoordinate().x);
                     } else if (geomType.equals(GT_GEOM_MULTIPOLYGON)) {
                         MultiPolygon polygon = geom.readMultiPolygon(featuresObj_geometry.toString());
                         item.addValue(PARAM_GEOMETRY, WKTHelper.getWKT(polygon));
-                        item.setLat(Double.toString(polygon.getCentroid().getCoordinate().y));
-                        item.setLon(Double.toString(polygon.getCentroid().getCoordinate().x));
+                        item.setLat(polygon.getCentroid().getCoordinate().y);
+                        item.setLon(polygon.getCentroid().getCoordinate().x);
                     } else if (geomType.equals(GT_GEOM_MULTILINESTRING)) {
                         MultiLineString lineGeom = geom.readMultiLine(featuresObj_geometry.toString());
                         item.addValue(PARAM_GEOMETRY, WKTHelper.getWKT(lineGeom));
-                        item.setLat(Double.toString(lineGeom.getCentroid().getCoordinate().y));
-                        item.setLon(Double.toString(lineGeom.getCentroid().getCoordinate().x));
+                        item.setLat(lineGeom.getCentroid().getCoordinate().y);
+                        item.setLon(lineGeom.getCentroid().getCoordinate().x);
                     } else if (geomType.equals(GT_GEOM_MULTIPOINT)) {
                         MultiPoint pointGeom = geom.readMultiPoint(featuresObj_geometry.toString());
                         item.addValue(PARAM_GEOMETRY, WKTHelper.getWKT(pointGeom));
-                        item.setLat(Double.toString(pointGeom.getCentroid().getCoordinate().y));
-                        item.setLon(Double.toString(pointGeom.getCentroid().getCoordinate().x));
+                        item.setLat(pointGeom.getCentroid().getCoordinate().y);
+                        item.setLon(pointGeom.getCentroid().getCoordinate().x);
                     }
                 }
                 searchResultList.addItem(item);

--- a/service-search/pom.xml
+++ b/service-search/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.oskari</groupId>
 		<artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>service-search</artifactId>

--- a/service-search/pom.xml
+++ b/service-search/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.oskari</groupId>
 		<artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
 	</parent>
 
 	<artifactId>service-search</artifactId>

--- a/service-search/src/main/java/fi/mml/portti/service/search/AreaSizeComparator.java
+++ b/service-search/src/main/java/fi/mml/portti/service/search/AreaSizeComparator.java
@@ -4,22 +4,14 @@ import java.util.Comparator;
 
 public class AreaSizeComparator implements Comparator<SearchResultItem> {
 
-	public int compare(SearchResultItem sri1, SearchResultItem sri2){
+    public int compare(SearchResultItem first, SearchResultItem second) {
+        return getArea(first) - getArea(second);
+    }
 
-		float left1 = Float.parseFloat(sri1.getEastBoundLongitude());
-		float right1 = Float.parseFloat(sri1.getWestBoundLongitude());
-		float bottom1 = Float.parseFloat(sri1.getSouthBoundLatitude());
-		float top1 = Float.parseFloat(sri1.getNorthBoundLatitude());
-		
-		float left2 = Float.parseFloat(sri2.getEastBoundLongitude());
-		float right2 = Float.parseFloat(sri2.getWestBoundLongitude());
-		float bottom2 = Float.parseFloat(sri2.getSouthBoundLatitude());
-		float top2 = Float.parseFloat(sri2.getNorthBoundLatitude());
-	
-		int areaSize1 = Math.round((right1-left1)* (top1-bottom1));
-		int areaSize2 =  Math.round((right2-left2)* (top2-bottom2));
-		
-		return areaSize1-areaSize2;
-
-	}
+    private int getArea(SearchResultItem item) {
+        return (int) Math.round(
+                (item.getWestBoundLongitude() - item.getEastBoundLongitude())
+                *
+                (item.getNorthBoundLatitude() - item.getSouthBoundLatitude()));
+    }
 }

--- a/service-search/src/main/java/fi/mml/portti/service/search/ChannelSearchResult.java
+++ b/service-search/src/main/java/fi/mml/portti/service/search/ChannelSearchResult.java
@@ -20,7 +20,7 @@ public class ChannelSearchResult  implements Serializable {
 	private boolean truncated;
 	private boolean queryFailed;
 
-	private List<SearchResultItem> searchResultItems = new ArrayList<SearchResultItem>();
+	private List<SearchResultItem> searchResultItems = new ArrayList<>();
 	private String searchMethod;
 	
 	public ChannelSearchResult() {
@@ -42,7 +42,9 @@ public class ChannelSearchResult  implements Serializable {
 		this.channelId = channel;
 	}
 
+	@Deprecated
 	public String getSearchMethod() { return searchMethod;	}
+	@Deprecated
 	public void setSearchMethod(String searchMethod) {this.searchMethod = searchMethod;	}
 
 	public boolean isAvailable() {

--- a/service-search/src/main/java/fi/mml/portti/service/search/SearchResultItem.java
+++ b/service-search/src/main/java/fi/mml/portti/service/search/SearchResultItem.java
@@ -1,5 +1,7 @@
 package fi.mml.portti.service.search;
 
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.util.ConversionHelper;
 import fi.nls.oskari.util.JSONHelper;
 import org.json.JSONArray;
@@ -14,6 +16,8 @@ import java.util.*;
  * Search result item.
  */
 public class SearchResultItem implements Comparable<SearchResultItem>, Serializable {
+
+    private static final Logger LOG = LogFactory.getLogger(SearchResultItem.class);
     // JSON keys (see toJSON())
     public static final String KEY_ID = "id";
     public static final String KEY_NAME = "name";
@@ -25,9 +29,6 @@ public class SearchResultItem implements Comparable<SearchResultItem>, Serializa
     public static final String KEY_LAT = "lat";
     public static final String KEY_ZOOMLEVEL = "zoomLevel";
     public static final String KEY_ZOOMSCALE = "zoomScale";
-	@Deprecated
-    public static final String KEY_VILLAGE = "village";
-	// region is the new "village"
 	public static final String KEY_REGION = "region";
 	public static final String KEY_CHANNELID = "channelId";
 
@@ -53,12 +54,12 @@ public class SearchResultItem implements Comparable<SearchResultItem>, Serializa
     private String type;
 	private String lang;
 	private String locationName;
-	private String lon;
-	private String lat;
-	private String westBoundLongitude;
-	private String southBoundLatitude;
-	private String eastBoundLongitude;
-	private String northBoundLatitude;	
+	private Double lon;
+	private Double lat;
+	private Double westBoundLongitude;
+	private Double southBoundLatitude;
+	private Double eastBoundLongitude;
+	private Double northBoundLatitude;
 	private String mapURL;
 	private String zoomLevel;
     private double zoomScale = -1;
@@ -197,10 +198,12 @@ public class SearchResultItem implements Comparable<SearchResultItem>, Serializa
         return this.zoomScale;
     }
 
+    @Deprecated
 	public String getMapURL() {
 		return mapURL;
 	}
 
+	@Deprecated
 	public void setMapURL(String mapURL) {
 		this.mapURL = mapURL;
 	}
@@ -261,69 +264,118 @@ public class SearchResultItem implements Comparable<SearchResultItem>, Serializa
 		this.region = region;
 	}
 
-	/**
-	 * Deprecated, use getRegion() instead.
-	 * @return
-     */
-	@Deprecated
-	public String getVillage() {
-		return getRegion();
-	}
-	/**
-	 * Deprecated, use setRegion() instead.
-	 * @return
-	 */
-	@Deprecated
-	public void setVillage(String village) {
-		setRegion(village);
-	}
 	public String getLocationTypeCode() {
 		return locationTypeCode;
 	}
 	public void setLocationTypeCode(String locationTypeCode) {
 		this.locationTypeCode = locationTypeCode;
 	}
-	public String getLon() {
+
+	public Double getLon() {
 		return lon;
 	}
+
+	/**
+	 * @deprecated Use setLong(double) instead
+	 * @param lon
+	 */
+	@Deprecated
 	public void setLon(String lon) {
-		this.lon = lon;
+		try {
+			this.lon = Double.parseDouble(lon);
+		} catch (Exception ignored) {
+			this.lon = null;
+		}
 	}
 	public void setLon(double lon) {
-		this.lon = "" + lon;
+		this.lon = lon;
 	}
-	public String getWestBoundLongitude() {
+
+	public Double getWestBoundLongitude() {
 		return westBoundLongitude;
 	}
+	/**
+	 * @deprecated Use setWestBoundLongitude(double) instead
+	 */
+	@Deprecated
 	public void setWestBoundLongitude(String westBoundLongitude) {
+		try {
+			this.westBoundLongitude = Double.parseDouble(westBoundLongitude);
+		} catch (Exception ignored) {
+			this.westBoundLongitude = null;
+		}
+	}
+	public void setWestBoundLongitude(double westBoundLongitude) {
 		this.westBoundLongitude = westBoundLongitude;
 	}
-	public String getSouthBoundLatitude() {
+	public Double getSouthBoundLatitude() {
 		return southBoundLatitude;
 	}
+	/**
+	 * @deprecated Use setSouthBoundLatitude(double) instead
+	 */
+	@Deprecated
 	public void setSouthBoundLatitude(String southBoundLatitude) {
+		try {
+			this.southBoundLatitude = Double.parseDouble(southBoundLatitude);
+		} catch (Exception ignored) {
+			this.southBoundLatitude = null;
+		}
+	}
+	public void setSouthBoundLatitude(double southBoundLatitude) {
 		this.southBoundLatitude = southBoundLatitude;
 	}
-	public String getEastBoundLongitude() {
+	public Double getEastBoundLongitude() {
 		return eastBoundLongitude;
 	}
+	/**
+	 * @deprecated Use setEastBoundLongitude(double) instead
+	 */
+	@Deprecated
 	public void setEastBoundLongitude(String eastBoundLongitude) {
+		try {
+			this.eastBoundLongitude = Double.parseDouble(eastBoundLongitude);
+		} catch (Exception ignored) {
+			this.eastBoundLongitude = null;
+		}
+	}
+	public void setEastBoundLongitude(double eastBoundLongitude) {
 		this.eastBoundLongitude = eastBoundLongitude;
 	}
-	public String getNorthBoundLatitude() {
+	public Double getNorthBoundLatitude() {
 		return northBoundLatitude;
 	}
+	/**
+	 * @deprecated Use setNorthBoundLatitude(double) instead
+	 */
+	@Deprecated
 	public void setNorthBoundLatitude(String northBoundLatitude) {
+		try {
+			this.northBoundLatitude = Double.parseDouble(northBoundLatitude);
+		} catch (Exception ignored) {
+			this.northBoundLatitude = null;
+		}
+	}
+	public void setNorthBoundLatitude(double northBoundLatitude) {
 		this.northBoundLatitude = northBoundLatitude;
 	}
-	public String getLat() {
+
+	public Double getLat() {
 		return lat;
 	}
+	/**
+	 * @deprecated Use setLat(double) instead
+	 */
+	@Deprecated
 	public void setLat(String lat) {
-		this.lat = lat;
+		try {
+			this.lat = Double.parseDouble(lat);
+		} catch (Exception ignored) {
+			this.lat = null;
+		}
 	}
 	public void setLat(double lat) {
-		this.lat = "" + lat;
+		this.lat = lat;
 	}
 	public String getLocationName() {
 		return locationName;
@@ -404,7 +456,7 @@ public class SearchResultItem implements Comparable<SearchResultItem>, Serializa
 	}
 
     public boolean hasNameAndLocation() {
-        return hasValue(getTitle()) && hasValue(getLat()) && hasValue(getLon());
+        return hasValue(getTitle()) && getLat() != null && getLon() != null;
     }
 
     private boolean hasValue(final String param) {
@@ -438,9 +490,6 @@ public class SearchResultItem implements Comparable<SearchResultItem>, Serializa
 
         String region = ConversionHelper.getString(getRegion(), "");
 		JSONHelper.putValue(node, KEY_REGION, Jsoup.clean(region, Whitelist.none()));
-		// TODO: Village has been deprecated on 1.42. Remove any time after 1.44.
-		// Note! This affects the frontend event/RPC API.
-		JSONHelper.putValue(node, KEY_VILLAGE, Jsoup.clean(region, Whitelist.none()));
 
         // do the bbox if we have any of the bbox values (Should have all if has any one of these)
         if(getWestBoundLongitude() != null) {

--- a/service-search/src/main/java/fi/nls/oskari/SearchWorker.java
+++ b/service-search/src/main/java/fi/nls/oskari/SearchWorker.java
@@ -92,7 +92,7 @@ public class SearchWorker {
 
         JSONArray methodArray = new JSONArray();
         for(String channelId : sc.getChannels()) {
-            methodArray.put(JSONHelper.createJSONObject(channelId, query.findResult(channelId).getSearchMethod()));
+            methodArray.put(JSONHelper.createJSONObject(channelId, !query.findResult(channelId).isQueryFailed()));
         }
         JSONHelper.putValue(result, KEY_METHODS, methodArray);
         return result;

--- a/service-spatineo-monitor/pom.xml
+++ b/service-spatineo-monitor/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-spatineo-monitor</artifactId>

--- a/service-spatineo-monitor/pom.xml
+++ b/service-spatineo-monitor/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
 
     <artifactId>service-spatineo-monitor</artifactId>

--- a/service-statistics-common/pom.xml
+++ b/service-statistics-common/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
 	</parent>
 
     <artifactId>service-statistics-common</artifactId>

--- a/service-statistics-common/pom.xml
+++ b/service-statistics-common/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
 	</parent>
 
     <artifactId>service-statistics-common</artifactId>

--- a/service-statistics-eurostat/pom.xml
+++ b/service-statistics-eurostat/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
 	</parent>
 
     <artifactId>service-statistics-eurostat</artifactId>

--- a/service-statistics-eurostat/pom.xml
+++ b/service-statistics-eurostat/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
 	</parent>
 
     <artifactId>service-statistics-eurostat</artifactId>

--- a/service-statistics-kapa/pom.xml
+++ b/service-statistics-kapa/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
 	</parent>
 
     <artifactId>service-statistics-kapa</artifactId>

--- a/service-statistics-kapa/pom.xml
+++ b/service-statistics-kapa/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
 	</parent>
 
     <artifactId>service-statistics-kapa</artifactId>

--- a/service-statistics-pxweb/pom.xml
+++ b/service-statistics-pxweb/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
 
     <artifactId>service-statistics-pxweb</artifactId>

--- a/service-statistics-pxweb/pom.xml
+++ b/service-statistics-pxweb/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-statistics-pxweb</artifactId>

--- a/service-statistics-sotka/pom.xml
+++ b/service-statistics-sotka/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
 	</parent>
 
     <artifactId>service-statistics-sotka</artifactId>

--- a/service-statistics-sotka/pom.xml
+++ b/service-statistics-sotka/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
 	</parent>
 
     <artifactId>service-statistics-sotka</artifactId>

--- a/service-statistics-unsd/pom.xml
+++ b/service-statistics-unsd/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
 	</parent>
 
     <artifactId>service-statistics-unsd</artifactId>

--- a/service-statistics-unsd/pom.xml
+++ b/service-statistics-unsd/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
 	</parent>
 
     <artifactId>service-statistics-unsd</artifactId>

--- a/service-statistics/pom.xml
+++ b/service-statistics/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
 	</parent>
 
     <artifactId>service-statistics</artifactId>

--- a/service-statistics/pom.xml
+++ b/service-statistics/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
 	</parent>
 
     <artifactId>service-statistics</artifactId>

--- a/service-userlayer/pom.xml
+++ b/service-userlayer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>service-userlayer</artifactId>
     <description>Everything related to UserLayers</description>

--- a/service-userlayer/pom.xml
+++ b/service-userlayer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
     <artifactId>service-userlayer</artifactId>
     <description>Everything related to UserLayers</description>

--- a/service-users/pom.xml
+++ b/service-users/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-users</artifactId>

--- a/service-users/pom.xml
+++ b/service-users/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
 
     <artifactId>service-users</artifactId>

--- a/service-wcs/pom.xml
+++ b/service-wcs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-wcs</artifactId>

--- a/service-wcs/pom.xml
+++ b/service-wcs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
 
     <artifactId>service-wcs</artifactId>

--- a/service-webapp/pom.xml
+++ b/service-webapp/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-webapp</artifactId>

--- a/service-webapp/pom.xml
+++ b/service-webapp/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
 
     <artifactId>service-webapp</artifactId>

--- a/service-wfs-client/pom.xml
+++ b/service-wfs-client/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>service-wfs-client</artifactId>
     <description>Utilities for accessing WFS 1.1.0 services</description>

--- a/service-wfs-client/pom.xml
+++ b/service-wfs-client/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
     <artifactId>service-wfs-client</artifactId>
     <description>Utilities for accessing WFS 1.1.0 services</description>

--- a/service-wfs3/pom.xml
+++ b/service-wfs3/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
     <artifactId>service-wfs3</artifactId>
     <description>When working with WFS 3 services</description>

--- a/service-wfs3/pom.xml
+++ b/service-wfs3/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>service-wfs3</artifactId>
     <description>When working with WFS 3 services</description>

--- a/servlet-map/pom.xml
+++ b/servlet-map/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>servlet-map</artifactId>
     <packaging>jar</packaging>

--- a/servlet-map/pom.xml
+++ b/servlet-map/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
     <artifactId>servlet-map</artifactId>
     <packaging>jar</packaging>

--- a/shared-test-resources/pom.xml
+++ b/shared-test-resources/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
 	</parent>
 
     <artifactId>shared-test-resources</artifactId>

--- a/shared-test-resources/pom.xml
+++ b/shared-test-resources/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
 	</parent>
 
     <artifactId>shared-test-resources</artifactId>

--- a/webapp-setup/pom.xml
+++ b/webapp-setup/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>webapp-setup</artifactId>

--- a/webapp-setup/pom.xml
+++ b/webapp-setup/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
 
     <artifactId>webapp-setup</artifactId>


### PR DESCRIPTION
As a hotfix since frontend assumes to get numbers as coordinates for showing the popup on map after oskariorg/oskari-frontend#1324

Without this the infobox isn't shown when clicking search results.