### PR TITLE
Add an action route that returns the fields information for WFS layers

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/layer/GetWFSLayerFieldsHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/GetWFSLayerFieldsHandler.java
@@ -1,0 +1,73 @@
+package fi.nls.oskari.control.layer;
+
+import fi.nls.oskari.annotation.OskariActionRoute;
+import fi.nls.oskari.control.ActionException;
+import fi.nls.oskari.control.ActionParameters;
+import fi.nls.oskari.control.ActionParamsException;
+import fi.nls.oskari.control.RestActionHandler;
+import fi.nls.oskari.domain.User;
+import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.map.layer.OskariLayerService;
+import fi.nls.oskari.service.OskariComponentManager;
+import fi.nls.oskari.service.ServiceException;
+import fi.nls.oskari.service.ServiceRuntimeException;
+import fi.nls.oskari.util.ResponseHelper;
+import fi.nls.oskari.util.WFSGetLayerFields;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.oskari.permissions.PermissionService;
+
+/**
+ * An action route that returns fields information for WFS layers
+ */
+@OskariActionRoute("GetWFSLayerFields")
+public class GetWFSLayerFieldsHandler extends RestActionHandler {
+    private static final String PARAM_LAYER_ID = "layer_id";
+    private PermissionHelper permissionHelper;
+
+    @Override
+    public void init() {
+        try {
+            final OskariLayerService layerService = OskariComponentManager.getComponentOfType(OskariLayerService.class);
+            final PermissionService permissionService = OskariComponentManager.getComponentOfType(PermissionService.class);
+            permissionHelper = new PermissionHelper(layerService, permissionService);
+        } catch (Exception e) {
+            throw new ServiceRuntimeException("Exception occurred while initializing map layer service", e);
+        }
+    }
+
+    @Override
+    public void handleAction(ActionParameters params) throws ActionException {
+        final int layerId = params.getRequiredParamInt(PARAM_LAYER_ID);
+        final User user = params.getUser();
+        final OskariLayer layer = getLayer(layerId, user);
+        final JSONObject response = getLayerFields(layer);
+        ResponseHelper.writeResponse(params, response);
+    }
+
+    private JSONObject getLayerFields(OskariLayer layer) throws ActionException {
+        try {
+            JSONObject fields = WFSGetLayerFields.getLayerFields(layer);
+            JSONObject locale = getFieldsLocale(layer);
+            fields.putOpt("locale", locale);
+            return fields;
+        } catch (ServiceException ex) {
+            throw new ActionException("Error getting layer fields", ex);
+        } catch (JSONException ex) {
+            throw new ActionException("Invalid attribute locale", ex);
+        }
+    }
+
+    private JSONObject getFieldsLocale(OskariLayer layer) {
+        JSONObject data = layer.getAttributes().optJSONObject("data");
+        return data != null ? data.optJSONObject("locale") : null;
+    }
+
+    private OskariLayer getLayer(int layerId, User user) throws ActionException {
+        final OskariLayer layer = permissionHelper.getLayer(layerId, user);
+        if (!OskariLayer.TYPE_WFS.equals(layer.getType())) {
+            throw new ActionParamsException("Only WFS supported. Wrong layer type: " + layer.getType());
+        }
+        return layer;
+    }
+}

--- a/control-base/src/main/java/fi/nls/oskari/util/WFSGetLayerFields.java
+++ b/control-base/src/main/java/fi/nls/oskari/util/WFSGetLayerFields.java
@@ -1,0 +1,172 @@
+package fi.nls.oskari.util;
+
+import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.service.ServiceException;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.oskari.service.wfs3.OskariWFS3Client;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.util.*;
+
+public class WFSGetLayerFields {
+    private static final String STRING = "string";
+    private static final String NUMBER = "number";
+    private static final String BOOLEAN = "boolean";
+    private static final String UNKNOWN = "unknown";
+    private static final String ATTRIBUTES_KEY = "attributes";
+    private static final String GEOMETRY_FIELD_KEY = "geometryField";
+    private static final String CONTENT_TYPE_GEOJSON = "application/geo+json";
+    /**
+     * Return fields information for the WFS layer
+     *
+     * The result is constructed as:
+     * {
+     *     "attributes": {
+     *         "field-1": STRING,
+     *         "field-2": NUMBER,
+     *         ...
+     *         "field-n": BOOLEAN
+     *     },
+     *     "geometryField": "geometry"
+     * }
+     *
+     * The field type can be one of the following values:
+     *  - string
+     *  - number
+     *  - boolean
+     *  - unknown
+     *
+     */
+    public static JSONObject getLayerFields(OskariLayer layer) throws ServiceException {
+        return layer.getVersion().startsWith("3") ? getCollectionFields(layer) : getFeatureTypeFields(layer);
+    }
+
+    /**
+     * Return fields information for WFS 3.x layer
+     *
+     * The fields are collected by requesting 10 features from the
+     * collection and derive the attribute type from the attribute
+     * value, which is either NUMBER or STRING. If the attribute
+     * type cannot be derived from any feature, e.g. all 10 features
+     * have null values on the attribute, then the attribute will
+     * have an "unknown" type
+     *
+     */
+    private static JSONObject getCollectionFields(OskariLayer layer) throws ServiceException {
+        try {
+            final JSONArray features = getCollectionItems(layer);
+            final JSONObject attributes = getFeatureAttributes(features);
+            final JSONObject result = new JSONObject();
+            result.put(ATTRIBUTES_KEY, attributes);
+            result.put(GEOMETRY_FIELD_KEY, "geometry");
+            return result;
+        } catch (JSONException ex) {
+            throw new ServiceException("Couldn't parse collection items response", ex);
+        }
+    }
+
+    private static JSONArray getCollectionItems(OskariLayer layer) throws ServiceException, JSONException {
+        final String path = OskariWFS3Client.getItemsPath(layer.getUrl(), layer.getName());
+        final Map<String, String> queryParams = Collections.singletonMap("limit", "10");
+        final Map<String, String> headers = Collections.singletonMap("Accept", CONTENT_TYPE_GEOJSON);
+        try {
+            final HttpURLConnection conn = IOHelper.getConnection(path, layer.getUsername(), layer.getPassword(), queryParams, headers);
+            OskariWFS3Client.validateResponse(conn, CONTENT_TYPE_GEOJSON);
+            final String rawResponse = IOHelper.readString(conn.getInputStream());
+            final JSONObject response = new JSONObject(rawResponse);
+            return response.getJSONArray("features");
+        } catch (IOException ex) {
+            throw new ServiceException("Cannot connect to the layer server", ex);
+        }
+    }
+
+    private static JSONObject getFeatureAttributes(JSONArray features) throws JSONException {
+        final JSONObject attributes = new JSONObject();
+        for (int i=0; i<features.length(); i++) {
+            JSONObject feature = features.getJSONObject(i);
+            JSONObject properties = feature.getJSONObject("properties");
+            Iterator<?> propertiesKeys = properties.keys();
+            while (propertiesKeys.hasNext()) {
+                String attributeName = (String) propertiesKeys.next();
+                Object attributeValue = properties.get(attributeName);
+                String attributeType = UNKNOWN;
+                if (attributeValue instanceof String) {
+                    attributeType = STRING;
+                } else if (attributeValue instanceof Boolean) {
+                    attributeType = BOOLEAN;
+                }  else if (
+                    attributeValue instanceof Integer ||
+                    attributeValue instanceof Long ||
+                    attributeValue instanceof Float ||
+                    attributeValue instanceof Double
+                ) {
+                    attributeType = NUMBER;
+                }
+
+                // update attribute type if its not set or UNKNOWN
+                String currentAttributeType = attributes.optString(attributeName);
+                if (currentAttributeType.isEmpty() || currentAttributeType.equals(UNKNOWN)) {
+                    attributes.put(attributeName, attributeType);
+                }
+            }
+        }
+        return attributes;
+    }
+
+    /**
+     * Return fields information for WFS 1.x/2.x layer
+     *
+     * The fields are collected by parsing the DescribeFeatureType
+     * response. The xml types are converted to STRING, NUMBER,
+     * BOOLEAN and UNKNOWN to conform to the same set of types
+     * as WFS 3.x
+     *
+     */
+    private static JSONObject getFeatureTypeFields(OskariLayer layer) throws ServiceException {
+        final JSONObject response = WFSDescribeFeatureHelper.getWFSFeaturePropertyTypes(layer, String.valueOf(layer.getId()));
+        final Set<String> geometryPropertyTypes = new HashSet<>(
+            Arrays.asList(
+                "GeometryPropertyType",
+                "PointPropertyType",
+                "LinePropertyType",
+                "PolygonPropertyType",
+                "MultiPointPropertyType",
+                "MultiLinePropertyType",
+                "MultiPolygonPropertyType"
+            )
+        );
+        final Set<String> stringTypes = new HashSet<>(Arrays.asList("string", "date", "time"));
+        final Set<String> numericTypes = new HashSet<>(Arrays.asList("decimal", "int", "integer", "float", "double"));
+        final Set<String> booleanTypes = new HashSet<>(Arrays.asList("boolean"));
+        try {
+            final JSONObject propertyTypes = response.getJSONObject("propertyTypes");
+            final Iterator<?> attributeNames = propertyTypes.keys();
+            final JSONObject attributes = new JSONObject();
+            final JSONObject result = new JSONObject();
+            while (attributeNames.hasNext()) {
+                String attributeName = (String) attributeNames.next();
+                String attributeType = propertyTypes.getString(attributeName);
+                // remove xml namespace prefix if there's one
+                attributeType = attributeType.contains(":") ? attributeType.split(":")[1] : attributeType;
+                if (geometryPropertyTypes.contains(attributeType)) {
+                    result.put(GEOMETRY_FIELD_KEY, attributeName);
+                } else if (stringTypes.contains(attributeType)) {
+                    attributes.put(attributeName, STRING);
+                } else if (numericTypes.contains(attributeType)) {
+                    attributes.put(attributeName, NUMBER);
+                } else if (booleanTypes.contains(attributeType)) {
+                    attributes.put(attributeName, BOOLEAN);
+                } else {
+                    attributes.put(attributeName, UNKNOWN);
+                }
+            }
+            result.put(ATTRIBUTES_KEY, attributes);
+            return result;
+        } catch (JSONException ex) {
+            throw new ServiceException("Couldn't parse feature property types response", ex);
+        }
+    }
+}

--- a/control-base/src/test/java/fi/nls/oskari/control/layer/GetWFSLayerFieldsHandlerTest.java
+++ b/control-base/src/test/java/fi/nls/oskari/control/layer/GetWFSLayerFieldsHandlerTest.java
@@ -1,0 +1,113 @@
+package fi.nls.oskari.control.layer;
+
+import fi.nls.oskari.control.ActionException;
+import fi.nls.oskari.control.ActionParameters;
+import fi.nls.oskari.control.ActionParamsException;
+import fi.nls.oskari.domain.User;
+import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.map.layer.OskariLayerService;
+import fi.nls.oskari.map.layer.OskariLayerServiceMybatisImpl;
+import fi.nls.oskari.service.OskariComponentManager;
+import fi.nls.oskari.service.ServiceException;
+import fi.nls.oskari.util.WFSGetLayerFields;
+import fi.nls.test.control.JSONActionRouteTest;
+import fi.nls.test.util.ResourceHelper;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.oskari.permissions.PermissionService;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({GetWFSLayerFieldsHandler.class, WFSGetLayerFields.class, OskariComponentManager.class})
+public class GetWFSLayerFieldsHandlerTest extends JSONActionRouteTest {
+    private static final Integer WFS_LAYER_ID = 1;
+    private static final Integer WMS_LAYER_ID = 2;
+    private static final String PARAM_LAYER_ID = "layer_id";
+    private static final GetWFSLayerFieldsHandler handler = new GetWFSLayerFieldsHandler();
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        mockWFSGetLayerFields();
+        mockPermissionHelper();
+        handler.init();
+    }
+
+    private static void mockWFSGetLayerFields() throws JSONException, ServiceException {
+        PowerMockito.mockStatic(WFSGetLayerFields.class);
+        final JSONObject mockFields = getMockFields();
+        when(WFSGetLayerFields.getLayerFields(any())).thenReturn(mockFields);
+    }
+
+    private static JSONObject getMockFields() throws JSONException {
+        final String rawFieldsStr = "{\"attributes\": {\"test-attribute\": \"string\"}, \"geometryField\": \"geometry\"}";
+        return new JSONObject(rawFieldsStr);
+    }
+
+    private static void mockPermissionHelper() throws Exception {
+        OskariLayerService mockLayerService = mock(OskariLayerServiceMybatisImpl.class);
+        PowerMockito.mockStatic(OskariComponentManager.class);
+        when(OskariComponentManager.getComponentOfType(OskariLayerService.class)).thenReturn(mockLayerService);
+        PermissionService mockPermissionService = mock(PermissionService.class);
+        when(OskariComponentManager.getComponentOfType(PermissionService.class)).thenReturn(mockPermissionService);
+        PermissionHelper mockPermissionHelper = mock(PermissionHelper.class);
+        PowerMockito.whenNew(PermissionHelper.class).withArguments(mockLayerService, mockPermissionService).thenReturn(mockPermissionHelper);
+        when(mockPermissionHelper.getLayer(anyInt(), any(User.class))).thenAnswer(invocation -> {
+            final Integer layerId = invocation.getArgument(0);
+            if (layerId.equals(WFS_LAYER_ID)) {
+                return getMockLayer(OskariLayer.TYPE_WFS);
+            } else if (layerId.equals(WMS_LAYER_ID)) {
+                return getMockLayer(OskariLayer.TYPE_WMS);
+            } else {
+                throw new ActionParamsException("Layer not found for id: " + layerId);
+            }
+        });
+    }
+
+    private static OskariLayer getMockLayer(String layerType) throws JSONException {
+        OskariLayer wfsLayer = new OskariLayer();
+        wfsLayer.setType(layerType);
+        final String rawJsonStr = "{\"data\": {\"locale\": {\"fi\": {\"test-attribute\": \"label for fi\"}}}}";
+        final JSONObject mockLayerAttributes = new JSONObject(rawJsonStr);
+        wfsLayer.setAttributes(mockLayerAttributes);
+        return wfsLayer;
+    }
+
+    @Test
+    public void handleActionShouldReturnCorrectResponse() throws Exception {
+        final ActionParameters params = getActionParameters("1");
+        handler.handleAction(params);
+        JSONObject response = ResourceHelper.readJSONResource("GetWFSLayerFieldsHandlerTest-expected.json", this);
+        verifyResponseContent(response);
+    }
+
+    @Test(expected =  ActionException.class)
+    public void handleActionShouldThrowActionExceptionForNonWFSLayer() throws  Exception {
+        final ActionParameters params = getActionParameters("2");
+        handler.handleAction(params);
+    }
+
+    @Test(expected = ActionException.class)
+    public void handleActionShouldThrowActionExceptionForInvalidLayerId() throws Exception {
+        final ActionParameters params = getActionParameters("3");
+        handler.handleAction(params);
+    }
+
+    private ActionParameters getActionParameters(String layerId) {
+        final Map<String, String> params = new HashMap<>();
+        params.put(PARAM_LAYER_ID, layerId);
+        final ActionParameters actionParams = createActionParams(params);
+        final User mockUser = mock(User.class);
+        actionParams.setUser(mockUser);
+        return actionParams;
+    }
+}

--- a/control-base/src/test/java/fi/nls/oskari/util/WFSGetLayerFieldsTest.java
+++ b/control-base/src/test/java/fi/nls/oskari/util/WFSGetLayerFieldsTest.java
@@ -1,0 +1,101 @@
+package fi.nls.oskari.util;
+
+import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.service.ServiceException;
+import fi.nls.test.util.ResourceHelper;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.oskari.service.wfs3.OskariWFS3Client;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*"})
+@PrepareForTest({OskariWFS3Client.class, IOHelper.class, WFSDescribeFeatureHelper.class})
+public class WFSGetLayerFieldsTest {
+    private final String LAYER_NAME = "layer-name";
+    private final String LAYER_URL = "https://example.com/";
+    private final String COLLECTION_ITEMS_URL = LAYER_URL + "collections/layer-name/items";
+    private final String USERNAME = "username";
+    private final String PASSWORD = "pwd";
+
+    @Test
+    public void getLayerFieldsForWFS3Collections() throws Exception {
+        mockOskariWFS3Client();
+        mockIOHelper();
+        final OskariLayer layer = getWFSLayer("3.0.0");
+        final JSONObject fields = WFSGetLayerFields.getLayerFields(layer);
+        assertEquals(fields.getString("geometryField"), "geometry");
+        final JSONObject attributes = fields.getJSONObject("attributes");
+        assertEquals(attributes.getString("fid"), "number");
+        assertEquals(attributes.getString("attr-1"), "string");
+        assertEquals(attributes.getString("attr-2"), "number");
+        assertEquals(attributes.getString("attr-3"), "boolean");
+        assertEquals(attributes.getString("attr-4"), "unknown");
+    }
+
+    @Test
+    public void getLayerFieldsForWFSDescribeFeatureType() throws Exception {
+        OskariLayer layer = getWFSLayer("2.0.0");
+        mockWFSDescribeFeatureHelper(layer);
+        final JSONObject fields = WFSGetLayerFields.getLayerFields(layer);
+        assertEquals(fields.get("geometryField"), "geom");
+        final JSONObject attributes = fields.getJSONObject("attributes");
+        assertEquals(attributes.getString("attr-1"), "number");
+        assertEquals(attributes.getString("attr-2"), "string");
+        assertEquals(attributes.getString("attr-3"), "number");
+        assertEquals(attributes.getString("attr-4"), "string");
+        assertEquals(attributes.getString("attr-5"), "unknown");
+    }
+
+    private void mockOskariWFS3Client() {
+        PowerMockito.mockStatic(OskariWFS3Client.class);
+        when(OskariWFS3Client.getItemsPath(eq(LAYER_URL), eq(LAYER_NAME))).thenReturn(COLLECTION_ITEMS_URL);
+    }
+
+    private void mockIOHelper() throws IOException {
+        PowerMockito.mockStatic(IOHelper.class);
+        String rawResponse = ResourceHelper.readStringResource("WFSGetLayerFieldsTest-WFS3CollectionItemsResponse.json", WFSGetLayerFieldsTest.class);
+        final HttpURLConnection conn = mock(HttpURLConnection.class);
+        when(IOHelper.getConnection(eq(COLLECTION_ITEMS_URL), eq(USERNAME), eq(PASSWORD), any(Map.class), any(Map.class))).thenReturn(conn);
+        when(IOHelper.readString(eq(conn.getInputStream()))).thenReturn(rawResponse);
+    }
+
+    private void mockWFSDescribeFeatureHelper(OskariLayer layer) throws ServiceException, JSONException {
+        PowerMockito.mockStatic(WFSDescribeFeatureHelper.class);
+        final JSONObject propertyTypes = new JSONObject();
+        propertyTypes.put("attr-1", "xs:int");
+        propertyTypes.put("attr-2", "xs:string");
+        propertyTypes.put("attr-3", "xs:double");
+        propertyTypes.put("attr-4", "xs:date");
+        propertyTypes.put("attr-5", "prefix:complex");
+        propertyTypes.put("geom", "gml:GeometryPropertyType");
+        final JSONObject propertyTypesResponse = new JSONObject();
+        propertyTypesResponse.put("propertyTypes", propertyTypes);
+        when(WFSDescribeFeatureHelper.getWFSFeaturePropertyTypes(layer, String.valueOf(layer.getId()))).thenReturn(propertyTypesResponse);
+    }
+
+    private OskariLayer getWFSLayer(String version) {
+        OskariLayer layer = new OskariLayer();
+        layer.setType(OskariLayer.TYPE_WFS);
+        layer.setId(1);
+        layer.setUrl(LAYER_URL);
+        layer.setName(LAYER_NAME);
+        layer.setUsername(USERNAME);
+        layer.setPassword(PASSWORD);
+        layer.setVersion(version);
+        return layer;
+    }
+}

--- a/control-base/src/test/resources/fi/nls/oskari/control/layer/GetWFSLayerFieldsHandlerTest-expected.json
+++ b/control-base/src/test/resources/fi/nls/oskari/control/layer/GetWFSLayerFieldsHandlerTest-expected.json
@@ -1,0 +1,11 @@
+{
+    "attributes": {
+        "test-attribute": "string"
+    },
+    "geometryField": "geometry",
+    "locale": {
+        "fi": {
+            "test-attribute": "label for fi"
+        }
+    }
+}

--- a/control-base/src/test/resources/fi/nls/oskari/util/WFSGetLayerFieldsTest-WFS3CollectionItemsResponse.json
+++ b/control-base/src/test/resources/fi/nls/oskari/util/WFSGetLayerFieldsTest-WFS3CollectionItemsResponse.json
@@ -1,0 +1,41 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "id": 1,
+            "properties": {
+                "fid": 1,
+                "attr-1": "str-value",
+                "attr-2": null,
+                "attr-3": null,
+                "attr-4": null
+            },
+            "geometry": ""
+        },
+        {
+            "type": "Feature",
+            "id": 2,
+            "properties": {
+                "fid": 2,
+                "attr-1": "str-value",
+                "attr-2": 10,
+                "attr-3": true,
+                "attr-4": null
+            },
+            "geometry": ""
+        },
+        {
+            "type": "Feature",
+            "id": 1,
+            "properties": {
+                "fid": 3,
+                "attr-1": "str-value",
+                "attr-2": 20,
+                "attr-3": null,
+                "attr-4": null
+            },
+            "geometry": ""
+        }
+    ]
+}

--- a/control-base/src/test/resources/fi/nls/oskari/util/test.properties
+++ b/control-base/src/test/resources/fi/nls/oskari/util/test.properties
@@ -1,0 +1,1 @@
+oskari.locales=fi_FI,sv_SE,en_EN

--- a/service-wfs3/src/main/java/org/oskari/service/wfs3/OskariWFS3Client.java
+++ b/service-wfs3/src/main/java/org/oskari/service/wfs3/OskariWFS3Client.java
@@ -201,7 +201,7 @@ public class OskariWFS3Client {
         }
     }
 
-    private static void validateResponse(HttpURLConnection conn, String expectedContentType)
+    public static void validateResponse(HttpURLConnection conn, String expectedContentType)
             throws ServiceRuntimeException, IOException {
         if (conn.getResponseCode() != 200) {
             throw new ServiceRuntimeException("Unexpected status code " + conn.getResponseCode());
@@ -226,7 +226,7 @@ public class OskariWFS3Client {
         return path.toString();
     }
 
-    private static String getItemsPath(String endPoint, String collectionId) {
+    public static String getItemsPath(String endPoint, String collectionId) {
         return getCollectionsPath(endPoint, collectionId) + "/items";
     }
 


### PR DESCRIPTION
The result is structured as:

```
{
    "attributes": {
        "attr-1": "string",
        "attr-2": "number",
        ...
        "attr-n": "unknown",
    },
    "geometryField": "geometry",
    "locale": {
        "en": {
            "attr-1: "attr-1-en"
            ...
        },
        "fi": {
            "attr-1": "attr-1-fi"
            ...
        },
        ...
    }
}
```