### PR TITLE
Update flyway

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
 
         <jetty.version>9.4.31.v20200723</jetty.version>
         <mybatis.version>3.5.5</mybatis.version>
-        <flyway.version>6.5.5</flyway.version>
+        <flyway.version>7.5.2</flyway.version>
         <postgresql.version>42.2.16</postgresql.version>
         <jedis.version>3.3.0</jedis.version>
         <quartz-scheduler.version>2.3.2</quartz-scheduler.version>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
 
         <jetty.version>9.4.31.v20200723</jetty.version>
         <mybatis.version>3.5.5</mybatis.version>
-        <flyway.version>7.5.2</flyway.version>
+        <flyway.version>6.5.7</flyway.version>
         <postgresql.version>42.2.16</postgresql.version>
         <jedis.version>3.3.0</jedis.version>
         <quartz-scheduler.version>2.3.2</quartz-scheduler.version>


### PR DESCRIPTION
The version 7 of Flyway drops support for Postgres 9.4 so just updating patch version for now.