### PR TITLE
Include times only when we have timeseries-layer

### DIFF
--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWMS.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWMS.java
@@ -130,12 +130,26 @@ public class LayerJSONFormatterWMS extends LayerJSONFormatter {
         // copy time from capabilities to attributes
         // timedata is merged into attributes  (times:{start:,end:,interval:}  or times: []
         // only reason for this is that admin can see the values offered by service
-        if(capabilities.has(KEY_TIMES)) {
+        if(capabilities.has(KEY_TIMES) && isTimeseriesLayer(layer)) {
             JSONHelper.putValue(layerJson, KEY_ATTRIBUTES, JSONHelper.merge(
                     JSONHelper.getJSONObject(layerJson, KEY_ATTRIBUTES),
                     JSONHelper.createJSONObject(KEY_TIMES, JSONHelper.get(capabilities, KEY_TIMES))));
         }
 
+    }
+
+    private Boolean isTimeseriesLayer(final OskariLayer layer) {
+        JSONObject options = layer.getOptions();
+        if(options != null && options.has("timeseries")) {
+            JSONObject timeseriesOptions = options.optJSONObject("timeseries");
+            if(timeseriesOptions != null && timeseriesOptions.has("ui")) {
+                String ui = timeseriesOptions.optString("ui");
+                if(ui != null && ui.equals("none")) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     /**


### PR DESCRIPTION
When WMS-T layer does not have UI set, then we handle it as normal WMS-layer.

![oskari-layers](https://user-images.githubusercontent.com/2784933/102491744-52d76380-4079-11eb-80cc-d2ff0e9507b1.png)