### PR TITLE
Analysis fixes for union and aggregate methods

### DIFF
--- a/service-map/src/main/java/fi/nls/oskari/analysis/AnalysisParser.java
+++ b/service-map/src/main/java/fi/nls/oskari/analysis/AnalysisParser.java
@@ -1430,15 +1430,15 @@ public class AnalysisParser {
         }
         return featureSet;
     }
-    public AnalysisLayer parseSwitch2UnionLayer(AnalysisLayer analysisLayer, String analyse, String filter1,
-                                               String filter2, String baseUrl, String outputFormat) {
+    public AnalysisLayer parseSwitch2UnionLayer(String analyse, String filter1, String filter2, String baseUrl,
+                                                User user, AnalysisLayer analysisLayer, String outputFormat) {
         try {
             JSONObject json = JSONHelper.createJSONObject(analyse);
             // Switch to UNION method
             json.remove(JSON_KEY_METHOD);
             json.put(JSON_KEY_METHOD, "union");
 
-            AnalysisLayer al2 = this.parseAnalysisLayer(json, filter1, filter2, baseUrl, null);
+            AnalysisLayer al2 = this.parseAnalysisLayer(json, filter1, filter2, baseUrl, user);
             // Set preused field definition
             al2.setFields(analysisLayer.getFields());
             // Aggregate results for to append to union result

--- a/service-map/src/main/java/fi/nls/oskari/map/analysis/service/TransformationService.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/analysis/service/TransformationService.java
@@ -187,6 +187,7 @@ public class TransformationService {
         List<String> geomcols = new ArrayList<String>();
         geomcols.add(ns_prefix + ":" + geometryProperty);
         geomcols.add(ns_prefix + ":geometry"); // default geometry
+        geomcols.add(ns_prefix + ":geom"); // geoserver uses geom in resultset
 
         MutableInt ncount = new MutableInt(0);
         MutableInt tcount = new MutableInt(0);

--- a/service-map/src/main/resources/fi/nls/oskari/map/analysis/domain/analysis-layer-wps-aggregate.xml
+++ b/service-map/src/main/resources/fi/nls/oskari/map/analysis/domain/analysis-layer-wps-aggregate.xml
@@ -6,7 +6,7 @@
       <ows:Identifier>features</ows:Identifier>
       <wps:Reference mimeType="application/json" xlink:href="{href}" method="POST">
            <wps:Body><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
-           <wfs:GetFeature handle="GeoTools 10.2 WFS DataStore" maxFeatures="{maxFeatures}" outputFormat="application/json" resultType="results" service="WFS"
+           <wfs:GetFeature maxFeatures="{maxFeatures}" outputFormat="application/json" resultType="results" service="WFS"
 
 version="{version}" srsName="{srsName}" {xmlns} xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml" xmlns:xlink="http://www.w3.org/1999/xlink" 
  xmlns:ows="http://www.opengis.net/ows" xmlns:wfs="http://www.opengis.net/wfs"><wfs:Query  srsName="{srsName}" typeName="{typeName}">

--- a/service-map/src/main/resources/fi/nls/oskari/map/analysis/domain/analysis-layer-wps-buffer.xml
+++ b/service-map/src/main/resources/fi/nls/oskari/map/analysis/domain/analysis-layer-wps-buffer.xml
@@ -6,7 +6,7 @@
       <ows:Identifier>features</ows:Identifier>
       <wps:Reference mimeType="text/xml; subtype=wfs-collection/1.1" xlink:href="{href}" method="POST"> 
            <wps:Body><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
-           <wfs:GetFeature handle="GeoTools 10.2 WFS DataStore" maxFeatures="{maxFeatures}" outputFormat="{outputFormat}" resultType="results" service="WFS"
+           <wfs:GetFeature maxFeatures="{maxFeatures}" outputFormat="{outputFormat}" resultType="results" service="WFS"
 
 version="{version}" srsName="{srsName}" {xmlns} xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml" xmlns:xlink="http://www.w3.org/1999/xlink" 
  xmlns:ows="http://www.opengis.net/ows" xmlns:wfs="http://www.opengis.net/wfs"><wfs:Query  srsName="{srsName}" typeName="{typeName}">

--- a/service-map/src/main/resources/fi/nls/oskari/map/analysis/domain/analysis-layer-wps-geomunion.xml
+++ b/service-map/src/main/resources/fi/nls/oskari/map/analysis/domain/analysis-layer-wps-geomunion.xml
@@ -22,7 +22,7 @@
                                     mimeType="text/xml; subtype=wfs-collection/1.1"
                                     xlink:href="{href}" method="POST">
                                     <wps:Body><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
-                                    <wfs:GetFeature handle="GeoTools 10.2 WFS DataStore" maxFeatures="{maxFeatures}" outputFormat="{outputFormat}" resultType="results" service="WFS"
+                                    <wfs:GetFeature maxFeatures="{maxFeatures}" outputFormat="{outputFormat}" resultType="results" service="WFS"
 version="{version}" srsName="{srsName}" {xmlns} xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml" xmlns:xlink="http://www.w3.org/1999/xlink" 
  xmlns:ows="http://www.opengis.net/ows" xmlns:wfs="http://www.opengis.net/wfs"><wfs:Query  srsName="{srsName}" typeName="{typeName}">
  {properties}{filter}</wfs:Query></wfs:GetFeature>]]>

--- a/service-map/src/main/resources/fi/nls/oskari/map/analysis/domain/wfs-reference.xml
+++ b/service-map/src/main/resources/fi/nls/oskari/map/analysis/domain/wfs-reference.xml
@@ -2,7 +2,7 @@
         mimeType="text/xml; subtype=wfs-collection/1.1"
         xlink:href="{href}" method="POST">
     <wps:Body><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
-                                    <wfs:GetFeature handle="GeoTools 10.2 WFS DataStore" maxFeatures="{maxFeatures}" outputFormat="{outputFormat}" resultType="results" service="WFS"
+                                    <wfs:GetFeature maxFeatures="{maxFeatures}" outputFormat="{outputFormat}" resultType="results" service="WFS"
 version="{version}" srsName="{srsName}" {xmlns} xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml" xmlns:xlink="http://www.w3.org/1999/xlink"
  xmlns:ows="http://www.opengis.net/ows" xmlns:wfs="http://www.opengis.net/wfs"><wfs:Query srsName="{srsName}" typeName="{typeName}">
  {properties}{filter}</wfs:Query></wfs:GetFeature>]]>

--- a/service-permissions/src/main/java/org/oskari/permissions/model/Resource.java
+++ b/service-permissions/src/main/java/org/oskari/permissions/model/Resource.java
@@ -83,6 +83,9 @@ public class Resource {
     }
 
     public boolean hasPermission(User user, String permissionType) {
+        if (user == null) {
+            return false;
+        }
         boolean userHasRoleWithId = getPermissions().stream()
                 .filter(p -> p.isOfType(permissionType))
                 .filter(p -> p.getExternalType() == PermissionExternalType.ROLE)


### PR DESCRIPTION
Aggregate method creates another analysis layer which didn't check user permission correctly (user==null). Added also permission service to return false for null user. Permission check is often handled in if statement which throws exception and with NPE it didn't throw correct exception. Analysis ignores many exceptions and log them on debug level.

GeoServer seems to return always features' geometry in "geom" property for resultset even endpoint service has different name for geometry. Added "geom" to geomcols to avoid parsing geometry to "normal" fields.

https://github.com/oskariorg/oskari-server/blob/master/service-map/src/main/java/fi/nls/oskari/map/analysis/service/TransformationService.java#L408
If geometry field isn't parsed correctly (not in geomcols) geomcol == "" => g.replace(geomcol, "gml:geometry") also geometry is added as textFeature (t1, t2,..). These caused invalid wfst xml which is used to store analysis data.

Removed handle="GeoTools 10.2 WFS DataStore" from GetFeatures templates. It looks like these doesn't affect to queries and version 10.2 is very old. 