### PR TITLE
User-agent/referer for http-requests made from Oskari-server

### DIFF
--- a/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
@@ -13,6 +13,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
 import java.util.*;
+import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -47,6 +48,7 @@ public class IOHelper {
 
     private static SSLSocketFactory TRUSTED_FACTORY;
     private static HostnameVerifier TRUSTED_VERIFIER;
+    private static String userAgent;
 
     public static int getConnectionTimeoutMs() {
         return PropertyUtil.getOptional("oskari.connection.timeout", 3000);
@@ -63,6 +65,14 @@ public class IOHelper {
     public static String getMyDomain() {
         return PropertyUtil.get("oskari.domain", "http://localhost:8080");
     }
+    public static String getUserAgent() {
+        if (userAgent == null) {
+            Package pkg = Manifest.class.getPackage();
+            userAgent = "Oskari/" + pkg.getImplementationVersion();
+        }
+        return userAgent;
+    }
+
     /**
      * Reads the given input stream and converts its contents to a string using #DEFAULT_CHARSET
      * @param is
@@ -660,6 +670,16 @@ public class IOHelper {
         if (value != null) {
             con.setRequestProperty(HEADER_CONTENTTYPE, value);
         }
+    }
+
+    /**
+     * Writes User-agent and Referer headers to the connection.
+     * @param con       connection to write to
+     * @throws IOException
+     */
+    public static void addIdentifierHeaders(final HttpURLConnection con) throws IOException {
+        con.setRequestProperty(HEADER_USERAGENT, getUserAgent());
+        con.setRequestProperty(HEADER_REFERER, getMyDomain());
     }
 
     /**

--- a/service-search-opendata/src/main/java/fi/nls/oskari/search/OpenStreetMapSearchChannel.java
+++ b/service-search-opendata/src/main/java/fi/nls/oskari/search/OpenStreetMapSearchChannel.java
@@ -9,7 +9,6 @@ import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.map.geometry.ProjectionHelper;
 import fi.nls.oskari.search.channel.SearchChannel;
-import fi.nls.oskari.util.ConversionHelper;
 import fi.nls.oskari.util.IOHelper;
 import fi.nls.oskari.util.JSONHelper;
 import fi.nls.oskari.util.PropertyUtil;
@@ -20,7 +19,7 @@ import org.json.JSONObject;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
+import java.net.HttpURLConnection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -78,8 +77,9 @@ public class OpenStreetMapSearchChannel extends SearchChannel {
         }
 
         String url = getUrl(searchCriteria);
-
-        String data = IOHelper.readString(getConnection(url));
+        HttpURLConnection connection = getConnection(url);
+        IOHelper.addIdentifierHeaders(connection);
+        String data = IOHelper.readString(connection);
         log.debug("DATA: " + data);
         return JSONHelper.createJSONArray(data);
     }


### PR DESCRIPTION
OSM Nominatim requires these. We could add it by default to all requests but it might break something and would require more testing.