### PR TITLE
Reduce logging on common "errors"

### DIFF
--- a/service-base/src/main/java/fi/nls/oskari/util/XmlHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/XmlHelper.java
@@ -224,7 +224,7 @@ public class XmlHelper {
         try {
             transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         } catch (TransformerConfigurationException ex) {
-            LOGGER.warn("Unable to enable feature for secure processing for TransformerFactory", ex.getMessage());
+            LOGGER.debug("Unable to enable feature for secure processing for TransformerFactory", ex.getMessage());
         }
         // Empty protocol String to disable access to external resources
         try {
@@ -237,7 +237,7 @@ public class XmlHelper {
             // Fox example Xalan is providing a custom TransformerFactory which doesn't support this so having it in the
             // classpath will give you this error and getting the actual impl class name is a huge win for debugging the reason.
             // You can check which dependency brings for example Xalan to classpath by running "mvn dependency:tree"
-            LOGGER.warn("Unable to disable external DTD and stylesheets for XML parsing. Transformer class impl is",
+            LOGGER.debug("Unable to disable external DTD and stylesheets for XML parsing. Transformer class impl is",
                     transformerFactory.getClass().getCanonicalName(), ". Error was:", e.getMessage());
         }
         // Disable resolving of any kind of URIs, not sure if this is actually necessary

--- a/service-control/src/main/java/fi/nls/oskari/util/ResponseHelper.java
+++ b/service-control/src/main/java/fi/nls/oskari/util/ResponseHelper.java
@@ -35,8 +35,8 @@ public class ResponseHelper {
             }
             params.getResponse().getWriter().print(response);
         } catch (IOException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
+            LOG.info("Couldn't write answer:", e.getMessage());
+            LOG.debug(e);
         }
     }
 
@@ -69,7 +69,8 @@ public class ResponseHelper {
         try (OutputStream out = resp.getOutputStream()) {
             out.write(b, 0, len);
         } catch (IOException e) {
-            LOG.warn(e);
+            LOG.info("Couldn't write answer:", e.getMessage());
+            LOG.debug(e);
         }
     }
 
@@ -93,7 +94,8 @@ public class ResponseHelper {
         try (OutputStream out = resp.getOutputStream()) {
             baos.writeTo(out);
         } catch (IOException e) {
-            LOG.warn(e);
+            LOG.info("Couldn't write answer:", e.getMessage());
+            LOG.debug(e);
         }
     }
 
@@ -160,8 +162,8 @@ public class ResponseHelper {
             // we dont want that 
             //params.getResponse().sendError(errorCode, error.toString());
         } catch (IOException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
+            LOG.info("Couldn't write answer:", e.getMessage());
+            LOG.debug(e);
         }
     }
 


### PR DESCRIPTION
- [x] Common error messages on XML handling:
```
2020-11-19 12:57:09,060 WARN  fi.nls.oskari.util.XmlHelper - Unable to disable external DTD and stylesheets for XML parsing. Transformer class impl is org.apache.xalan.processor.TransformerFactoryImpl . Error was: Not supported: http://javax.xml.XMLConstants/property/accessExternalDTD
```
-> changed to debug level


- [x] Common error if client closes browser before getting the response for an XHR request:
```
2020-11-19 12:57:22,552 WARN  fi.nls.oskari.util.ResponseHelper -
org.eclipse.jetty.io.EofException: null
        at org.eclipse.jetty.io.ChannelEndPoint.flush(ChannelEndPoint.java:279) ~[jetty-io-9.4.31.v20200723.jar:9.4.31.v20200723]
        at org.eclipse.jetty.io.WriteFlusher.flush(WriteFlusher.java:422) ~[jetty-io-9.4.31.v20200723.jar:9.4.31.v20200723]
Caused by: java.io.IOException: Broken pipe
```
-> changed to info level with stacktrace to debug
