### PR TITLE
Check response status before trying to read image when printing

### DIFF
--- a/service-print/src/main/java/org/oskari/print/loader/CommandLoadImageFromURL.java
+++ b/service-print/src/main/java/org/oskari/print/loader/CommandLoadImageFromURL.java
@@ -43,6 +43,15 @@ public class CommandLoadImageFromURL extends CommandLoadImageBase {
         for (int i = 0; i < RETRY_COUNT; i++) {
             try {
                 HttpURLConnection conn = IOHelper.getConnection(uri, user, pass);
+                if (conn.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
+                    // short-circuit 404 as we get these a lot in the log
+                    return null;
+                }
+                if (conn.getResponseCode() != HttpURLConnection.HTTP_OK) {
+                    // Try again after sleep if not ok
+                    Thread.sleep(SLEEP_BETWEEN_RETRIES_MS);
+                    continue;
+                }
                 try (InputStream in = new BufferedInputStream(conn.getInputStream())) {
                     return ImageIO.read(in);
                 }


### PR DESCRIPTION
There's a lot of logging for 404 responses when trying to load images for print output. This should help with that a bit.