### PR TITLE
Add a way to programmatically update log levels

### DIFF
--- a/control-admin/pom.xml
+++ b/control-admin/pom.xml
@@ -28,6 +28,16 @@
             <artifactId>service-logging</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.oskari</groupId>
             <artifactId>service-search-wfs</artifactId>
         </dependency>
@@ -113,6 +123,5 @@
             <artifactId>powermock-api-mockito2</artifactId>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 </project>

--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/LoggerHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/LoggerHandler.java
@@ -1,0 +1,118 @@
+package fi.nls.oskari.control.admin;
+
+import fi.nls.oskari.annotation.OskariActionRoute;
+import fi.nls.oskari.control.ActionDeniedException;
+import fi.nls.oskari.control.ActionException;
+import fi.nls.oskari.control.ActionParameters;
+import fi.nls.oskari.control.RestActionHandler;
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.util.JSONHelper;
+import fi.nls.oskari.util.ResponseHelper;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.json.JSONObject;
+import org.oskari.log.AuditLog;
+
+import java.util.Map;
+
+@OskariActionRoute("Logger")
+public class LoggerHandler extends RestActionHandler {
+
+    private Logger log = LogFactory.getLogger(LoggerHandler.class);
+
+    private static final String NAME_ROOT = "ROOT";
+
+    /**
+     * Returns current loggers and log levels
+     * @param params
+     */
+    @Override
+    public void handleGet(ActionParameters params) {
+        final JSONObject response = new JSONObject();
+        LoggerContext context = (LoggerContext) LogManager.getContext(false);
+        Configuration config = context.getConfiguration();
+        for (Map.Entry<String, LoggerConfig> entry : config.getLoggers().entrySet()) {
+            String name = entry.getKey();
+            if (name.isEmpty()) {
+                name = NAME_ROOT;
+            }
+            JSONHelper.putValue(response, name, entry.getValue().getLevel());
+        }
+
+        ResponseHelper.writeResponse(params, response);
+    }
+
+    /**
+     * Set a log level for logger (creating one if not specific match)
+     * @param params
+     */
+    @Override
+    public void handlePost(ActionParameters params) throws ActionException {
+        LoggerContext context = (LoggerContext) LogManager.getContext(false);
+        Configuration config = context.getConfiguration();
+        String level = params.getRequiredParam("level");
+        String loggerName = params.getHttpParam("name", NAME_ROOT);
+        if (loggerName != null && !NAME_ROOT.equals(loggerName)) {
+            LoggerConfig lc = getConfig(loggerName);
+            if (lc == null) {
+                // create a new one so we can give more granular logging
+                lc = new LoggerConfig();
+                config.addLogger(loggerName, lc);
+            }
+            lc.setLevel(Level.toLevel(level));
+        } else {
+            config.getRootLogger().setLevel(Level.toLevel(level));
+        }
+
+        // This causes all Loggers to refetch information from their LoggerConfig.
+        context.updateLoggers();
+
+        AuditLog.user(params.getClientIp(), params.getUser())
+                .withParam("name", loggerName)
+                .withParam("level", level)
+                .updated("Log level");
+
+        ResponseHelper.writeResponse(params, JSONHelper.createJSONObject(loggerName, level));
+    }
+
+    private LoggerConfig getConfig(String name) {
+        LoggerContext context = (LoggerContext) LogManager.getContext(false);
+        Configuration config = context.getConfiguration();
+        for (Map.Entry<String, LoggerConfig> entry : config.getLoggers().entrySet()) {
+            if (entry.getKey().equals(name)) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Removes a logger (so custom added ones can be cleaned up without rebooting)
+     * @param params
+     */
+    public void handleDelete(ActionParameters params) throws ActionException {
+        LoggerContext context = (LoggerContext) LogManager.getContext(false);
+        Configuration config = context.getConfiguration();
+        String loggerName = params.getRequiredParam("name");
+        config.removeLogger(loggerName);
+        // This causes all Loggers to refetch information from their LoggerConfig.
+        context.updateLoggers();
+
+        AuditLog.user(params.getClientIp(), params.getUser())
+                .withParam("name", loggerName)
+                .deleted("Logger");
+
+        ResponseHelper.writeResponse(params, JSONHelper.createJSONObject(loggerName, "Removed"));
+    }
+
+    @Override
+    public void preProcess(ActionParameters params) throws ActionException {
+        if (!params.getUser().isAdmin()) {
+            throw new ActionDeniedException("Admin only");
+        }
+    }
+}

--- a/control-admin/src/test/java/fi/nls/oskari/control/admin/LoggerHandlerTest.java
+++ b/control-admin/src/test/java/fi/nls/oskari/control/admin/LoggerHandlerTest.java
@@ -3,8 +3,6 @@ package fi.nls.oskari.control.admin;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 
 public class LoggerHandlerTest {

--- a/control-admin/src/test/java/fi/nls/oskari/control/admin/LoggerHandlerTest.java
+++ b/control-admin/src/test/java/fi/nls/oskari/control/admin/LoggerHandlerTest.java
@@ -1,0 +1,32 @@
+package fi.nls.oskari.control.admin;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+
+public class LoggerHandlerTest {
+
+    @Test
+    public void testClusterMsgDelete() {
+        String loggerName = "testing";
+        LoggerHandler handler = spy(LoggerHandler.class);
+        // when getting remove msg
+        handler.handleClusterMsg(LoggerHandler.CLUSTER_CMD_REMOVE_PREFIX + loggerName);
+        // removeLogger with the logger name is called
+        Mockito.verify(handler).removeLogger(loggerName);
+    }
+
+    @Test
+    public void testClusterMsgSetLevel() {
+        String loggerName = "testing";
+        String level = "warn";
+        LoggerHandler handler = spy(LoggerHandler.class);
+        // when getting set level msg
+        handler.handleClusterMsg(LoggerHandler.CLUSTER_CMD_SET_PREFIX + loggerName + LoggerHandler.CLUSTER_CMD_SEPARATOR + level);
+        // setLevel with the correctly parsed values is called
+        Mockito.verify(handler).setLevel(loggerName, level);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <xmlunit.version>1.6</xmlunit.version>
         <h2database.version>1.4.199</h2database.version>
 
-        <log4j.version>2.13.2</log4j.version>
+        <log4j.version>2.13.3</log4j.version>
         <slf4j.version>1.7.30</slf4j.version>
         <metrics.version>4.1.0</metrics.version>
         <xom.version>1.2.5</xom.version>


### PR DESCRIPTION
Allows admin-users to make requests to server that change log levels at runtime. Makes it easier to debug on production.