### PR TITLE
Update GeoTools (requires JTS upgrade as well)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,8 +87,8 @@
         <jedis.version>3.3.0</jedis.version>
         <quartz-scheduler.version>2.3.2</quartz-scheduler.version>
 
-        <geotools.version>23.2</geotools.version>
-        <jts.version>1.16.1</jts.version>
+        <geotools.version>23.4</geotools.version>
+        <jts.version>1.17.0</jts.version>
         <mvt.version>3.1.0</mvt.version>
         <flexjson.version>2.0</flexjson.version>
 


### PR DESCRIPTION
Mainly to resolve issues with Shapefile parsing:
- https://osgeo-org.atlassian.net/browse/GEOT-6729
- https://osgeo-org.atlassian.net/browse/GEOT-6740

GeoTools 23.2 -> 23.4
JTS 1.16.1 -> 1.17.0