### PR TITLE
Update dbcp, remove lambdaj

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,9 +62,8 @@
         <commons-collections.version>3.2.2</commons-collections.version>
         <commons-codec.version>1.7</commons-codec.version>
         <commons-fileupload.version>1.4</commons-fileupload.version>
-        <commons-dbcp2.version>2.0.1</commons-dbcp2.version>
+        <commons-dbcp2.version>2.8.0</commons-dbcp2.version>
 
-        <lambdaj.version>2.3.3</lambdaj.version>
         <jsoup.version>1.13.1</jsoup.version>
 
         <axiom.version>1.2.22</axiom.version>
@@ -619,11 +618,6 @@
                 <groupId>com.github.jsonld-java</groupId>
                 <artifactId>jsonld-java</artifactId>
                 <version>${jsonld-java.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.googlecode.lambdaj</groupId>
-                <artifactId>lambdaj</artifactId>
-                <version>${lambdaj.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jsoup</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -47,9 +47,9 @@
         <jdk.version>1.8</jdk.version>
         <oskari.version>${project.version}</oskari.version>
 
-        <spring.version>5.2.8.RELEASE</spring.version>
-        <spring-security.version>5.3.4.RELEASE</spring-security.version>
-        <spring.session.version>Dragonfruit-RELEASE</spring.session.version>
+        <spring.version>5.3.3</spring.version>
+        <spring-security.version>5.4.2</spring-security.version>
+        <spring.session.version>Dragonfruit-SR2</spring.session.version>
 
         <javax.servlet.version>3.1.0</javax.servlet.version>
         <javax.servlet.jsp.version>2.3.3</javax.servlet.jsp.version>
@@ -73,7 +73,7 @@
         <woodstox.version>5.1.0</woodstox.version>
         <xmlbeans.version>3.1.0</xmlbeans.version>
 
-        <jackson.version>2.11.2</jackson.version>
+        <jackson.version>2.12.1</jackson.version>
         <jsonld-java.version>0.3</jsonld-java.version>
 
         <fi.mml.capabilities.version>1.3.0</fi.mml.capabilities.version>


### PR DESCRIPTION
Continues and includes commit from #678. 

- Update commons-dbcp2 2.0.1 -> 2.8.0
- Remove com.googlecode.lambda/lambdaj as it looks like it's not used.