### PR TITLE
Legends migrate options

### DIFF
--- a/content-resources/src/main/java/flyway/oskari/V2_0_9__migrate_legend_image.java
+++ b/content-resources/src/main/java/flyway/oskari/V2_0_9__migrate_legend_image.java
@@ -1,0 +1,77 @@
+package flyway.oskari;
+
+import fi.nls.oskari.util.JSONHelper;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class V2_0_9__migrate_legend_image extends BaseJavaMigration {
+
+    @Override
+    public void migrate(Context context) throws Exception {
+        Connection connection = context.getConnection();
+        List<LayerConfig> layers = getLayers(connection);
+        for (LayerConfig layer : layers) {
+            migrateLegendImages(layer);
+            updateOptions(connection, layer.layerId, layer.options);
+        }
+
+    }
+    private void migrateLegendImages (LayerConfig layer) throws JSONException {
+        String legendImage = layer.legendImage;
+        JSONArray styleList = JSONHelper.getEmptyIfNull(layer.capabilities.optJSONArray("styles"));
+        JSONObject legends = new JSONObject();
+        if (styleList == null || styleList.length() == 0) {
+            JSONHelper.putValue(legends, "legendImage", legendImage);
+        } else {
+            for (int i = 0; i < styleList.length(); i++ ) {
+                JSONObject style = styleList.getJSONObject(i);
+                // copy legend image to every style
+                JSONHelper.putValue(legends, style.getString("name"), legendImage);
+            }
+        }
+        JSONHelper.putValue(layer.options, "legends", legends);
+
+    }
+    private void updateOptions (Connection conn, int layerId, JSONObject options) throws SQLException {
+        final String sql = "UPDATE oskari_maplayer SET options=? where id=?";
+        try(PreparedStatement statement = conn.prepareStatement(sql)) {
+            statement.setString(1, options.toString());
+            statement.setInt(2, layerId);
+            statement.execute();
+        }
+    }
+    private List<LayerConfig> getLayers(Connection conn) throws SQLException {
+        List<LayerConfig> layers = new ArrayList<>();
+        // only process layers which haves legend_image (mostly wms and wmts layers)
+        final String sql = "SELECT id, legend_image, options, capabilities FROM oskari_maplayer where legend_image <> '' and legend_image is not null";
+        try(PreparedStatement statement = conn.prepareStatement(sql)) {
+            try (ResultSet rs = statement.executeQuery()) {
+                while(rs.next()) {
+                    LayerConfig layer = new LayerConfig();
+                    layer.layerId = rs.getInt("id");
+                    layer.legendImage = rs.getString("legend_image");
+                    layer.options = JSONHelper.createJSONObject(rs.getString("options"));
+                    layer.capabilities = JSONHelper.createJSONObject(rs.getString("capabilities"));
+                    layers.add(layer);
+                }
+            }
+        }
+        return layers;
+    }
+    class LayerConfig {
+        int layerId;
+        String legendImage;
+        JSONObject options;
+        JSONObject capabilities;
+    }
+}

--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerAdminHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerAdminHandler.java
@@ -308,7 +308,6 @@ public class LayerAdminHandler extends AbstractLayerAdminHandler {
                         PropertyUtil.get("oskari.native.srs", "EPSG:4326"))));
 
         ml.setStyle(getOrDefaultStr(layer.getStyle(), ml.getStyle()));
-        ml.setLegendImage(getOrDefaultStr(layer.getLegend_image(), ml.getLegendImage()));
         ml.setMetadataId(getOrDefaultStr(layer.getMetadataid(), ml.getMetadataId()));
         if (layer.getAttributes() != null) {
             ml.setAttributes(new JSONObject(layer.getAttributes()));

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/OskariLayer.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/OskariLayer.java
@@ -49,7 +49,6 @@ public class OskariLayer extends JSONLocalizedNameAndTitle implements Comparable
 	private Double minScale = -1d;
 	private Double maxScale = -1d;
 
-    private String legendImage;
     private String metadataId;
 
     private JSONObject params = new JSONObject();
@@ -225,11 +224,24 @@ public class OskariLayer extends JSONLocalizedNameAndTitle implements Comparable
 	public void setStyle(String style) {
 		this.style = style;
 	}
+
+    @Deprecated
 	public String getLegendImage() {
-		return legendImage;
+        if (!options.has("legends")) {
+            return "";
+        }
+        return JSONHelper.getJSONObject(options, "legends").optString("legendImage", "");
 	}
+    @Deprecated
 	public void setLegendImage(String legendImage) {
-		this.legendImage = legendImage;
+        JSONObject legends;
+        if (!options.has("legends")) {
+            legends = new JSONObject();
+            JSONHelper.putValue(options, "legends", legends);
+        } else {
+            legends = JSONHelper.getJSONObject(options, "legends");
+        }
+        JSONHelper.putValue(legends, "legendImage", legendImage);
 	}
 
     public int getParentId() {

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/OskariLayerServiceMybatisImpl.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/OskariLayerServiceMybatisImpl.java
@@ -99,7 +99,6 @@ public class OskariLayerServiceMybatisImpl extends OskariLayerService {
         result.setMaxScale((Double) data.get("maxscale"));
 
         // additional info
-        result.setLegendImage((String) data.get("legend_image"));
         result.setMetadataId((String) data.get("metadataid"));
 
         // map implementation parameters

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
@@ -27,13 +27,14 @@ public class LayerJSONFormatter {
     public static final String PROPERTY_AJAXURL = "oskari.ajax.url.prefix";
     public static final String KEY_ATTRIBUTE_FORCED_SRS = "forcedSRS";
     public static final String KEY_ATTRIBUTE_IGNORE_COVERAGE = "ignoreCoverage";
+    public static final String KEY_LEGENDS = "legends";
+    public static final String KEY_GLOBAL_LEGEND = "legendImage";
     public static final String KEY_TYPE = "type";
     protected static final String KEY_ID = "id";
     protected static final String KEY_NAME = "layerName"; // FIXME: name
     protected static final String KEY_LOCALIZED_NAME = "name"; // FIXME: title
     protected static final String KEY_SUBTITLE = "subtitle";
     protected static final String KEY_OPTIONS = "options";
-    protected static final String KEY_LEGENDS = "legends";
     protected static final String KEY_ADMIN = "admin";
     protected static final String KEY_DATA_PROVIDER = "orgName";
     protected static final String[] STYLE_KEYS ={"name", "title", "legend"};
@@ -218,11 +219,10 @@ public class LayerJSONFormatter {
         JSONArray styles = new JSONArray();
         Map<String, String> legends = JSONHelper.getObjectAsMap(layer.getOptions().optJSONObject(KEY_LEGENDS));
         JSONArray styleList = JSONHelper.getEmptyIfNull(layer.getCapabilities().optJSONArray(KEY_STYLES));
-        String globalLegend = layer.getLegendImage();
-        boolean hasGlobal = globalLegend != null && !globalLegend.isEmpty();
-        if (styleList.length() == 0 && hasGlobal) {
+        String globalLegend = legends.getOrDefault(KEY_GLOBAL_LEGEND, "");
+        if (styleList.length() == 0 && !globalLegend.isEmpty()) {
             styleList = new JSONArray();
-            styleList.put(createStylesJSON("default","" , globalLegend));
+            styleList.put(createStylesJSON("","" , globalLegend));
         }
         for(int i = 0; i < styleList.length(); i++) {
             JSONObject style = styleList.optJSONObject(i);
@@ -231,7 +231,7 @@ public class LayerJSONFormatter {
             String title = style.optString(KEY_STYLE_TITLE);
             if (legends.containsKey(name)) {
                 legend = legends.get(name);
-            } else if (hasGlobal) {
+            } else if (!globalLegend.isEmpty()) {
                 legend = globalLegend;
             }
             boolean secureUrl = legend.toLowerCase().startsWith("https://") || legend.startsWith("/");

--- a/service-map/src/main/java/org/oskari/maplayer/admin/LayerAdminJSONHelper.java
+++ b/service-map/src/main/java/org/oskari/maplayer/admin/LayerAdminJSONHelper.java
@@ -61,7 +61,6 @@ public class LayerAdminJSONHelper {
         layer.setMinScale(model.getMinscale());
         layer.setMaxScale(model.getMaxscale());
 
-        layer.setLegendImage(model.getLegend_image());
         layer.setMetadataId(model.getMetadataid());
         if (model.getParams() != null) {
             layer.setParams(new JSONObject(model.getParams()));
@@ -114,7 +113,6 @@ public class LayerAdminJSONHelper {
         out.setMinscale(layer.getMinScale());
         out.setMaxscale(layer.getMaxScale());
 
-        out.setLegend_image(layer.getLegendImage());
         out.setMetadataid(layer.getMetadataId());
 
         out.setParams(JSONHelper.getObjectAsMap(layer.getParams()));

--- a/service-map/src/main/java/org/oskari/maplayer/model/MapLayer.java
+++ b/service-map/src/main/java/org/oskari/maplayer/model/MapLayer.java
@@ -26,7 +26,6 @@ public class MapLayer {
     private double minscale = -1;
     private double maxscale = -1;
 
-    private String legend_image;
     private String metadataid;
     private boolean internal;
 
@@ -168,14 +167,6 @@ public class MapLayer {
 
     public void setMaxscale(double maxscale) {
         this.maxscale = maxscale;
-    }
-
-    public String getLegend_image() {
-        return legend_image;
-    }
-
-    public void setLegend_image(String legend_image) {
-        this.legend_image = legend_image;
     }
 
     public String getMetadataid() {

--- a/service-map/src/main/resources/fi/nls/oskari/map/layer/OskariLayerMapper.xml
+++ b/service-map/src/main/resources/fi/nls/oskari/map/layer/OskariLayerMapper.xml
@@ -26,7 +26,6 @@
         l.minscale,
         l.maxscale,
 
-        l.legend_image,
         l.metadataId,
 
         l.params,
@@ -82,7 +81,6 @@
         l.minscale,
         l.maxscale,
 
-        l.legend_image,
         l.metadataId,
 
         l.params,
@@ -149,7 +147,6 @@
         l.minscale,
         l.maxscale,
 
-        l.legend_image,
         l.metadataId,
 
         l.params,
@@ -205,7 +202,6 @@
         l.minscale,
         l.maxscale,
 
-        l.legend_image,
         l.metadataId,
 
         l.params,
@@ -260,7 +256,6 @@
         l.minscale,
         l.maxscale,
 
-        l.legend_image,
         l.metadataId,
 
         l.params,
@@ -313,7 +308,6 @@
         l.minscale,
         l.maxscale,
 
-        l.legend_image,
         l.metadataId,
 
         l.params,
@@ -370,7 +364,6 @@
         l.minscale,
         l.maxscale,
 
-        l.legend_image,
         l.metadataId,
 
         l.params,
@@ -419,7 +412,6 @@
         minscale = #{minScale},
         maxscale = #{maxScale},
 
-        legend_image = #{legendImage},
         metadataId = #{metadataId},
 
         params = #{params},
@@ -465,7 +457,6 @@
         minscale,
         maxscale,
 
-        legend_image,
         metadataId,
 
         params,
@@ -493,7 +484,7 @@
         capabilities_update_rate_sec)
 
         values (#{parentId},#{type},#{baseMap},#{internal},#{dataproviderId},#{name},#{url},#{locale},
-        #{opacity},#{style},#{minScale},#{maxScale},#{legendImage},#{metadataId},#{params},#{options},
+        #{opacity},#{style},#{minScale},#{maxScale},#{metadataId},#{params},#{options},
         #{attributes},#{capabilities},#{gfiXslt},#{gfiType},#{gfiContent},#{realtime},#{refreshRate},
         #{username},#{password},#{version},#{srs_name},#{created},#{updated},#{capabilitiesLastUpdated},
         #{capabilitiesUpdateRateSec})

--- a/service-map/src/test/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterTest.java
+++ b/service-map/src/test/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterTest.java
@@ -5,6 +5,7 @@ import fi.nls.oskari.service.capabilities.CapabilitiesConstants;
 import fi.nls.oskari.util.JSONHelper;
 import fi.nls.oskari.util.PropertyUtil;
 import org.json.JSONArray;
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
@@ -51,6 +52,9 @@ public class LayerJSONFormatterTest {
         }
         return "";
     }
+    private static void setGlobalLegend (OskariLayer layer) throws JSONException {
+        layer.getOptions().getJSONObject(LayerJSONFormatter.KEY_LEGENDS).put(LayerJSONFormatter.KEY_GLOBAL_LEGEND, GLOBAL_LEGEND);
+    }
 
     @Test
     public void getFixedDataUrl() {
@@ -77,7 +81,7 @@ public class LayerJSONFormatterTest {
         Assert.assertEquals("Style 2 should have legend url defined in capabilities", "http://example.com/style2", getLegend(layerJSON, "style2"));
 
 
-        layer.setLegendImage(GLOBAL_LEGEND);
+        setGlobalLegend(layer);
         layerJSON = FORMATTER.getJSON(layer, LANG, false, CRS);
         Assert.assertEquals("Style 1 should have overrided legend url", "https://mydomain.org", getLegend(layerJSON, "style1"));
         Assert.assertEquals("Style 2 should have global legend", GLOBAL_LEGEND, getLegend(layerJSON, "style2"));
@@ -85,7 +89,7 @@ public class LayerJSONFormatterTest {
         layer.setCapabilities(new JSONObject());
         layerJSON = FORMATTER.getJSON(layer, LANG, false, CRS);
         Assert.assertTrue(layerJSON.getJSONArray("styles").length() == 1);
-        Assert.assertEquals("layer should have default style with global legend", GLOBAL_LEGEND, getLegend(layerJSON, "default"));
+        Assert.assertEquals("layer should have default style with global legend", GLOBAL_LEGEND, getLegend(layerJSON, ""));
 
     }
     @Test
@@ -109,5 +113,13 @@ public class LayerJSONFormatterTest {
         Assert.assertEquals( "Proxy non-secure url with secure connection",
                 String.format(proxyLegend, "style2"),
                 getLegend(layerJSON, "style2"));
+    }
+
+    // test deprecated methods
+    @Test
+    public void legendImage() throws Exception {
+        OskariLayer layer = new OskariLayer();
+        layer.setLegendImage(GLOBAL_LEGEND);
+        Assert.assertEquals(GLOBAL_LEGEND,layer.getLegendImage());
     }
 }


### PR DESCRIPTION
Migrate legend_image to options.legends. Remove legend_image from MapLayer and legendImage from OskariLayer. Mark OskariLayer set/getLegendImage as deprecated. Old admin layer editor uses legendImage.

If layer has styles (capabilities) then legend_image url is added to every styleName (options) because it used to override all legends. Also default style (style_name) isn't set for every layer or it may differ from style in legend_image url. If layer doesn't have any style but has legend_image then url is added to options.legends.legendImage. I don't know if the naming is good (globalLegend, legendUrl, oskariLegend,..) but "default" or other keys which could be used as style name could cause unwanted behavior if capabilities/styles is added afterwards.

If layer doesn't have styles but it has legend. Legend is added to created style which earlier was named "default" changed to "" as in frontend:
https://github.com/oskariorg/oskari-frontend/blob/master/bundles/mapping/mapmodule/domain/AbstractLayer.js#L783

deprecated oskariLayer.getLegendImage() is used also in:
https://github.com/oskariorg/oskari-server/blob/develop/service-map/src/main/java/fi/nls/oskari/service/capabilities/OskariLayerCapabilitiesHelper.java#L67-L88