### PR TITLE
Fix export table file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <stax-api.version>1.0-2</stax-api.version>
         <stax2-api.version>3.1.4</stax2-api.version>
         <woodstox.version>5.1.0</woodstox.version>
-        <xmlbeans.version>2.6.0</xmlbeans.version>
+        <xmlbeans.version>3.1.0</xmlbeans.version>
 
         <jackson.version>2.11.2</jackson.version>
         <jsonld-java.version>0.3</jsonld-java.version>


### PR DESCRIPTION
Apache POI is updated from 3.13 to 4.1.2. and it has new ooxml-schemas which seems to need newer xmlbeans.

"ooxml-schemas-1.4.jar for POI 4.0.0 or later, ooxml-schemas-1.3.jar for POI 3.14"

"The ooxml schemas jars are compiled with Apache XMLBeans 2.3, and so can be used at runtime with any version of XMLBeans from 3.0.0 or newer. Wherever possible though, we recommend that you use XMLBeans 3.1.0 with Apache POI, and that is the version now shipped in the binary release packages."