### PR TITLE
Make caches aware of cluster environment

### DIFF
--- a/service-base/pom.xml
+++ b/service-base/pom.xml
@@ -65,5 +65,16 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- PowerMock can be used to mock static/private methods -->
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/service-base/src/main/java/fi/nls/oskari/cache/Cache.java
+++ b/service-base/src/main/java/fi/nls/oskari/cache/Cache.java
@@ -16,7 +16,7 @@ import java.util.concurrent.ConcurrentSkipListMap;
  */
 public class Cache<T> {
 
-    private static final Logger log = LogFactory.getLogger(Cache.class);
+    private static final Logger LOG = LogFactory.getLogger(Cache.class);
 
     // the items are sorted by key.compare(key) -> we should map the String to a "CacheKey" which compares insertion time
     private final ConcurrentNavigableMap<String,T> items = new ConcurrentSkipListMap<>();
@@ -69,7 +69,7 @@ public class Cache<T> {
      */
     public void setLimit(int limit) {
         if(cacheSizeConfigured) {
-            log.info("Trying to set cache limit, but it's configured by user so ignoring automatic limit change.",
+            LOG.info("Trying to set cache limit, but it's configured by user so ignoring automatic limit change.",
                     "Limit is", this.limit, "- Change limit with property: ", getLimitPropertyName());
             return;
         }
@@ -117,7 +117,7 @@ public class Cache<T> {
         T value = items.get(name);
 
         if(cacheMissDebugEnabled && value == null) {
-            log.debug("Cache", getName(), "miss for name", name);
+            LOG.debug("Cache", getName(), "miss for name", name);
         }
         return value;
     }
@@ -129,7 +129,7 @@ public class Cache<T> {
         return removeSilent(name);
     }
 
-    protected T removeSilent(final String name) {
+    private T removeSilent(final String name) {
         flush(false);
         T value = items.remove(name);
         keys.remove(name);
@@ -146,8 +146,8 @@ public class Cache<T> {
         final boolean overflowing = (items.size() >= limit);
         if(overflowing) {
             // limit reached - remove oldest object
-            log.warn("Cache", getName(), "overflowing! Limit is", limit);
-            log.info("Configure larger limit for cache by setting the property:", getLimitPropertyName());
+            LOG.warn("Cache", getName(), "overflowing! Limit is", limit);
+            LOG.info("Configure larger limit for cache by setting the property:", getLimitPropertyName());
             final String key = keys.poll();
             if(key != null) {
                 items.remove(key);
@@ -162,7 +162,7 @@ public class Cache<T> {
         final long now = currentTime();
         if(force || isTimeToFlush(now)) {
             // flushCache
-            log.debug("Flushing cache! Cache:", getName(), "Forced: ", force);
+            LOG.debug("Flushing cache! Cache:", getName(), "Forced: ", force);
             items.clear();
             keys.clear();
             lastFlush = now;

--- a/service-base/src/main/java/fi/nls/oskari/cache/Cache.java
+++ b/service-base/src/main/java/fi/nls/oskari/cache/Cache.java
@@ -140,6 +140,7 @@ public class Cache<T> {
         flush(false);
         if(item == null) {
             // can't save null value
+            remove(name);
             return false;
         }
         final boolean overflowing = (items.size() >= limit);

--- a/service-base/src/main/java/fi/nls/oskari/cache/CacheManager.java
+++ b/service-base/src/main/java/fi/nls/oskari/cache/CacheManager.java
@@ -48,7 +48,7 @@ public class CacheManager {
      *
      * @param name name of the cache
      * @param supplier function which creates a new cache if one doesn't exists for the key
-     * @param <T>  type mapping for cache
+     * @param <T1>  type mapping for cache
      * @return
      */
     @SuppressWarnings("unchecked")

--- a/service-base/src/main/java/fi/nls/oskari/cache/ComputeOnceCache.java
+++ b/service-base/src/main/java/fi/nls/oskari/cache/ComputeOnceCache.java
@@ -16,6 +16,7 @@ public class ComputeOnceCache<T> extends Cache<T> {
     }
 
     public ComputeOnceCache(int limit, long expiration) {
+        super();
         setLimit(limit);
         setExpiration(expiration);
         tmp = new ConcurrentHashMap<>();

--- a/service-base/src/main/java/fi/nls/oskari/cache/JedisManager.java
+++ b/service-base/src/main/java/fi/nls/oskari/cache/JedisManager.java
@@ -498,13 +498,20 @@ public class JedisManager {
     public static boolean isClusterEnv() {
         if (isClustered == null) {
             final String[] configuredProfiles = PropertyUtil.getCommaSeparatedList("oskari.profiles");
-            for (String profile: configuredProfiles) {
-                if (CLUSTERED_ENV_PROFILE.equalsIgnoreCase(profile)) {
-                    isClustered = true;
-                }
-            }
-            isClustered = false;
+            isClustered = hasClusterProfile(configuredProfiles);
         }
         return isClustered;
+    }
+
+    protected static boolean hasClusterProfile(String[] configuredProfiles) {
+        if (configuredProfiles == null) {
+            return false;
+        }
+        for (String profile: configuredProfiles) {
+            if (CLUSTERED_ENV_PROFILE.equalsIgnoreCase(profile.trim())) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/service-base/src/main/java/fi/nls/oskari/cache/JedisManager.java
+++ b/service-base/src/main/java/fi/nls/oskari/cache/JedisManager.java
@@ -18,6 +18,7 @@ import java.util.Set;
  */
 public class JedisManager {
 
+    public static final String CLUSTERED_ENV_PROFILE = "redis-session";
     public static String ERROR_REDIS_COMMUNICATION_FAILURE = "redis_communication_failure";
     public static String PUBSUB_CHANNEL_PREFIX = "oskari_";
     public static final int EXPIRY_TIME_DAY = 86400;
@@ -29,7 +30,7 @@ public class JedisManager {
     private static final String KEY_REDIS_HOSTNAME = "redis.hostname";
     private static final String KEY_REDIS_PORT = "redis.port";
     private static final String KEY_REDIS_POOL_SIZE = "redis.pool.size";
-
+    private static Boolean isClustered = null;
 
     /**
      * Blocking construction of instances from other classes by making constructor private
@@ -494,4 +495,16 @@ public class JedisManager {
         }).start();
     }
 
+    public static boolean isClusterEnv() {
+        if (isClustered == null) {
+            final String[] configuredProfiles = PropertyUtil.getCommaSeparatedList("oskari.profiles");
+            for (String profile: configuredProfiles) {
+                if (CLUSTERED_ENV_PROFILE.equalsIgnoreCase(profile)) {
+                    isClustered = true;
+                }
+            }
+            isClustered = false;
+        }
+        return isClustered;
+    }
 }

--- a/service-base/src/main/java/fi/nls/oskari/cache/JedisManager.java
+++ b/service-base/src/main/java/fi/nls/oskari/cache/JedisManager.java
@@ -451,10 +451,11 @@ public class JedisManager {
      * @return long
      */
     public static Long publish(final String channel, final String message) {
-        try (Jedis jedis = instance.getJedis()){
+        try (Jedis jedis = instance.getJedis()) {
             if (jedis == null) {
                 return null;
             }
+            log.debug("Sending to", PUBSUB_CHANNEL_PREFIX + channel, "msg:", message);
             return jedis.publish(PUBSUB_CHANNEL_PREFIX + channel, message);
         } catch(JedisConnectionException e) {
             log.error("Failed to publish on:", channel);

--- a/service-base/src/test/java/fi/nls/oskari/cache/CacheClusterTest.java
+++ b/service-base/src/test/java/fi/nls/oskari/cache/CacheClusterTest.java
@@ -1,0 +1,65 @@
+package fi.nls.oskari.cache;
+
+import fi.nls.oskari.util.PropertyUtil;
+import org.junit.After;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.UUID;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+
+/**
+ * Simple tests for cache.
+ */
+public class CacheClusterTest {
+
+    @After
+    public void teardown() {
+        PropertyUtil.clearProperties();
+    }
+
+    @Test
+    public void testClusterMsgFromSelfFlush() {
+        Cache<String> cache = spy(Cache.class);
+        cache.setName("Clustered");
+        cache.handleClusterMsg(cache.getCacheInstanceId() + "_" + Cache.CLUSTER_CMD_FLUSH);
+        // message from self should NOT trigger call
+        Mockito.verify(cache, never()).flush(true);
+    }
+
+    @Test
+    public void testClusterMsgFromOthersFlush() {
+        Cache<String> cache = spy(Cache.class);
+        cache.setName("Clustered");
+        // another cache instance
+        cache.handleClusterMsg(UUID.randomUUID().toString() + "_" + Cache.CLUSTER_CMD_FLUSH);
+        // message from OTHER should trigger call
+        Mockito.verify(cache).flush(true);
+    }
+
+    @Test
+    public void testClusterMsgFromSelfDelete() {
+        String cacheKey = "testing";
+        Cache<String> cache = spy(Cache.class);
+        cache.setName("Clustered");
+        cache.handleClusterMsg(cache.getCacheInstanceId() + "_" + Cache.CLUSTER_CMD_REMOVE_PREFIX + cacheKey);
+        // message from self should NOT trigger call
+        Mockito.verify(cache, never()).remove(cacheKey);
+        Mockito.verify(cache, never()).removeSilent(cacheKey);
+    }
+
+    @Test
+    public void testClusterMsgFromOthersDelete() {
+        String cacheKey = "testing";
+        Cache<String> cache = spy(Cache.class);
+        cache.setName("Clustered");
+        // another cache instance
+        cache.handleClusterMsg(UUID.randomUUID().toString() + "_" + Cache.CLUSTER_CMD_REMOVE_PREFIX + cacheKey);
+        // message from OTHER should trigger call
+        Mockito.verify(cache).removeSilent(cacheKey);
+        // but not trigger another notify for cluster
+        Mockito.verify(cache, never()).remove(cacheKey);
+    }
+}

--- a/service-base/src/test/java/fi/nls/oskari/cache/JedisManagerTest.java
+++ b/service-base/src/test/java/fi/nls/oskari/cache/JedisManagerTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Set;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @Ignore
@@ -62,5 +63,14 @@ public class JedisManagerTest {
 
         Long res = JedisManager.publish("test", "test message");
         assertTrue(res == 1);
+    }
+
+    @Test
+    public void testCluster() {
+        assertFalse("Null input returns false ", JedisManager.hasClusterProfile(null));
+        assertFalse("Empty profile list returns false", JedisManager.hasClusterProfile(new String[]{}));
+        assertFalse("Profiles without Redis session returns false", JedisManager.hasClusterProfile(new String[]{"some", "other"}));
+        assertTrue("Redis session profile as single returns true", JedisManager.hasClusterProfile(new String[]{JedisManager.CLUSTERED_ENV_PROFILE}));
+        assertTrue("Redis session profile in list returns true", JedisManager.hasClusterProfile(new String[]{"some", JedisManager.CLUSTERED_ENV_PROFILE, "other"}));
     }
 }

--- a/service-map/src/main/java/org/oskari/service/maplayer/OskariMapLayerGroupServiceMybatisImpl.java
+++ b/service-map/src/main/java/org/oskari/service/maplayer/OskariMapLayerGroupServiceMybatisImpl.java
@@ -57,7 +57,7 @@ public class OskariMapLayerGroupServiceMybatisImpl extends OskariMapLayerGroupSe
             session.getMapper(MAPPER).update(group);
             session.commit();
         }
-        cache(group);
+        cache.remove(getCacheKey(group));
     }
     public void delete(MaplayerGroup group) {
         try (SqlSession session = factory.openSession(false)) {

--- a/service-myplaces/src/main/java/fi/nls/oskari/myplaces/MyPlacesServiceMybatisImpl.java
+++ b/service-myplaces/src/main/java/fi/nls/oskari/myplaces/MyPlacesServiceMybatisImpl.java
@@ -214,7 +214,7 @@ public class MyPlacesServiceMybatisImpl extends MyPlacesService {
             // update data in cache
             MyPlaceCategory layer = getFromCache(id);
             if (layer != null && rows > 0) {
-                layer.setPublisher_name(name);
+                cache.remove(getCacheKey(id));
             }
             return rows;
         } catch (Exception e) {

--- a/service-permissions/src/main/java/org/oskari/permissions/PermissionServiceMybatisImpl.java
+++ b/service-permissions/src/main/java/org/oskari/permissions/PermissionServiceMybatisImpl.java
@@ -120,7 +120,7 @@ public class PermissionServiceMybatisImpl extends PermissionService {
 
         if (exists(resource)) {
             setPermissions(resource.getId(), resource.getPermissions());
-            cache.put(getCacheKey(resource), resource);
+            cache.remove(getCacheKey(resource));
         } else {
             insertResource(resource);
         }

--- a/service-print/src/main/java/org/oskari/print/wmts/WMTSCapabilitiesCache.java
+++ b/service-print/src/main/java/org/oskari/print/wmts/WMTSCapabilitiesCache.java
@@ -1,5 +1,6 @@
 package org.oskari.print.wmts;
 
+import fi.nls.oskari.cache.CacheManager;
 import fi.nls.oskari.service.ServiceException;
 import fi.nls.oskari.cache.Cache;
 import fi.nls.oskari.service.capabilities.CapabilitiesCacheService;
@@ -23,7 +24,7 @@ public class WMTSCapabilitiesCache {
 
     public WMTSCapabilitiesCache(CapabilitiesCacheService capabilitiesService) {
         this.capabilitiesService = capabilitiesService;
-        this.wmtsCapabilitiesCache = new Cache<>();
+        this.wmtsCapabilitiesCache = CacheManager.getCache(WMTSCapabilitiesCache.class.getName());
     }
 
     public WMTSCapabilities get(PrintLayer layer) throws ServiceException {

--- a/service-userlayer/src/main/java/org/oskari/map/userlayer/service/UserLayerDbServiceMybatisImpl.java
+++ b/service-userlayer/src/main/java/org/oskari/map/userlayer/service/UserLayerDbServiceMybatisImpl.java
@@ -104,6 +104,8 @@ public class UserLayerDbServiceMybatisImpl extends UserLayerDbService {
         } catch (Exception e) {
             log.error(e, "Failed to update userLayer", userLayer);
             throw new UserLayerException("Failed to update userlayer", UserLayerException.ErrorType.STORE);
+        } finally {
+            cache.remove(Long.toString(userLayer.getId()));
         }
     }
 

--- a/service-userlayer/src/main/java/org/oskari/map/userlayer/service/UserLayerDbServiceMybatisImpl.java
+++ b/service-userlayer/src/main/java/org/oskari/map/userlayer/service/UserLayerDbServiceMybatisImpl.java
@@ -209,7 +209,7 @@ public class UserLayerDbServiceMybatisImpl extends UserLayerDbService {
             // update data in cache
             UserLayer layer = getFromCache(id);
             if (layer != null && result > 0) {
-                layer.setPublisher_name(name);
+                cache.remove(Long.toString(id));
             }
             return result;
         } catch (Exception e) {

--- a/servlet-map/src/main/java/fi/nls/oskari/spring/SpringInitializer.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/spring/SpringInitializer.java
@@ -42,6 +42,11 @@ public class SpringInitializer extends AbstractHttpSessionApplicationInitializer
         }
     }
 
+    /**
+     * @see fi.nls.oskari.cache.JedisManager#isClusterEnv()
+     * @param context
+     * @return
+     */
     private boolean isRedisSessionActived(WebApplicationContext context) {
         String[] profiles = context.getEnvironment().getActiveProfiles();
         for (String profile: profiles) {

--- a/servlet-map/src/main/java/fi/nls/oskari/spring/session/RedisSessionConfig.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/spring/session/RedisSessionConfig.java
@@ -1,5 +1,6 @@
 package fi.nls.oskari.spring.session;
 
+import fi.nls.oskari.cache.JedisManager;
 import fi.nls.oskari.util.PropertyUtil;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,13 +16,12 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 @EnableRedisHttpSession(maxInactiveIntervalInSeconds=7200)
 public class RedisSessionConfig extends WebMvcConfigurerAdapter {
 
-    public static final String PROFILE ="redis-session";
+    public static final String PROFILE = JedisManager.CLUSTERED_ENV_PROFILE;
 
     @Bean
     public JedisConnectionFactory connectionFactory() {
         RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(
-                PropertyUtil.get("redis.hostname", "127.0.0.1"),
-                PropertyUtil.getOptional("redis.port", 6379));
+                JedisManager.getHost(), JedisManager.getPort());
         JedisConnectionFactory jedis = new JedisConnectionFactory(config);
         return jedis;
     }


### PR DESCRIPTION
Includes commits from #645 and continues building on it to make caches aware of clustered environment.

Caches will start to notify other cluster nodes of removals via Jedis pubsub when clustered environment is detected.
- Removes from cache now trigger notification for other cluster nodes
- Setting a new value for existing key now triggers notification for other cluster nodes
- Unfortunately we don't know if other nodes have a value cached that the current node doesn't and cache flush should be triggered because of put(). We can workaround this if values are NOT updated by calling put() but removed before updating the value. Not sure if we should bake it in to cache to always call notifyRemove() on put() so the cache would never have updated values on some node. However this would reduce the effect caching has if putting in new values would trigger on existing cached items to be flushed each time a new node caches something. Because of this updating a cached value should ALWAYS call remove() before caching the updated value so cluster nodes will be notified appropriately.

Note! This is a intermediate step that is continued on #648 