### PR TITLE
Add LayerAccessHandler

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/data/GetPrintHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/data/GetPrintHandler.java
@@ -105,6 +105,9 @@ public class GetPrintHandler extends AbstractWFSFeaturesHandler {
 
     public void handleAction(ActionParameters params) throws ActionException {
         PrintRequest pr = createPrintRequest(params);
+        for (PrintLayer layer : pr.getLayers()) {
+            layerAccessHandlers.forEach(handler -> handler.handle(layer.getOskariLayer(), pr.getUser()));
+        }
         switch (pr.getFormat()) {
         case PDF:
             handlePDF(pr, params);

--- a/control-base/src/main/java/fi/nls/oskari/control/feature/AbstractWFSFeaturesHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/feature/AbstractWFSFeaturesHandler.java
@@ -7,6 +7,7 @@ import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.service.OskariComponentManager;
 
 import org.oskari.permissions.PermissionService;
+import org.oskari.service.user.LayerAccessHandler;
 import org.oskari.service.user.UserLayerService;
 import org.oskari.service.util.ServiceFactory;
 import org.oskari.service.wfs.client.CachingOskariWFSClient;
@@ -28,6 +29,7 @@ public abstract class AbstractWFSFeaturesHandler extends ActionHandler {
     protected OskariFeatureClient featureClient;
     protected PermissionHelper permissionHelper;
     protected Collection<UserLayerService> userContentProcessors;
+    protected Collection<LayerAccessHandler> layerAccessHandlers;
 
     protected void setPermissionHelper(PermissionHelper permissionHelper) {
         this.permissionHelper = permissionHelper;
@@ -45,6 +47,9 @@ public abstract class AbstractWFSFeaturesHandler extends ActionHandler {
         };
         Map<String, UserLayerService> components = OskariComponentManager.getComponentsOfType(UserLayerService.class);
         this.userContentProcessors = components.values();
+
+        Map<String, LayerAccessHandler> handlerComponents = OskariComponentManager.getComponentsOfType(LayerAccessHandler.class);
+        this.layerAccessHandlers = handlerComponents.values();
     }
 
     protected OskariWFSClient createWFSClient() {

--- a/control-base/src/main/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandler.java
@@ -65,6 +65,7 @@ public class GetWFSFeaturesHandler extends AbstractWFSFeaturesHandler {
         }
 
         ReferencedEnvelope bbox = parseBbox(bboxStr, targetCRS);
+        layerAccessHandlers.forEach(handler -> handler.handle(layer, params.getUser()));
         SimpleFeatureCollection fc = getFeatures(id, layer, bbox, targetCRS, contentProcessor);
         if (fc.isEmpty()) {
             ResponseHelper.writeResponse(params, 200,

--- a/service-map/src/main/java/org/oskari/service/user/LayerAccessHandler.java
+++ b/service-map/src/main/java/org/oskari/service/user/LayerAccessHandler.java
@@ -1,0 +1,11 @@
+package org.oskari.service.user;
+
+import fi.nls.oskari.domain.User;
+import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.service.OskariComponent;
+
+public abstract class LayerAccessHandler extends OskariComponent {
+
+    public abstract void handle(OskariLayer layer, User user);
+
+}


### PR DESCRIPTION
Add new type of `OskariComponent` called `LayerAccessHandler` to handle layer access.

Currently the only method in the API `void handle(OskariLayer layer, User user);` gets called when a layer is "accessed" meaning when a data accessing request is made to the backing service via oskari-server. Right now this includes action routes `GetLayerTile` for WMTS/WMS layers, `GetWFSFeatures` for WFS/OAPIF layers, and `GetPrint` for all types of layers as `service-print` works a bit differently. There's no way for this method to change the logic (except by throwing RuntimeExceptions I guess). LayerAccessHandler isn't meant for checking or validating anything but more for logging or monitoring purposes.

The idea is to allow `server-extension`s to provide their own implementations of `LayerAccessHandler`s which will get loaded at runtime. For more discussion see: https://github.com/oskariorg/oskari-docs/issues/243