### PR TITLE
Wfs attributes data

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/layer/GetWFSDescribeFeatureHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/GetWFSDescribeFeatureHandler.java
@@ -22,6 +22,8 @@ import org.oskari.service.util.ServiceFactory;
 
 /**
  * Get WMS capabilites and return JSON
+ * @deprecated As of release 2.3.0, use fi.nls.oskari.control.layer.GetWFSLayerFields action route instead for WFS layers
+ * For Analysis, Myplaces and Userlayer use values returned from GetXXLayers action route (JSONFormatter handles)
  */
 @OskariActionRoute("GetWFSDescribeFeature")
 public class GetWFSDescribeFeatureHandler extends ActionHandler {

--- a/control-base/src/main/java/fi/nls/oskari/control/layer/GetWFSLayerFieldsHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/GetWFSLayerFieldsHandler.java
@@ -11,8 +11,10 @@ import fi.nls.oskari.map.layer.OskariLayerService;
 import fi.nls.oskari.service.OskariComponentManager;
 import fi.nls.oskari.service.ServiceException;
 import fi.nls.oskari.service.ServiceRuntimeException;
+import fi.nls.oskari.util.JSONHelper;
 import fi.nls.oskari.util.ResponseHelper;
 import fi.nls.oskari.util.WFSGetLayerFields;
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.oskari.permissions.PermissionService;
@@ -50,6 +52,7 @@ public class GetWFSLayerFieldsHandler extends RestActionHandler {
             JSONObject fields = WFSGetLayerFields.getLayerFields(layer);
             JSONObject locale = getFieldsLocale(layer);
             fields.putOpt("locale", locale);
+            fields.putOpt("filter", getFieldsFilter(layer));
             return fields;
         } catch (ServiceException ex) {
             throw new ActionException("Error getting layer fields", ex);
@@ -61,6 +64,23 @@ public class GetWFSLayerFieldsHandler extends RestActionHandler {
     private JSONObject getFieldsLocale(OskariLayer layer) {
         JSONObject data = layer.getAttributes().optJSONObject("data");
         return data != null ? data.optJSONObject("locale") : null;
+    }
+    private JSONObject getFieldsFilter(OskariLayer layer) {
+        JSONObject data = layer.getAttributes().optJSONObject("data");
+        if(data == null) {
+            return null;
+        }
+        Object filterObj = data.opt("filter");
+        if (filterObj == null) {
+            return null;
+        }
+        if (filterObj instanceof JSONArray) {
+            return JSONHelper.createJSONObject("default", (JSONArray) filterObj);
+        }
+        if (filterObj instanceof JSONObject) {
+            return (JSONObject) filterObj;
+        }
+        return null;
     }
 
     private OskariLayer getLayer(int layerId, User user) throws ActionException {

--- a/control-base/src/main/java/fi/nls/oskari/util/WFSDescribeFeatureHelper.java
+++ b/control-base/src/main/java/fi/nls/oskari/util/WFSDescribeFeatureHelper.java
@@ -5,7 +5,6 @@ import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.map.analysis.service.AnalysisDataService;
 import fi.nls.oskari.service.ServiceException;
-import fi.nls.oskari.util.IOHelper;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -13,10 +12,8 @@ import org.json.XML;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.List;
 
 /**
  * Moved WFSDescribeFeature response parsing code from
@@ -42,29 +39,13 @@ public class WFSDescribeFeatureHelper {
 
     private final static String ENCODE_ATTRIBUTE = "encoding=\"";
 
-    private static final List<String> NUMERIC_FIELD_TYPES = Arrays.asList("double",
-            "byte",
-            "decimal",
-            "int",
-            "integer",
-            "long",
-            "negativeInteger",
-            "nonNegativeInteger",
-            "nonPositiveInteger",
-            "positiveInteger",
-            "short",
-            "unsignedLong",
-            "unsignedInt",
-            "unsignedShort",
-            "unsignedByte"
-    );
+
 
     /**
      *  Parses DescribeFeatureType url request for WFS request
      * @param url  Wfs service Url
      * @param version  Wfs service version
-     * @param xmlns  Feature type namespace
-     * @param featureTypeName  Feature type name
+     * @param typename  Feature type name
      * @return Wfs request url
      * e.g. http://tampere.navici.com/tampere_wfs_geoserver/ows?SERVICE=WFS&VERSION=1.1.0&REQUEST=DescribeFeatureType&TYPENAME=tampere_ora:KIINTEISTOT_ALUE
      */
@@ -157,20 +138,6 @@ public class WFSDescribeFeatureHelper {
     }
 
     /**
-     * Check is WFS property (field) type is numeric
-     * @param wfsTypeValue
-     * @return true, if numeric
-     */
-    private static boolean isNumericField(String wfsTypeValue) {
-        boolean numericValue = false;
-        String typeval = stripNamespace(wfsTypeValue);
-        if (NUMERIC_FIELD_TYPES.contains(typeval)) {
-            numericValue = true;
-        }
-        return numericValue;
-    }
-
-    /**
      * Strip namspace out of featureTypeName, if exists
      * @param tag featureTypeName
      * @return
@@ -194,7 +161,9 @@ public class WFSDescribeFeatureHelper {
      *
      * @param sid  Analysis layer id
      * @return analysis property names and types"
+     * @deprecated only GetWFSDescribeFeature needs this
      */
+    @Deprecated
     public static JSONObject getAnalysisFeaturePropertyTypes(String sid) {
         JSONObject propertyTypes = new JSONObject(); // Field names and types
         JSONObject js_out = new JSONObject();
@@ -270,8 +239,7 @@ public class WFSDescribeFeatureHelper {
     /**
      * Pick up property names and types out of DescribeFeatureType response
      * works with WFS version 1.0.0 and 1.1.0
-     * WFSlayerconfiguration ala Oskari
-     * @param lc WFSlayerconfiguration ala Oskari
+     * @param layer
      * @param layer_id
      * @return
      * @throws ServiceException
@@ -317,9 +285,8 @@ public class WFSDescribeFeatureHelper {
                 if (props_js.get(i) instanceof JSONObject) {
                     JSONObject prop_js = props_js.getJSONObject(i);
                     if (prop_js.has(KEY_NAME) && prop_js.has(KEY_TYPE)) {
-                        String strigOrNumeric = "string";
-                        if(isNumericField(prop_js.getString(KEY_TYPE))) strigOrNumeric="numeric" ;
-                        js_props_out.put(prop_js.getString(KEY_NAME), strigOrNumeric);
+                        String type = stripNamespace(prop_js.getString(KEY_TYPE));
+                        js_props_out.put(prop_js.getString(KEY_NAME), WFSConversionHelper.getStringOrNumber(type));
                     }
                 }
             }

--- a/control-base/src/main/java/fi/nls/oskari/util/WFSGetLayerFields.java
+++ b/control-base/src/main/java/fi/nls/oskari/util/WFSGetLayerFields.java
@@ -18,6 +18,7 @@ public class WFSGetLayerFields {
     private static final String UNKNOWN = "unknown";
     private static final String ATTRIBUTES_KEY = "attributes";
     private static final String GEOMETRY_FIELD_KEY = "geometryField";
+    private static final String GEOMETRY_TYPE_KEY = "geometryType";
     private static final String CONTENT_TYPE_GEOJSON = "application/geo+json";
     /**
      * Return fields information for the WFS layer
@@ -135,7 +136,8 @@ public class WFSGetLayerFields {
                 "PolygonPropertyType",
                 "MultiPointPropertyType",
                 "MultiLinePropertyType",
-                "MultiPolygonPropertyType"
+                "MultiPolygonPropertyType",
+                "SurfacePropertyType"
             )
         );
         final Set<String> stringTypes = new HashSet<>(Arrays.asList("string", "date", "time"));
@@ -153,6 +155,7 @@ public class WFSGetLayerFields {
                 attributeType = attributeType.contains(":") ? attributeType.split(":")[1] : attributeType;
                 if (geometryPropertyTypes.contains(attributeType)) {
                     result.put(GEOMETRY_FIELD_KEY, attributeName);
+                    result.put(GEOMETRY_TYPE_KEY, attributeType);
                 } else if (stringTypes.contains(attributeType)) {
                     attributes.put(attributeName, STRING);
                 } else if (numericTypes.contains(attributeType)) {

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/wfs/WFSLayerAttributes.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/wfs/WFSLayerAttributes.java
@@ -123,7 +123,7 @@ public class WFSLayerAttributes {
 
     public List<String> getSelectedAttributes(String lang) {
         return params.getOrDefault(lang,
-                params.getOrDefault(PropertyUtil.getDefaultLanguage(), Collections.emptyList()));
+                params.getOrDefault("default", Collections.emptyList()));
     }
 
     public String getNamespaceURL() {

--- a/service-base/src/main/java/fi/nls/oskari/util/WFSConversionHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/WFSConversionHelper.java
@@ -1,0 +1,85 @@
+package fi.nls.oskari.util;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class WFSConversionHelper {
+    public static final String STRING = "string";
+    public static final String NUMBER = "number";
+    public static final String BOOLEAN = "boolean";
+    public static final String GEOMETRY = "geometry";
+    public static final String UNKNOWN = "unknown";
+    private static final Set<String> NUMBER_TYPES = new HashSet<>(
+            Arrays.asList("double",
+                "float",
+                "byte",
+                "decimal",
+                "int",
+                "integer",
+                "long",
+                "negativeInteger",
+                "nonNegativeInteger",
+                "nonPositiveInteger",
+                "positiveInteger",
+                "short",
+                "unsignedLong",
+                "unsignedInt",
+                "unsignedShort",
+                "unsignedByte"
+            )
+    );
+    private static final Set<String> GEOMETRY_TYPES = new HashSet<>(
+            Arrays.asList(
+                "GeometryPropertyType",
+                "PointPropertyType",
+                "LinePropertyType",
+                "PolygonPropertyType",
+                "MultiPointPropertyType",
+                "MultiLinePropertyType",
+                "MultiPolygonPropertyType",
+                "SurfacePropertyType"
+            )
+    );
+    private static final Set<String> STRING_TYPES = new HashSet<>(Arrays.asList("string", "date", "time"));
+    private static final Set<String> BOOLEAN_TYPES = new HashSet<>(Arrays.asList("boolean"));
+
+    public static boolean isNumeberType (String type) {
+        return NUMBER_TYPES.contains(type);
+    }
+    public static boolean isStringType (String type) {
+        return STRING_TYPES.contains(type);
+    }
+    public static boolean isBooleanType (String type) {
+        return BOOLEAN_TYPES.contains(type);
+    }
+    public static boolean isGeometryType (String type) {
+        return GEOMETRY_TYPES.contains(type);
+    }
+    public static String getSimpleType (String type) {
+        if (isGeometryType(type)) {
+            return GEOMETRY;
+        }
+        if (isStringType(type)) {
+            return STRING;
+        }
+        if (isNumeberType(type)) {
+            return NUMBER;
+        }
+        if (isBooleanType(type)) {
+            return BOOLEAN;
+        }
+        return UNKNOWN;
+    }
+    public static String getStringOrNumber (String type) {
+        return isNumeberType(type) ? NUMBER : STRING;
+
+    }
+    public static String stripNamespace(String tag) {
+        String splitted[] = tag.split(":");
+        if (splitted.length > 1) {
+            return splitted[1];
+        }
+        return splitted[0];
+    }
+}

--- a/service-map/src/main/java/fi/nls/oskari/analysis/AnalysisHelper.java
+++ b/service-map/src/main/java/fi/nls/oskari/analysis/AnalysisHelper.java
@@ -1,15 +1,14 @@
 package fi.nls.oskari.analysis;
 
 import fi.mml.map.mapwindow.util.OskariLayerWorker;
-import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.domain.map.analysis.Analysis;
 import fi.nls.oskari.domain.map.wfs.WFSLayerOptions;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
-import fi.nls.oskari.map.analysis.service.AnalysisDataService;
 import fi.nls.oskari.util.ConversionHelper;
 import fi.nls.oskari.util.JSONHelper;
 import fi.nls.oskari.util.PropertyUtil;
+import fi.nls.oskari.util.WFSConversionHelper;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.oskari.permissions.model.PermissionType;
@@ -29,8 +28,11 @@ public class AnalysisHelper {
     private static final String JSKEY_OPACITY = "opacity";
     private static final String JSKEY_MINSCALE = "minScale";
     private static final String JSKEY_MAXSCALE = "maxScale";
-    private static final String JSKEY_FIELDS = "fields";
-    private static final String JSKEY_LOCALES = "locales";
+    private static final String JSKEY_ATTRIBUTES = "attributes";
+    private static final String JSKEY_DATA = "data";
+    private static final String JSKEY_FILTER = "filter";
+    private static final String JSKEY_LOCALE = "locale";
+    private static final String JSKEY_TYPES = "types";
 
     private static final String JSKEY_BBOX = "bbox";
     private static final String JSKEY_GEOM = "geom";
@@ -40,23 +42,14 @@ public class AnalysisHelper {
     private static final String JSKEY_RIGHT = "right";
 
     private static final String JSKEY_ID = "id";
-    private static final String JSKEY_SUBTITLE = "subtitle";
-    private static final String JSKEY_ORGNAME = "orgname";
-    private static final String JSKEY_INSPIRE = "inspire";
     private static final String JSKEY_WPSURL = "wpsUrl";
     private static final String JSKEY_WPSNAME = "wpsName";
-    private static final String JSKEY_RESULT = "result";
     private static final String JSKEY_METHOD = "method";
-    private static final String JSKEY_OVERRIDE_SLD = "override_sld";
-    private static final String JSKEY_WPS_PARAMS = "wps_params";
+    private static final String JSKEY_WPS_PARAMS = "wpsParams";
     private static final String JSKEY_NO_DATA = "no_data";
     private static final String JSKEY_METHODPARAMS = "methodParams";
     private static final String LAYER_PREFIX = "analysis_";
     private static final String JSKEY_OPTIONS = "options";
-    private static final String JSKEY_STYLES = "styles";
-
-    private static final String ANALYSIS_ORGNAME = ""; // managed in front
-    private static final String ANALYSIS_INSPIRE = ""; // managed in front
 
     private static final String ANALYSIS_BASELAYER_ID = PropertyUtil.get("analysis.baselayer.id");
     private static final String PROPERTY_RENDERING_URL = PropertyUtil.getOptional("analysis.rendering.url");
@@ -128,9 +121,6 @@ public class AnalysisHelper {
 
             json.put(JSKEY_NAME, JSONHelper.getStringFromJSON(analyse_js,
                     JSKEY_NAME, "n/a"));
-            json.put(JSKEY_SUBTITLE, "");
-            json.put(JSKEY_ORGNAME, ANALYSIS_ORGNAME);
-            json.put(JSKEY_INSPIRE, ANALYSIS_INSPIRE);
 
             json.put(JSKEY_OPACITY, ConversionHelper.getInt(JSONHelper
                     .getStringFromJSON(analyse_js, JSKEY_OPACITY, "80"), 80));
@@ -139,34 +129,16 @@ public class AnalysisHelper {
                     15000000));
             json.put(JSKEY_MAXSCALE, ConversionHelper.getDouble(JSONHelper
                     .getStringFromJSON(analyse_js, JSKEY_MAXSCALE, "1"), 1));
-            json.put(JSKEY_FIELDS, getAnalyseNativeFields(al));
-            json.put(JSKEY_LOCALES, getAnalyseFields(al));
+            json.put(JSKEY_ATTRIBUTES, getAttributes(al, analyse_js, lang));
             json.put(JSKEY_WPSURL, ANALYSIS_RENDERING_URL);
             json.put(JSKEY_WPSNAME, ANALYSIS_RENDERING_ELEMENT);
             json.put(JSKEY_WPSLAYERID, wpsid);
-            json.put(JSKEY_METHOD, JSONHelper.getStringFromJSON(analyse_js,
-                    JSKEY_METHOD, "n/a"));
-            json.put(JSKEY_RESULT, "");
+
             WFSLayerOptions wfsOpts = al.getWFSLayerOptions();
             wfsOpts.injectBaseLayerOptions(baseOptions);
             json.put(JSKEY_OPTIONS, wfsOpts.getOptions());
-            if (analyse_js.has(JSKEY_METHODPARAMS)) {
-                // Put nodata value to analysis layer, if it was in analysis source layer
-                JSONObject params = JSONHelper.getJSONObject(analyse_js, JSKEY_METHODPARAMS);
-                try {
-                    if (params.has(JSKEY_NO_DATA)) {
-                        json.put(JSKEY_WPS_PARAMS, JSONHelper.createJSONObject(JSKEY_NO_DATA, params.get(JSKEY_NO_DATA)));
-                    }
 
-                } catch (Exception ex) {
-                    log.debug("Unable to get analysis layer method params", ex);
-                }
-
-            }
-
-            if (analyse_js.has(JSKEY_OVERRIDE_SLD))json.put(JSKEY_OVERRIDE_SLD, analyse_js.optString(JSKEY_OVERRIDE_SLD));
-            //
-                if (analyse_js.has(JSKEY_BBOX)) {
+            if (analyse_js.has(JSKEY_BBOX)) {
                 JSONObject bbox = JSONHelper.getJSONObject(analyse_js, JSKEY_BBOX);
                 try {
                     String bottom = Double.toString(bbox.getDouble(JSKEY_BOTTOM));
@@ -199,64 +171,39 @@ public class AnalysisHelper {
         return permissions;
     }
 
-    private static JSONArray getAnalyseFields(Analysis analysis) {
-        JSONArray fm = new JSONArray();
-        try {
-            if (analysis != null) {
-                // Fixed 1st is ID
-                fm.put("ID");
-                for (int j = 1; j < 11; j++) {
-                    String colx = analysis.getColx(j);
-                    if (colx != null && !colx.isEmpty()) {
-                        if (colx.indexOf("=") != -1) {
-                            fm.put(colx.split("=")[1]);
-                        }
-                    }
-
-                }
-                // Add geometry for filter and for highlight
-                fm.put(AnalysisDataService.ANALYSIS_GEOMETRY_FIELD);
-                fm.put("x");
-                fm.put("y");
+    private static JSONObject getAttributes (Analysis analysis, JSONObject analysisJSON, String lang) {
+        JSONObject attributes = new JSONObject();
+        JSONObject params = JSONHelper.getJSONObject(analysisJSON, JSKEY_METHODPARAMS);
+        if (params != null) {
+            Object noData = JSONHelper.get(params, JSKEY_NO_DATA);
+            if (noData != null) {
+                JSONHelper.putValue(attributes, JSKEY_WPS_PARAMS, JSONHelper.createJSONObject(JSKEY_NO_DATA, noData));
             }
-        } catch (Exception ex) {
-            log.debug("Unable to get analysis field layer json", ex);
         }
-        return fm;
-    }
+        String method = JSONHelper.optString(analysisJSON, JSKEY_METHOD);
+        JSONHelper.putValue(attributes, JSKEY_METHOD, method);
 
-    /**
-     * Get native field names
-     *
-     * @param analysis
-     * @return
-     */
-    private  static JSONArray getAnalyseNativeFields(Analysis analysis) {
-        JSONArray fm = new JSONArray();
-        try {
-            if (analysis != null) {
-                // Fixed 1st is ID
-                fm.put("__fid");
-                for (int j = 1; j < 11; j++) {
-                    String colx = analysis.getColx(j);
-                    if (colx != null && !colx.isEmpty()) {
-                        if (colx.indexOf("=") != -1) {
-                            fm.put(colx.split("=")[0]);
-                        }
-                    }
-
-                }
-                // Add geometry for filter and for highlight.
-                // ...or maybe not since Transport will add it anyway.
-                // This prevents the geometry text from polluting the GFI and feature data.
-                //fm.put(AnalysisDataService.ANALYSIS_GEOMETRY_FIELD);
-                fm.put("__centerX");
-                fm.put("__centerY");
+        JSONArray filter = new JSONArray();
+        JSONObject locale = new JSONObject();
+        JSONObject types = new JSONObject();
+        for (int j = 1; j < 11; j++) {
+            String colx = analysis.getColx(j);
+            if (colx != null && colx.contains("=")) {
+                String[] splitted = colx.split("=");
+                String field = splitted[0];
+                String name = splitted[1];
+                filter.put(field);
+                JSONHelper.putValue(locale, field, name);
+                String type = field.startsWith("n") ? WFSConversionHelper.NUMBER : WFSConversionHelper.STRING;
+                JSONHelper.putValue(types, field, type);
             }
-        } catch (Exception ex) {
-            log.debug("Unable to get analysis field layer json", ex);
         }
-        return fm;
+        JSONObject data = new JSONObject();
+        JSONHelper.put(data, JSKEY_FILTER, filter);
+        JSONHelper.putValue(data, JSKEY_TYPES, types);
+        JSONHelper.putValue(data, JSKEY_LOCALE, JSONHelper.createJSONObject(lang, locale));
+        JSONHelper.putValue(attributes, JSKEY_DATA, data);
+        return attributes;
     }
 
     public static String getAnalysisRenderingUrl() {

--- a/service-map/src/main/java/fi/nls/oskari/map/analysis/service/AnalysisDataService.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/analysis/service/AnalysisDataService.java
@@ -280,6 +280,7 @@ public class AnalysisDataService {
      *
      * @param analysis_id Key to one analysis
      * @return analysis columns and types
+     * @deprecated only GetWFSDescribeFeature needs this
      */
     public JSONObject getAnalysisNativeColumnTypes(final String analysis_id) {
         JSONObject columnTypes = new JSONObject(); // {fieldName1:type,fieldname2:type ... (type is string or numeric)

--- a/service-map/src/test/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERLAYERTest.java
+++ b/service-map/src/test/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERLAYERTest.java
@@ -1,0 +1,70 @@
+package fi.nls.oskari.map.layer.formatters;
+
+import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.domain.map.userlayer.UserLayer;
+import fi.nls.oskari.domain.map.wfs.WFSLayerAttributes;
+import fi.nls.oskari.util.PropertyUtil;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+public class LayerJSONFormatterUSERLAYERTest {
+    private final static LayerJSONFormatterUSERLAYER FORMATTER_USERLAYER = new LayerJSONFormatterUSERLAYER();
+    private final static String SRS = "EPSG:4326";
+    private final static String LANG = PropertyUtil.getDefaultLanguage();
+    private final static String NAMESPACE = "http://www.oskari.org";
+
+    private static final String FIELDS = "[{" +
+            "\"name\": \"the_geom\"," +
+            "\"type\": \"MultiPolygon\"" +
+        "}, {" +
+            "\"name\": \"NAME\"," +
+            "\"type\": \"String\"," +
+            "\"locales\": {" +
+                "\"en\": \"Name\"," +
+                "\"fi\": \"Nimi\"" +
+            "}" +
+        "}, {" +
+            "\"name\": \"CODE\"," +
+            "\"type\": \"Long\","+
+            "\"locales\": {" +
+                "\"en\": \"Code\"," +
+                "\"fi\": \"Koodi\"" +
+        "}" +
+    "}]";
+
+    @Test
+    public void parseFields() throws JSONException {
+        OskariLayer baseLayer = new OskariLayer();
+        baseLayer.getAttributes().put("namespaceURL", NAMESPACE);
+        UserLayer ulayer = new UserLayer();
+        ulayer.setFields(new JSONArray(FIELDS));
+        JSONObject layerJson = FORMATTER_USERLAYER.getJSON(baseLayer, ulayer, SRS, LANG);
+        WFSLayerAttributes attr = new WFSLayerAttributes(layerJson.getJSONObject("attributes"));
+        Assert.assertEquals( "parseFields shouldn't override baselayer attributes", NAMESPACE, attr.getNamespaceURL());
+
+        List<String> selected = attr.getSelectedAttributes();
+        Assert.assertEquals("2 attributes selected", 2, selected.size());
+        Assert.assertEquals("NAME should be first", "NAME", selected.get(0));
+        Assert.assertEquals( "CODE should be second","CODE", selected.get(1));
+
+        JSONObject en = attr.getLocalization().get();
+        Assert.assertEquals(2, en.length());
+        Assert.assertEquals("Name", en.getString("NAME"));
+        JSONObject fi = attr.getLocalization("fi").get();
+        Assert.assertEquals(2, fi.length());
+        Assert.assertEquals("Nimi", fi.getString("NAME"));
+
+        JSONObject data = attr.getAttributes().getJSONObject("data");
+        JSONObject types = data.optJSONObject("types");
+        Assert.assertEquals("string", types.getString("NAME"));
+        Assert.assertEquals("number", types.getString("CODE"));
+
+        Assert.assertEquals("the_geom", data.getString("geometryField"));
+        Assert.assertEquals("MultiPolygon", data.getString("geometryType"));
+    }
+}


### PR DESCRIPTION
Add filter and geometryType to GetWFSLayerFields response. I don't know if its better to return [names] instead of {default: [names]} if filter is array.

Move type checks and conversions to WFSConversionHelper to use them also in userlayer and analysis json formatter. 

Parse fields to attributes.data for userlayers and analysis. Add test for userlayer.

WFSLayerAttributes.getSelectedAttributes() find selected attribute with default key if language specific isn't available. I don't know if default lang should be last fallback like lang, default, defaultLang,[]