### PR TITLE
Cleanup timeseries metadata after layer removal

### DIFF
--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerAdminHelper.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerAdminHelper.java
@@ -1,0 +1,42 @@
+package fi.nls.oskari.control.admin;
+
+import fi.nls.oskari.control.ActionException;
+import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class LayerAdminHelper {
+    private static final Logger LOG = LogFactory.getLogger(LayerAdminHelper.class);
+
+    protected static Set<OskariLayer> getTimeseriesReferencedLayers(int layerId, List<OskariLayer> layers) throws ActionException {
+        Set<OskariLayer> timeseriesLayers = new HashSet<>();
+        for (OskariLayer layer : layers) {
+            JSONObject options = layer.getOptions();
+            try {
+                if (options != null && options.has("timeseries")) {
+                    JSONObject timeseriesOptions = options.getJSONObject("timeseries");
+                    JSONObject timeseriesMetadata = timeseriesOptions.optJSONObject("metadata");
+                    if (timeseriesMetadata == null) {
+                        continue;
+                    }
+                    Integer metadataLayerId = timeseriesMetadata.getInt("layer");
+                    if (metadataLayerId == layerId) {
+                        LOG.debug("Found timeseries referenced layer, layerId: " + layerId);
+                        timeseriesLayers.add(layer);
+                    }
+                }
+            } catch (JSONException e) {
+                throw new ActionException("Cannot parse layer metadata options for layer: " +
+                        layer.getName() + ", id: " + layer.getId());
+            }
+        }
+        return timeseriesLayers;
+    }
+
+}

--- a/control-admin/src/test/java/fi/nls/oskari/control/admin/AbstractLayerAdminHandlerTest.java
+++ b/control-admin/src/test/java/fi/nls/oskari/control/admin/AbstractLayerAdminHandlerTest.java
@@ -1,0 +1,70 @@
+package fi.nls.oskari.control.admin;
+
+import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.map.layer.OskariLayerService;
+import fi.nls.oskari.service.DummyUserService;
+import fi.nls.oskari.service.OskariComponentManager;
+import fi.nls.oskari.util.PropertyUtil;
+import fi.nls.test.control.JSONActionRouteTest;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.oskari.permissions.PermissionService;
+import org.powermock.api.mockito.PowerMockito;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+public abstract class AbstractLayerAdminHandlerTest extends JSONActionRouteTest {
+
+    protected final static Integer WMS_LAYER_ID = 1;
+    protected final static Integer SECOND_WMS_LAYER_ID = 2;
+    protected final static Integer THIRD_WMS_LAYER_ID = 3;
+    protected final static Integer METADATA_LAYER_ID = 10;
+
+    protected static void setupMocks() throws Exception {
+        PropertyUtil.addProperty("oskari.user.service", DummyUserService.class.getCanonicalName(), true);
+        PermissionService permissionService = mock(PermissionService.class);
+        OskariLayerService mapLayerService = mock(OskariLayerService.class);
+        PowerMockito.mockStatic(OskariComponentManager.class);
+        when(OskariComponentManager.getComponentOfType(PermissionService.class)).thenReturn(permissionService);
+        when(OskariComponentManager.getComponentOfType(OskariLayerService.class)).thenReturn(mapLayerService);
+        doReturn(getTestLayers()).when(mapLayerService).findAll();
+        doNothing().when(mapLayerService).update(any());
+        doReturn(new HashSet<String>()).when(permissionService).getAdditionalPermissions();
+        doAnswer(invocation -> invocation.getArgument(0)).when(permissionService).getPermissionName(anyString(),anyString());
+    }
+
+    protected static void tearDownMocks() {
+        PropertyUtil.clearProperties();
+    }
+
+    protected static List<OskariLayer> getTestLayers() throws JSONException {
+        List<OskariLayer> layers = new ArrayList<>();
+        layers.add(createLayer(METADATA_LAYER_ID, "areas:100k", OskariLayer.TYPE_WFS, "https://test/wfs", null));
+        layers.add(createLayer(WMS_LAYER_ID, "areas:10k", OskariLayer.TYPE_WMS, "https://test/wms", METADATA_LAYER_ID));
+        layers.add(createLayer(SECOND_WMS_LAYER_ID, "areas:100k", OskariLayer.TYPE_WMS, "https://test/wms", null));
+        layers.add(createLayer(THIRD_WMS_LAYER_ID, "areas:1000k", OskariLayer.TYPE_WMS, "https://test/wms", METADATA_LAYER_ID));
+        return layers;
+    }
+
+    protected static OskariLayer createLayer(Integer wmsLayerId, String name, String layerType, String url, Integer metadataLayerId) throws JSONException {
+        OskariLayer wmsLayer = new OskariLayer();
+        wmsLayer.setId(wmsLayerId);
+        wmsLayer.setType(layerType);
+        wmsLayer.setUrl(url);
+        wmsLayer.setName(name);
+        if (metadataLayerId != null) {
+            createTimeseriesMetadata(wmsLayer, metadataLayerId);
+        }
+        return wmsLayer;
+    }
+
+    protected static void createTimeseriesMetadata(OskariLayer wmsLayer, Integer metadataLayerId) throws JSONException {
+        JSONObject metadata = new JSONObject().put("layer", metadataLayerId);
+        JSONObject timeseries = new JSONObject().put("metadata", metadata);
+        wmsLayer.setOptions(new JSONObject().put("timeseries", timeseries));
+    }
+}

--- a/control-admin/src/test/java/fi/nls/oskari/control/admin/LayerAdminHandlerTest.java
+++ b/control-admin/src/test/java/fi/nls/oskari/control/admin/LayerAdminHandlerTest.java
@@ -1,0 +1,40 @@
+package fi.nls.oskari.control.admin;
+
+import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.service.OskariComponentManager;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({OskariComponentManager.class})
+public class LayerAdminHandlerTest extends AbstractLayerAdminHandlerTest {
+
+    private static final LayerAdminHandler handler = new LayerAdminHandler();
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        setupMocks();
+        handler.init();
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        tearDownMocks();
+    }
+
+    @Test
+    public void testCleanupLayerReferences() throws Exception {
+        List<OskariLayer> layers = handler.cleanupLayerReferences(METADATA_LAYER_ID);
+        for (OskariLayer layer : layers) {
+            assertNull(layer.getOptions().optJSONObject("timeseries"));
+        }
+    }
+}

--- a/control-admin/src/test/java/fi/nls/oskari/control/admin/LayerAdminUsageCheckHandlerTest.java
+++ b/control-admin/src/test/java/fi/nls/oskari/control/admin/LayerAdminUsageCheckHandlerTest.java
@@ -4,25 +4,25 @@ import fi.nls.oskari.control.ActionException;
 import fi.nls.oskari.control.ActionParameters;
 import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.map.layer.OskariLayerService;
+import fi.nls.oskari.service.DummyUserService;
 import fi.nls.oskari.service.OskariComponentManager;
+import fi.nls.oskari.util.PropertyUtil;
 import fi.nls.test.control.JSONActionRouteTest;
 import fi.nls.test.util.ResourceHelper;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.oskari.permissions.PermissionService;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 @RunWith(PowerMockRunner.class)
@@ -32,18 +32,31 @@ public class LayerAdminUsageCheckHandlerTest extends JSONActionRouteTest {
     private final static Integer WMS_LAYER_ID = 1;
     private final static Integer SECOND_WMS_LAYER_ID = 2;
     private final static Integer THIRD_WMS_LAYER_ID = 3;
-    private final static Integer FOURTH_WMS_LAYER_ID = 4;
     private final static Integer METADATA_LAYER_ID = 10;
 
-    final private static LayerAdminUsageCheckHandler handler = new LayerAdminUsageCheckHandler();
+    final private static LayerAdminUsageCheckHandler adminUsageCheckHandler = new LayerAdminUsageCheckHandler();
+
+    final private static LayerAdminHandler adminHandler = new LayerAdminHandler();
 
     @BeforeClass
-    public static void setup() throws JSONException {
+    public static void setup() throws Exception {
+        PropertyUtil.addProperty("oskari.user.service", DummyUserService.class.getCanonicalName(), true);
+        PermissionService permissionService = mock(PermissionService.class);
         OskariLayerService mapLayerService = mock(OskariLayerService.class);
         PowerMockito.mockStatic(OskariComponentManager.class);
+        when(OskariComponentManager.getComponentOfType(PermissionService.class)).thenReturn(permissionService);
         when(OskariComponentManager.getComponentOfType(OskariLayerService.class)).thenReturn(mapLayerService);
         doReturn(getTestLayers()).when(mapLayerService).findAll();
-        handler.init();
+        doNothing().when(mapLayerService).update(any());
+        doReturn(new HashSet<String>()).when(permissionService).getAdditionalPermissions();
+        doAnswer(invocation -> invocation.getArgument(0)).when(permissionService).getPermissionName(anyString(),anyString());
+        adminUsageCheckHandler.init();
+        adminHandler.init();
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        PropertyUtil.clearProperties();
     }
 
     private static List<OskariLayer> getTestLayers() throws JSONException {
@@ -51,8 +64,7 @@ public class LayerAdminUsageCheckHandlerTest extends JSONActionRouteTest {
         layers.add(createLayer(METADATA_LAYER_ID, "areas:100k", OskariLayer.TYPE_WFS, "https://test/wfs", null));
         layers.add(createLayer(WMS_LAYER_ID, "areas:10k", OskariLayer.TYPE_WMS, "https://test/wms", METADATA_LAYER_ID));
         layers.add(createLayer(SECOND_WMS_LAYER_ID, "areas:100k", OskariLayer.TYPE_WMS, "https://test/wms", null));
-        layers.add(createLayer(THIRD_WMS_LAYER_ID, "areas:1000k", OskariLayer.TYPE_WMS, "https://test/wms", WMS_LAYER_ID));
-        layers.add(createLayer(FOURTH_WMS_LAYER_ID, "areas:10000k", OskariLayer.TYPE_WMS, "https://test/wms", METADATA_LAYER_ID));
+        layers.add(createLayer(THIRD_WMS_LAYER_ID, "areas:1000k", OskariLayer.TYPE_WMS, "https://test/wms", METADATA_LAYER_ID));
         return layers;
     }
 
@@ -78,7 +90,7 @@ public class LayerAdminUsageCheckHandlerTest extends JSONActionRouteTest {
     public void testLayerUsageCheck() throws Exception {
         Map requestParameters = getRequestParams();
         ActionParameters params = createActionParams(requestParameters, getAdminUser());
-        handler.handleAction(params);
+        adminUsageCheckHandler.handleAction(params);
         JSONObject responseJson = ResourceHelper.readJSONResource("LayerAdminUsageCheckHandlerTests-expected.json", this);
         verifyResponseContent(responseJson);
     }
@@ -88,10 +100,18 @@ public class LayerAdminUsageCheckHandlerTest extends JSONActionRouteTest {
         Map requestParameters = getRequestParams();
         ActionParameters params = createActionParams(requestParameters, getNotAdminUser());
         try {
-            handler.handleAction(params);
+            adminUsageCheckHandler.handleAction(params);
             fail("ActionDeniedException should have been thrown");
         } catch (ActionException e) {
             assertEquals("Admin only", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testCleanupLayerReferences() throws Exception {
+        List<OskariLayer> layers = adminHandler.cleanupLayerReferences(METADATA_LAYER_ID);
+        for (OskariLayer layer : layers) {
+            assertNull(layer.getOptions().optJSONObject("timeseries"));
         }
     }
 

--- a/control-admin/src/test/java/fi/nls/oskari/control/admin/LayerAdminUsageCheckHandlerTest.java
+++ b/control-admin/src/test/java/fi/nls/oskari/control/admin/LayerAdminUsageCheckHandlerTest.java
@@ -2,95 +2,42 @@ package fi.nls.oskari.control.admin;
 
 import fi.nls.oskari.control.ActionException;
 import fi.nls.oskari.control.ActionParameters;
-import fi.nls.oskari.domain.map.OskariLayer;
-import fi.nls.oskari.map.layer.OskariLayerService;
-import fi.nls.oskari.service.DummyUserService;
 import fi.nls.oskari.service.OskariComponentManager;
-import fi.nls.oskari.util.PropertyUtil;
-import fi.nls.test.control.JSONActionRouteTest;
 import fi.nls.test.util.ResourceHelper;
-import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.oskari.permissions.PermissionService;
-import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.*;
 
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({OskariComponentManager.class})
-public class LayerAdminUsageCheckHandlerTest extends JSONActionRouteTest {
+public class LayerAdminUsageCheckHandlerTest extends AbstractLayerAdminHandlerTest {
 
-    private final static Integer WMS_LAYER_ID = 1;
-    private final static Integer SECOND_WMS_LAYER_ID = 2;
-    private final static Integer THIRD_WMS_LAYER_ID = 3;
-    private final static Integer METADATA_LAYER_ID = 10;
-
-    final private static LayerAdminUsageCheckHandler adminUsageCheckHandler = new LayerAdminUsageCheckHandler();
-
-    final private static LayerAdminHandler adminHandler = new LayerAdminHandler();
+    final private static LayerAdminUsageCheckHandler handler = new LayerAdminUsageCheckHandler();
 
     @BeforeClass
     public static void setup() throws Exception {
-        PropertyUtil.addProperty("oskari.user.service", DummyUserService.class.getCanonicalName(), true);
-        PermissionService permissionService = mock(PermissionService.class);
-        OskariLayerService mapLayerService = mock(OskariLayerService.class);
-        PowerMockito.mockStatic(OskariComponentManager.class);
-        when(OskariComponentManager.getComponentOfType(PermissionService.class)).thenReturn(permissionService);
-        when(OskariComponentManager.getComponentOfType(OskariLayerService.class)).thenReturn(mapLayerService);
-        doReturn(getTestLayers()).when(mapLayerService).findAll();
-        doNothing().when(mapLayerService).update(any());
-        doReturn(new HashSet<String>()).when(permissionService).getAdditionalPermissions();
-        doAnswer(invocation -> invocation.getArgument(0)).when(permissionService).getPermissionName(anyString(),anyString());
-        adminUsageCheckHandler.init();
-        adminHandler.init();
+        setupMocks();
+        handler.init();
     }
 
     @AfterClass
     public static void tearDown() {
-        PropertyUtil.clearProperties();
-    }
-
-    private static List<OskariLayer> getTestLayers() throws JSONException {
-        List<OskariLayer> layers = new ArrayList<>();
-        layers.add(createLayer(METADATA_LAYER_ID, "areas:100k", OskariLayer.TYPE_WFS, "https://test/wfs", null));
-        layers.add(createLayer(WMS_LAYER_ID, "areas:10k", OskariLayer.TYPE_WMS, "https://test/wms", METADATA_LAYER_ID));
-        layers.add(createLayer(SECOND_WMS_LAYER_ID, "areas:100k", OskariLayer.TYPE_WMS, "https://test/wms", null));
-        layers.add(createLayer(THIRD_WMS_LAYER_ID, "areas:1000k", OskariLayer.TYPE_WMS, "https://test/wms", METADATA_LAYER_ID));
-        return layers;
-    }
-
-    private static OskariLayer createLayer(Integer wmsLayerId, String name, String layerType, String url, Integer metadataLayerId) throws JSONException {
-        OskariLayer wmsLayer = new OskariLayer();
-        wmsLayer.setId(wmsLayerId);
-        wmsLayer.setType(layerType);
-        wmsLayer.setUrl(url);
-        wmsLayer.setName(name);
-        if (metadataLayerId != null) {
-            createTimeseriesMetadata(wmsLayer, metadataLayerId);
-        }
-        return wmsLayer;
-    }
-
-    private static void createTimeseriesMetadata(OskariLayer wmsLayer, Integer metadataLayerId) throws JSONException {
-        JSONObject metadata = new JSONObject().put("layer", metadataLayerId);
-        JSONObject timeseries = new JSONObject().put("metadata", metadata);
-        wmsLayer.setOptions(new JSONObject().put("timeseries", timeseries));
+        tearDownMocks();
     }
 
     @Test
     public void testLayerUsageCheck() throws Exception {
         Map requestParameters = getRequestParams();
         ActionParameters params = createActionParams(requestParameters, getAdminUser());
-        adminUsageCheckHandler.handleAction(params);
+        handler.handleAction(params);
         JSONObject responseJson = ResourceHelper.readJSONResource("LayerAdminUsageCheckHandlerTests-expected.json", this);
         verifyResponseContent(responseJson);
     }
@@ -100,18 +47,10 @@ public class LayerAdminUsageCheckHandlerTest extends JSONActionRouteTest {
         Map requestParameters = getRequestParams();
         ActionParameters params = createActionParams(requestParameters, getNotAdminUser());
         try {
-            adminUsageCheckHandler.handleAction(params);
+            handler.handleAction(params);
             fail("ActionDeniedException should have been thrown");
         } catch (ActionException e) {
             assertEquals("Admin only", e.getMessage());
-        }
-    }
-
-    @Test
-    public void testCleanupLayerReferences() throws Exception {
-        List<OskariLayer> layers = adminHandler.cleanupLayerReferences(METADATA_LAYER_ID);
-        for (OskariLayer layer : layers) {
-            assertNull(layer.getOptions().optJSONObject("timeseries"));
         }
     }
 

--- a/control-admin/src/test/resources/fi/nls/oskari/control/admin/LayerAdminUsageCheckHandlerTests-expected.json
+++ b/control-admin/src/test/resources/fi/nls/oskari/control/admin/LayerAdminUsageCheckHandlerTests-expected.json
@@ -1,3 +1,3 @@
 {
-  "timeseries": [1,4]
+  "timeseries": [1,3]
 }


### PR DESCRIPTION
Cleanup referenced layers metadata after layer removal.
Refactor layer metadata handling to be done in one place with Helper-class.
Create own test class for Layer Admin tests.
Refactor existing Layer Admin Usage tests to use a common base class with Layer Admin tests.