### PR TITLE
Update JUnit/Mock libs

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/layer/GetWFSLayerFieldsHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/GetWFSLayerFieldsHandler.java
@@ -27,6 +27,9 @@ public class GetWFSLayerFieldsHandler extends RestActionHandler {
 
     @Override
     public void init() {
+        if (permissionHelper != null) {
+            return;
+        }
         try {
             final OskariLayerService layerService = OskariComponentManager.getComponentOfType(OskariLayerService.class);
             final PermissionService permissionService = OskariComponentManager.getComponentOfType(PermissionService.class);
@@ -34,6 +37,10 @@ public class GetWFSLayerFieldsHandler extends RestActionHandler {
         } catch (Exception e) {
             throw new ServiceRuntimeException("Exception occurred while initializing map layer service", e);
         }
+    }
+
+    public void setPermissionHelper(PermissionHelper helper) {
+        permissionHelper = helper;
     }
 
     @Override

--- a/control-base/src/main/java/fi/nls/oskari/util/WFSDescribeFeatureHelper.java
+++ b/control-base/src/main/java/fi/nls/oskari/util/WFSDescribeFeatureHelper.java
@@ -69,6 +69,9 @@ public class WFSDescribeFeatureHelper {
      * e.g. http://tampere.navici.com/tampere_wfs_geoserver/ows?SERVICE=WFS&VERSION=1.1.0&REQUEST=DescribeFeatureType&TYPENAME=tampere_ora:KIINTEISTOT_ALUE
      */
     public static String parseDescribeFeatureUrl(String url, String version, String typename) {
+        if (url == null) {
+            return null;
+        }
 
         if (url.toLowerCase().indexOf("service=") == -1) {
             url = IOHelper.addQueryString(url, "service=WFS");

--- a/control-base/src/test/java/fi/nls/oskari/control/layer/GetWFSLayerFieldsHandlerTest.java
+++ b/control-base/src/test/java/fi/nls/oskari/control/layer/GetWFSLayerFieldsHandlerTest.java
@@ -41,7 +41,8 @@ public class GetWFSLayerFieldsHandlerTest extends JSONActionRouteTest {
     private static void mockWFSGetLayerFields() throws JSONException, ServiceException {
         PowerMockito.mockStatic(WFSGetLayerFields.class);
         final JSONObject mockFields = getMockFields();
-        when(WFSGetLayerFields.getLayerFields(any())).thenReturn(mockFields);
+        //when(WFSGetLayerFields.getLayerFields(any())).thenReturn(mockFields);
+        when(WFSGetLayerFields.getLayerFields(any())).thenAnswer(invocation -> mockFields);
     }
 
     private static JSONObject getMockFields() throws JSONException {

--- a/control-base/src/test/java/fi/nls/oskari/control/layer/GetWFSLayerFieldsHandlerTest.java
+++ b/control-base/src/test/java/fi/nls/oskari/control/layer/GetWFSLayerFieldsHandlerTest.java
@@ -5,9 +5,6 @@ import fi.nls.oskari.control.ActionParameters;
 import fi.nls.oskari.control.ActionParamsException;
 import fi.nls.oskari.domain.User;
 import fi.nls.oskari.domain.map.OskariLayer;
-import fi.nls.oskari.map.layer.OskariLayerService;
-import fi.nls.oskari.map.layer.OskariLayerServiceMybatisImpl;
-import fi.nls.oskari.service.OskariComponentManager;
 import fi.nls.oskari.service.ServiceException;
 import fi.nls.oskari.util.WFSGetLayerFields;
 import fi.nls.test.control.JSONActionRouteTest;
@@ -17,7 +14,6 @@ import org.json.JSONObject;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.oskari.permissions.PermissionService;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -28,7 +24,7 @@ import java.util.Map;
 import static org.mockito.Mockito.*;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({GetWFSLayerFieldsHandler.class, WFSGetLayerFields.class, OskariComponentManager.class})
+@PrepareForTest({GetWFSLayerFieldsHandler.class, WFSGetLayerFields.class})
 public class GetWFSLayerFieldsHandlerTest extends JSONActionRouteTest {
     private static final Integer WFS_LAYER_ID = 1;
     private static final Integer WMS_LAYER_ID = 2;
@@ -54,13 +50,7 @@ public class GetWFSLayerFieldsHandlerTest extends JSONActionRouteTest {
     }
 
     private static void mockPermissionHelper() throws Exception {
-        OskariLayerService mockLayerService = mock(OskariLayerServiceMybatisImpl.class);
-        PowerMockito.mockStatic(OskariComponentManager.class);
-        when(OskariComponentManager.getComponentOfType(OskariLayerService.class)).thenReturn(mockLayerService);
-        PermissionService mockPermissionService = mock(PermissionService.class);
-        when(OskariComponentManager.getComponentOfType(PermissionService.class)).thenReturn(mockPermissionService);
         PermissionHelper mockPermissionHelper = mock(PermissionHelper.class);
-        PowerMockito.whenNew(PermissionHelper.class).withArguments(mockLayerService, mockPermissionService).thenReturn(mockPermissionHelper);
         when(mockPermissionHelper.getLayer(anyInt(), any(User.class))).thenAnswer(invocation -> {
             final Integer layerId = invocation.getArgument(0);
             if (layerId.equals(WFS_LAYER_ID)) {
@@ -71,6 +61,7 @@ public class GetWFSLayerFieldsHandlerTest extends JSONActionRouteTest {
                 throw new ActionParamsException("Layer not found for id: " + layerId);
             }
         });
+        handler.setPermissionHelper(mockPermissionHelper);
     }
 
     private static OskariLayer getMockLayer(String layerType) throws JSONException {

--- a/pom.xml
+++ b/pom.xml
@@ -98,8 +98,8 @@
         <pdfbox.version>2.0.16</pdfbox.version>
         <hystrix.version>1.5.18</hystrix.version>
         <!-- Test deps versions -->
-        <powermock.version>2.0.0</powermock.version>
-        <junit.version>4.13.1</junit.version>
+        <powermock.version>2.0.9</powermock.version>
+        <junit.version>4.13.2</junit.version>
         <xmlunit.version>1.6</xmlunit.version>
         <h2database.version>1.4.199</h2database.version>
 
@@ -861,6 +861,11 @@
 
             <dependency>
                 <groupId>org.powermock</groupId>
+                <artifactId>powermock-core</artifactId>
+                <version>${powermock.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.powermock</groupId>
                 <artifactId>powermock-module-junit4</artifactId>
                 <version>${powermock.version}</version>
             </dependency>
@@ -960,13 +965,29 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.1</version>
                 <configuration>
-                    <!-- prevent forking java process from stealing
-                    window focus on Mac OS -->
-                    <argLine>-Djava.awt.headless=true</argLine>
-                    <!--systemPropertyVariables>
-                        <oskari.syslog.level></oskari.syslog.level>
-                    </systemPropertyVariables -->
-                    <argLine>-Doskari.syslog.level=warn</argLine>
+                    <!-- headless=true prevents forking java process from stealing window focus on Mac OS -->
+                    <!-- add-opens and illegal-access is a workaround for test/mock libraries -->
+                    <!-- syslog.level makes builds less verbose (defaults to system.out logger) -->
+                    <argLine>
+                        --add-opens java.base/java.lang=ALL-UNNAMED
+                        --add-opens java.base/java.util=ALL-UNNAMED
+                        --add-opens java.base/java.util.concurrent=ALL-UNNAMED
+                        --add-opens java.base/java.util.stream=ALL-UNNAMED
+                        --add-opens java.base/java.net=ALL-UNNAMED
+                        --add-opens java.base/java.io=ALL-UNNAMED
+                        --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED
+                        --illegal-access=warn
+                        -Djava.awt.headless=true
+                        -Doskari.syslog.level=warn</argLine>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.22.1</version>
+                <configuration>
+                    <!-- Workaround for test/mock libraries -->
+                    <argLine>--add-opens java.base/java.lang=ALL-UNNAMED --illegal-access=permit</argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jdk.version>1.8</jdk.version>
         <oskari.version>${project.version}</oskari.version>
+        <!-- Value comes from profile when needed -->
+        <module.build.config></module.build.config>
 
         <spring.version>5.3.3</spring.version>
         <spring-security.version>5.4.2</spring-security.version>
@@ -965,18 +967,11 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.1</version>
                 <configuration>
+                    <!-- module.build.config is a workaround for test/mock libraries on Java 11 -->
                     <!-- headless=true prevents forking java process from stealing window focus on Mac OS -->
-                    <!-- add-opens and illegal-access is a workaround for test/mock libraries -->
                     <!-- syslog.level makes builds less verbose (defaults to system.out logger) -->
                     <argLine>
-                        --add-opens java.base/java.lang=ALL-UNNAMED
-                        --add-opens java.base/java.util=ALL-UNNAMED
-                        --add-opens java.base/java.util.concurrent=ALL-UNNAMED
-                        --add-opens java.base/java.util.stream=ALL-UNNAMED
-                        --add-opens java.base/java.net=ALL-UNNAMED
-                        --add-opens java.base/java.io=ALL-UNNAMED
-                        --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED
-                        --illegal-access=warn
+                        ${module.build.config}
                         -Djava.awt.headless=true
                         -Doskari.syslog.level=warn</argLine>
                 </configuration>
@@ -1124,6 +1119,25 @@
     </pluginRepositories>
 
     <profiles>
+        <profile>
+            <id>javamodules</id>
+            <!-- required for build/mock libraries to work on Java 11 -->
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <properties>
+                <module.build.config>
+                    --add-opens java.base/java.lang=ALL-UNNAMED
+                    --add-opens java.base/java.util=ALL-UNNAMED
+                    --add-opens java.base/java.util.concurrent=ALL-UNNAMED
+                    --add-opens java.base/java.util.stream=ALL-UNNAMED
+                    --add-opens java.base/java.net=ALL-UNNAMED
+                    --add-opens java.base/java.io=ALL-UNNAMED
+                    --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED
+                    --illegal-access=warn
+                </module.build.config>
+            </properties>
+        </profile>
         <profile>
             <id>owasp-check</id>
             <build>

--- a/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
@@ -952,6 +952,9 @@ public class IOHelper {
         if (queryString == null || queryString.trim().isEmpty()) {
             return url;
         }
+        if (url == null || url.isEmpty()) {
+            return queryString;
+        }
         final StringBuilder urlBuilder = new StringBuilder(url);
         char lastChar = urlBuilder.charAt(urlBuilder.length()-1);
         if (!url.contains("?")) {


### PR DESCRIPTION
And try solving compiling with Java 11 update 5+. Mocking doesn't seem to work properly with later Java versions.

The mock in `GetWFSLayerFieldsHandlerTest` for `WFSGetLayerFields.getLayerFields(layer);` still tries to get stuff online instead of returning the mock object and to make it worse it works "sometimes" or most of the times especially on Java 11 update 3 or lower. 