### PR TITLE
Geotools 23.2 to 24.2 (requires JTS upgrade as well 1.16.1 -> 1.17.1)

### DIFF
--- a/control-routing/pom.xml
+++ b/control-routing/pom.xml
@@ -28,6 +28,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.oskari</groupId>
             <artifactId>shared-test-resources</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -87,8 +87,8 @@
         <jedis.version>3.3.0</jedis.version>
         <quartz-scheduler.version>2.3.2</quartz-scheduler.version>
 
-        <geotools.version>23.2</geotools.version>
-        <jts.version>1.16.1</jts.version>
+        <geotools.version>23.4</geotools.version>
+        <jts.version>1.17.0</jts.version>
         <mvt.version>3.1.0</mvt.version>
         <flexjson.version>2.0</flexjson.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -87,8 +87,8 @@
         <jedis.version>3.3.0</jedis.version>
         <quartz-scheduler.version>2.3.2</quartz-scheduler.version>
 
-        <geotools.version>23.4</geotools.version>
-        <jts.version>1.17.0</jts.version>
+        <geotools.version>24.2</geotools.version>
+        <jts.version>1.17.1</jts.version>
         <mvt.version>3.1.0</mvt.version>
         <flexjson.version>2.0</flexjson.version>
 


### PR DESCRIPTION
Upgrading resolves issues with Shapefile parsing:

https://osgeo-org.atlassian.net/browse/GEOT-6729
https://osgeo-org.atlassian.net/browse/GEOT-6740

GeoTools 23.2 -> 24.2
JTS 1.16.1 -> 1.17.1

For some reason after updating control-routing requires declaration of provided servlet-api to compile.