### PR TITLE
Short-circuit analysis layer processing when there is none present

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/view/modifier/bundle/MapfullHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/view/modifier/bundle/MapfullHandler.java
@@ -368,7 +368,9 @@ public class MapfullHandler extends BundleHandler {
                                              final Set<String> bundleIds,
                                              final boolean useDirectURL,
                                              final boolean modifyURLs) {
-
+        if (publishedAnalysis.isEmpty()) {
+            return;
+        }
         final boolean analyseBundlePresent = bundleIds.contains(BUNDLE_ANALYSE);
         final Set<String> permissions = permissionsService.getResourcesWithGrantedPermissions(
                 AnalysisLayer.TYPE, user, PermissionType.VIEW_PUBLISHED.name());


### PR DESCRIPTION
Fixes an issue in the demo-application (and every application without analysis) where every call to GetAppSetup logs an ERROR-level message about missing analysis baselayer id. Since analysis is not included in the demo app the missing configuration is intended but produces unnecessary logging. The unnecessary logging no longer happens with this fix.

This also helps performance for most users since there was database queries being made for analysis permissions even when there is no analysis layers present.

We should isolate analysis related code to a separate Maven module that can be used when analysis is used. We also already have pluggable UserContentService and UserLayerService OskariComponents that are used to contain the special handling for user generated content layers without hardcoding. We should use those in mapfull as well.