### PR TITLE
WMS layer capabilities json parsing

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/layer/GetWSCapabilitiesHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/GetWSCapabilitiesHandler.java
@@ -36,6 +36,7 @@ import static fi.nls.oskari.service.capabilities.CapabilitiesConstants.KEY_LAYER
 /**
  * Get capabilites for layer and returns JSON formatted as Oskari layers
  */
+@Deprecated
 @OskariActionRoute("GetWSCapabilities")
 public class GetWSCapabilitiesHandler extends ActionHandler {
 

--- a/service-admin/src/main/java/org/oskari/admin/LayerCapabilitiesHelper.java
+++ b/service-admin/src/main/java/org/oskari/admin/LayerCapabilitiesHelper.java
@@ -1,6 +1,5 @@
 package org.oskari.admin;
 
-import fi.mml.map.mapwindow.service.wms.WebMapService;
 import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.map.layer.OskariLayerService;
 import fi.nls.oskari.map.view.ViewService;
@@ -14,17 +13,13 @@ import fi.nls.oskari.wms.WMSCapabilitiesService;
 import fi.nls.oskari.wmts.WMTSCapabilitiesService;
 import fi.nls.oskari.wmts.domain.WMTSCapabilities;
 import org.geotools.data.wfs.WFSDataStore;
-import org.oskari.maplayer.admin.LayerAdminJSONHelper;
 import org.oskari.maplayer.model.ServiceCapabilitiesResult;
-import org.oskari.maplayer.model.ServiceCapabilitiesResultWMS;
-import org.oskari.maplayer.model.ServiceCapabilitiesResultWMTS;
 import org.oskari.service.wfs3.WFS3Service;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public class LayerCapabilitiesHelper {
 
@@ -72,8 +67,7 @@ public class LayerCapabilitiesHelper {
                 updateCapabilitiesWFS(ml);
                 break;
             case OskariLayer.TYPE_WMS:
-                WebMapService wms = wmsCapabilities.updateCapabilities(ml);
-                OskariLayerCapabilitiesHelper.setPropertiesFromCapabilitiesWMS(wms, ml, getSystemCRSs());
+                wmsCapabilities.updateLayerCapabilities(ml, getSystemCRSs());
                 break;
             case OskariLayer.TYPE_WMTS:
                 WMTSCapabilities wmts = wmtsCapabilities.updateCapabilities(ml);

--- a/service-map/src/main/java/fi/mml/map/mapwindow/service/wms/AbstractWebMapService.java
+++ b/service-map/src/main/java/fi/mml/map/mapwindow/service/wms/AbstractWebMapService.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import javax.xml.namespace.QName;
 
+@Deprecated
 public abstract class AbstractWebMapService implements WebMapService {
 
     protected static final QName XLINK_HREF = new QName("http://www.w3.org/1999/xlink", "href");

--- a/service-map/src/main/java/fi/mml/map/mapwindow/service/wms/LayerNotFoundInCapabilitiesException.java
+++ b/service-map/src/main/java/fi/mml/map/mapwindow/service/wms/LayerNotFoundInCapabilitiesException.java
@@ -1,5 +1,6 @@
 package fi.mml.map.mapwindow.service.wms;
 
+@Deprecated
 public class LayerNotFoundInCapabilitiesException extends Exception {
 
     private static final long serialVersionUID = 1L;

--- a/service-map/src/main/java/fi/mml/map/mapwindow/service/wms/WebMapService.java
+++ b/service-map/src/main/java/fi/mml/map/mapwindow/service/wms/WebMapService.java
@@ -3,6 +3,7 @@ package fi.mml.map.mapwindow.service.wms;
 import java.util.List;
 import java.util.Map;
 
+@Deprecated
 public interface WebMapService {
 
 	/**
@@ -78,5 +79,4 @@ public interface WebMapService {
      * @return String bounding box
      */
     String getGeom();
-
 }

--- a/service-map/src/main/java/fi/mml/map/mapwindow/service/wms/WebMapServiceFactory.java
+++ b/service-map/src/main/java/fi/mml/map/mapwindow/service/wms/WebMapServiceFactory.java
@@ -15,6 +15,7 @@ import fi.nls.oskari.wms.WMSCapabilities;
  * Factory for creating WMS objects
  * 
  */
+@Deprecated
 public class WebMapServiceFactory {
 
     private static final CapabilitiesCacheService CAPABILITIES_SERVICE = OskariComponentManager.getComponentOfType(CapabilitiesCacheService.class);
@@ -33,11 +34,12 @@ public class WebMapServiceFactory {
 	 * @throws WebMapServiceParseException if something goes wrong when parsing
 	 * @throws LayerNotFoundInCapabilitiesException if layer is not found in capabilities
 	 */
+	@Deprecated
 	public static WebMapService buildWebMapService(int layerId)
 	        throws ServiceException, WebMapServiceParseException, LayerNotFoundInCapabilitiesException {
         return buildWebMapService(LAYER_SERVICE.find(layerId));
     }
-
+	@Deprecated
 	public static WebMapService buildWebMapService(OskariLayer layer)
 	        throws ServiceException, WebMapServiceParseException, LayerNotFoundInCapabilitiesException {
 	    final String cacheKey = "wmsCache_" + layer.getId();
@@ -75,11 +77,11 @@ public class WebMapServiceFactory {
     public static WebMapService createFromXML(final String layerName, final String xml) throws WebMapServiceParseException, LayerNotFoundInCapabilitiesException {
         return WebMapServiceFactoryHelper.createFromXML(layerName, xml);
     }
-
+	@Deprecated
     public static void flushCache(final int layerId) {
         wmsCache.remove("wmsCache_"+layerId);
     }
-
+	@Deprecated
     public static void flushCache() {
         wmsCache.flush(true);
     }

--- a/service-map/src/main/java/fi/mml/map/mapwindow/service/wms/WebMapServiceFactoryHelper.java
+++ b/service-map/src/main/java/fi/mml/map/mapwindow/service/wms/WebMapServiceFactoryHelper.java
@@ -1,5 +1,6 @@
 package fi.mml.map.mapwindow.service.wms;
 
+@Deprecated
 public class WebMapServiceFactoryHelper {
 
     public static WebMapService createFromXML(final String layerName, final String xml)

--- a/service-map/src/main/java/fi/mml/map/mapwindow/service/wms/WebMapServiceParseException.java
+++ b/service-map/src/main/java/fi/mml/map/mapwindow/service/wms/WebMapServiceParseException.java
@@ -4,6 +4,7 @@ package fi.mml.map.mapwindow.service.wms;
  * Exception should be thrown if xml of web map service cannot be parsed
  *
  */
+@Deprecated
 public class WebMapServiceParseException extends Exception {
 
 	private static final long serialVersionUID = 1L;

--- a/service-map/src/main/java/fi/mml/map/mapwindow/service/wms/WebMapServiceV1_1_1_Impl.java
+++ b/service-map/src/main/java/fi/mml/map/mapwindow/service/wms/WebMapServiceV1_1_1_Impl.java
@@ -1,5 +1,6 @@
 package fi.mml.map.mapwindow.service.wms;
 
+import java.lang.Exception;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -10,6 +11,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import fi.mml.wms.v111.*;
 import org.apache.xmlbeans.XmlCursor;
 import org.apache.xmlbeans.XmlObject;
 
@@ -17,19 +19,10 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Polygon;
 
-import fi.mml.wms.v111.Format;
-import fi.mml.wms.v111.GetFeatureInfo;
-import fi.mml.wms.v111.Keyword;
-import fi.mml.wms.v111.LatLonBoundingBox;
-import fi.mml.wms.v111.Layer;
-import fi.mml.wms.v111.LegendURL;
-import fi.mml.wms.v111.SRS;
-import fi.mml.wms.v111.Style;
-import fi.mml.wms.v111.WMTMSCapabilitiesDocument;
-
 /**
  * 1.1.1 implementation of WMS
  */
+@Deprecated
 public class WebMapServiceV1_1_1_Impl extends AbstractWebMapService {
 
     public WebMapServiceV1_1_1_Impl(String url, String data, String layerName)
@@ -96,6 +89,7 @@ public class WebMapServiceV1_1_1_Impl extends AbstractWebMapService {
                     .map(s -> Arrays.asList(s.split(",")))
                     .orElse(Collections.emptyList());
             this.keywords = parseKeywords(layer);
+            OnlineResource serviceResource = wmtms.getWMTMSCapabilities().getService().getOnlineResource();
         } catch (Exception e) {
             throw new WebMapServiceParseException(e);
         }

--- a/service-map/src/main/java/fi/mml/map/mapwindow/service/wms/WebMapServiceV1_3_0_Impl.java
+++ b/service-map/src/main/java/fi/mml/map/mapwindow/service/wms/WebMapServiceV1_3_0_Impl.java
@@ -28,6 +28,7 @@ import fi.mml.capabilities.KeywordListDocument.KeywordList;
 /**
  * 1.3.0 implementation of WMS
  */
+@Deprecated
 public class WebMapServiceV1_3_0_Impl extends AbstractWebMapService {
 
     public WebMapServiceV1_3_0_Impl(String url, String data, String layerName)
@@ -49,7 +50,6 @@ public class WebMapServiceV1_3_0_Impl extends AbstractWebMapService {
             throws WebMapServiceParseException, LayerNotFoundInCapabilitiesException {
         try {
             WMSCapabilitiesDocument wms = WMSCapabilitiesDocument.Factory.parse(data);
-
             Layer layerCapabilities = wms.getWMSCapabilities().getCapability().getLayer();
             BoundingBox bbox = null;
             if (layerCapabilities.getBoundingBoxArray().length > 0) {

--- a/service-map/src/main/java/fi/nls/oskari/service/capabilities/CapabilitiesConstants.java
+++ b/service-map/src/main/java/fi/nls/oskari/service/capabilities/CapabilitiesConstants.java
@@ -19,6 +19,7 @@ public class CapabilitiesConstants {
     public static final String KEY_GEOM_NAME = WFSLayerCapabilities.KEY_GEOMETRYFIELD;
     public static final String KEY_NAMESPACE_URL = WFSLayerCapabilities.KEY_NAMESPACE_URL;
     public static final String KEY_LAYER_COVERAGE = "geom";
+    public static final String KEY_METADATA = "metadataUuid";
     public static final String KEY_ISQUERYABLE = "isQueryable";
     public static final String KEY_KEYWORDS = "keywords";
     public static final String KEY_CRS_URI = "crs-uri";

--- a/service-map/src/main/java/fi/nls/oskari/service/capabilities/OskariLayerCapabilitiesHelper.java
+++ b/service-map/src/main/java/fi/nls/oskari/service/capabilities/OskariLayerCapabilitiesHelper.java
@@ -24,6 +24,8 @@ import java.util.Set;
 import org.geotools.data.simple.SimpleFeatureSource;
 import org.geotools.data.wfs.WFSDataStore;
 import org.geotools.data.wfs.internal.WFSGetCapabilities;
+import org.geotools.ows.wms.Layer;
+import org.geotools.ows.wms.WMSCapabilities;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.oskari.service.wfs3.WFS3Service;
@@ -40,6 +42,7 @@ public class OskariLayerCapabilitiesHelper {
      * @throws WebMapServiceParseException if something goes wrong
      * @throws LayerNotFoundInCapabilitiesException if layer can't be found in capabilities
      */
+    @Deprecated
     public static WebMapService parseWMSCapabilities(String xml, OskariLayer ml)
             throws WebMapServiceParseException, LayerNotFoundInCapabilitiesException {
         // flush cache, otherwise only db is updated but code retains the old cached version
@@ -54,7 +57,7 @@ public class OskariLayerCapabilitiesHelper {
     public static void setPropertiesFromCapabilitiesWMS(WebMapService wms, OskariLayer ml) {
         setPropertiesFromCapabilitiesWMS(wms, ml, null);
     }
-
+    @Deprecated
     public static void setPropertiesFromCapabilitiesWMS(WebMapService wms,
             OskariLayer ml, Set<String> systemCRSs) {
         JSONObject caps = LayerJSONFormatterWMS.createCapabilitiesJSON(wms, systemCRSs);
@@ -70,7 +73,23 @@ public class OskariLayerCapabilitiesHelper {
             ml.setStyle(style);
         }
     }
+    public static void setPropertiesFromCapabilitiesWMS(WMSCapabilities capa, Layer capabilitiesLayer,
+                                                        OskariLayer ml, Set<String> systemCRSs) {
+        JSONObject caps = LayerJSONFormatterWMS.createCapabilitiesJSON(capa, capabilitiesLayer, systemCRSs);
+        ml.setCapabilities(caps);
+        ml.setCapabilitiesLastUpdated(new Date());
+    }
 
+    public static void setDefaultStyleFromCapabilitiesJSON(OskariLayer ml) {
+        JSONArray styles = ml.getCapabilities().optJSONArray(KEY_STYLES);
+        String style = "";
+        if (styles != null && styles.length() > 0) {
+            style = JSONHelper.optString(JSONHelper.getJSONObject(styles, 0), "name");
+        }
+        ml.setStyle(style);
+    }
+
+    @Deprecated
     private static String getDefaultStyle(OskariLayer ml, final JSONObject caps) {
         String style = null;
         if (ml.getId() == -1 && ml.getLegendImage() == null && caps.has(KEY_STYLES)) {
@@ -96,7 +115,6 @@ public class OskariLayerCapabilitiesHelper {
             OskariLayer ml, String crs) {
         setPropertiesFromCapabilitiesWMTS(caps, ml, Collections.emptySet());
     }
-
     public static void setPropertiesFromCapabilitiesWMTS(WMTSCapabilities caps,
             OskariLayer ml, Set<String> systemCRSs) {
         int id = ml.getId();

--- a/service-map/src/main/java/fi/nls/oskari/wfs/GetGtWFSCapabilities.java
+++ b/service-map/src/main/java/fi/nls/oskari/wfs/GetGtWFSCapabilities.java
@@ -47,6 +47,7 @@ import static fi.nls.oskari.service.capabilities.CapabilitiesConstants.KEY_FEATU
  * Methods for parsing WFS capabilities data
  * Prototype
  */
+@Deprecated
 public class GetGtWFSCapabilities {
 
     private static final Logger log = LogFactory.getLogger(GetGtWFSCapabilities.class);

--- a/service-map/src/main/java/fi/nls/oskari/wfs/WFSCapabilities.java
+++ b/service-map/src/main/java/fi/nls/oskari/wfs/WFSCapabilities.java
@@ -1,5 +1,6 @@
 package fi.nls.oskari.wfs;
 
+@Deprecated
 public class WFSCapabilities {
     String geometryfield;
     String namespaceURL;

--- a/service-map/src/main/java/fi/nls/oskari/wfs/WFSCapabilitiesService.java
+++ b/service-map/src/main/java/fi/nls/oskari/wfs/WFSCapabilitiesService.java
@@ -18,7 +18,6 @@ import org.oskari.maplayer.admin.LayerAdminJSONHelper;
 import org.oskari.maplayer.model.ServiceCapabilitiesResult;
 import org.oskari.service.wfs3.WFS3Service;
 import org.oskari.service.wfs3.model.WFS3CollectionInfo;
-import org.oskari.service.wfs3.model.WFS3Exception;
 import org.oskari.utils.common.Sets;
 
 import java.io.IOException;

--- a/service-map/src/main/java/fi/nls/oskari/wms/GetGtWMSCapabilities.java
+++ b/service-map/src/main/java/fi/nls/oskari/wms/GetGtWMSCapabilities.java
@@ -33,6 +33,7 @@ import java.util.logging.Level;
 /**
  * Methods for parsing WMS capabilities data
  */
+@Deprecated
 public class GetGtWMSCapabilities {
 
     private static final Logger log = LogFactory.getLogger(GetGtWMSCapabilities.class);

--- a/service-map/src/main/java/fi/nls/oskari/wms/WMSCapabilities.java
+++ b/service-map/src/main/java/fi/nls/oskari/wms/WMSCapabilities.java
@@ -14,6 +14,7 @@ import java.util.Map;
  * Time: 12:48
  * To change this template use File | Settings | File Templates.
  */
+@Deprecated
 public class WMSCapabilities implements WebMapService {
 
     private String capabilitiesURL = null;

--- a/service-map/src/main/java/fi/nls/oskari/wms/WMSStyle.java
+++ b/service-map/src/main/java/fi/nls/oskari/wms/WMSStyle.java
@@ -9,6 +9,7 @@ import org.json.JSONObject;
 /**
  * Class for Oskari WMS capabilities layer style
  */
+@Deprecated
 public class WMSStyle {
 
  /*   [{

--- a/service-map/src/main/java/fi/nls/oskari/wmts/WMTSCapabilitiesService.java
+++ b/service-map/src/main/java/fi/nls/oskari/wmts/WMTSCapabilitiesService.java
@@ -6,19 +6,14 @@ import fi.nls.oskari.service.ServiceException;
 import fi.nls.oskari.service.capabilities.CapabilitiesCacheService;
 import fi.nls.oskari.service.capabilities.OskariLayerCapabilities;
 import fi.nls.oskari.service.capabilities.OskariLayerCapabilitiesHelper;
-import fi.nls.oskari.util.JSONHelper;
-import fi.nls.oskari.wmts.domain.TileMatrixSet;
 import fi.nls.oskari.wmts.domain.WMTSCapabilities;
 import fi.nls.oskari.wmts.domain.WMTSCapabilitiesLayer;
-import org.json.JSONObject;
 import org.oskari.maplayer.admin.LayerAdminJSONHelper;
 import org.oskari.maplayer.model.ServiceCapabilitiesResultWMTS;
 import org.oskari.service.util.ServiceFactory;
 
 import java.util.*;
 import java.util.stream.Collectors;
-
-import static fi.nls.oskari.service.capabilities.CapabilitiesConstants.*;
 
 public class WMTSCapabilitiesService {
     private CapabilitiesCacheService capabilitiesService = ServiceFactory.getCapabilitiesCacheService();

--- a/service-map/src/test/java/fi/nls/oskari/wms/WMSCapabilitiesServiceTest.java
+++ b/service-map/src/test/java/fi/nls/oskari/wms/WMSCapabilitiesServiceTest.java
@@ -3,15 +3,14 @@ package fi.nls.oskari.wms;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
+import fi.nls.oskari.util.PropertyUtil;
 import org.geotools.ows.wms.Layer;
 import org.geotools.ows.wms.WMSCapabilities;
 import org.junit.Test;
+import org.oskari.maplayer.model.MapLayerAdminOutput;
 import org.oskari.maplayer.model.ServiceCapabilitiesResultWMS;
 
 import fi.nls.oskari.util.IOHelper;
@@ -66,6 +65,56 @@ public class WMSCapabilitiesServiceTest {
          *
          * This test case is mostly for documentary purposes of what might go wrong...
          */
+    }
+    @Test
+    public void test_capabilities_json_1_3_0() throws Exception {
+        String xml = IOHelper.readString(getClass().getResourceAsStream("capa_1_3_0.xml"));
+        String url = "http://www.test.domain/wms";
+        String version = "1.3.0";
+        String user = null;
+        String pwd = null;
+        String name = "LayerName";
+        Set<String> systemCRSs = new HashSet<>(Arrays.asList("EPSG:3067", "EPSG:4326"));
+        ServiceCapabilitiesResultWMS result = WMSCapabilitiesService.parseCapabilitiesResults(xml, url, version, user, pwd, systemCRSs);
+        MapLayerAdminOutput layer = result.getLayers().get(name);
+
+        // Test info parsed for oskari layer from capabilities xml (admin add new layer)
+        Map<String, Map<String, String>> locales = layer.getLocale();
+        for (String lang : PropertyUtil.getSupportedLanguages()) {
+            Map <String, String> locale = locales.get(lang);
+            assertEquals("LayerTitle", locale.get("name"));
+        }
+        assertEquals("first style should be selected for layer's style", "default", layer.getStyle());
+        // THIS IS ON PURPOSE: min -> max, max -> min
+        assertEquals( 4724.702381, layer.getMaxscale(), 0.1);
+        assertEquals( 18898809.523810, layer.getMinscale(), 0.1);
+
+        // Test layer capabilities json (insert new layer and update capabilities)
+        Map<String, Object> capa = layer.getCapabilities();
+        assertTrue((boolean) capa.get("isQueryable"));
+        assertEquals("AAAAA1234-1234-1234-1AAA-1A1A1A111A1", capa.get("metadataUuid"));
+        assertEquals(layer.getVersion(), capa.get("version"));
+
+        String geom = "POLYGON ((19.158138 59.756708, 19.158138 68.910986, 31.417899 68.910986, 31.417899 59.756708, 19.158138 59.756708))";
+        assertEquals(geom, capa.get("geom"));
+
+        Map <String, Object> formats = (Map <String, Object>)capa.get("formats");
+        assertEquals("text/html", formats.get("value"));
+        assertEquals(4, ((List)formats.get("available")).size());
+
+        Set <String> crs = new HashSet<>((List <String>)capa.get("srs"));
+        assertTrue("All and only system crs found from capabilities", crs.equals(systemCRSs));
+
+        List<Object> styles = (List)capa.get("styles");
+        assertEquals(1, styles.size());
+        Map<String,String> style = (Map<String,String>)styles.get(0);
+        assertEquals(layer.getStyle(), style.get("name"));
+        assertEquals("LayerName", style.get("title"));
+        assertEquals("http://www.test.domain/wms?request=GetLegendGraphic%26version=1.3.0%26format=image/png%26layer=LayerName", style.get("legend"));
+
+        List<String> times = (List) capa.get("times");
+        assertEquals(4, times.size());
+        assertEquals("1931-12-31T00:00:00.000Z", times.get(0));
     }
 
 }

--- a/service-map/src/test/resources/fi/nls/oskari/wms/capa_1_3_0.xml
+++ b/service-map/src/test/resources/fi/nls/oskari/wms/capa_1_3_0.xml
@@ -1,0 +1,205 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<WMS_Capabilities xmlns="http://www.opengis.net/wms"   xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.3.0" xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd">
+    <Service>
+        <Name>WMS</Name>
+        <Title>INSPIRE WMS service</Title>
+        <Abstract>WMS abstract</Abstract>
+        <KeywordList>
+            <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
+            <Keyword>INSPIRE</Keyword>
+            <Keyword>GEOSERVER</Keyword>
+        </KeywordList>
+        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www.test.domain/wms?"/>
+        <MaxWidth>4096</MaxWidth>
+        <MaxHeight>4096</MaxHeight>
+    </Service>
+    <Capability>
+        <Request>
+            <GetCapabilities>
+                <Format>application/vnd.ogc.wms_xml</Format>
+                <Format>text/xml</Format>
+                <DCPType>
+                    <HTTP>
+                        <Get>
+                            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www.test.domain/wms?"/>
+                        </Get>
+                    </HTTP>
+                </DCPType>
+            </GetCapabilities>
+            <GetMap>
+                <Format>image/bmp</Format>
+                <Format>image/jpeg</Format>
+                <Format>image/tiff</Format>
+                <Format>image/png</Format>
+                <Format>image/png8</Format>
+                <Format>image/png24</Format>
+                <Format>image/png32</Format>
+                <Format>image/gif</Format>
+                <Format>image/svg+xml</Format>
+                <DCPType>
+                    <HTTP>
+                        <Get>
+                            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www.test.domain/wms?"/>
+                        </Get>
+                    </HTTP>
+                </DCPType>
+            </GetMap>
+            <GetFeatureInfo>
+                <Format>application/vnd.esri.wms_raw_xml</Format>
+                <Format>application/vnd.esri.wms_featureinfo_xml</Format>
+                <Format>application/vnd.ogc.wms_xml</Format>
+                <Format>application/geojson</Format>
+                <Format>text/xml</Format>
+                <Format>text/html</Format>
+                <Format>text/plain</Format>
+                <DCPType>
+                    <HTTP>
+                        <Get>
+                            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www.test.domain/wms?"/>
+                        </Get>
+                    </HTTP>
+                </DCPType>
+            </GetFeatureInfo>
+        </Request>
+        <Exception>
+            <Format>application/vnd.ogc.se_xml</Format>
+            <Format>application/vnd.ogc.se_inimage</Format>
+            <Format>application/vnd.ogc.se_blank</Format>
+            <Format>text/xml</Format>
+            <Format>XML</Format>
+        </Exception>
+        <Layer>
+            <Title>Layers</Title>
+            <CRS>CRS:84</CRS>
+            <CRS>EPSG:4326</CRS>
+            <CRS>EPSG:3067</CRS>
+            <CRS>EPSG:4258</CRS>
+            <CRS>EPSG:3034</CRS>
+            <CRS>EPSG:3035</CRS>
+            <CRS>EPSG:3046</CRS>
+            <CRS>EPSG:3047</CRS>
+            <CRS>EPSG:3048</CRS>
+            <CRS>EPSG:3873</CRS>
+            <CRS>EPSG:3874</CRS>
+            <CRS>EPSG:3875</CRS>
+            <CRS>EPSG:3876</CRS>
+            <CRS>EPSG:3877</CRS>
+            <CRS>EPSG:3878</CRS>
+            <CRS>EPSG:3879</CRS>
+            <CRS>EPSG:3880</CRS>
+            <CRS>EPSG:3881</CRS>
+            <CRS>EPSG:3882</CRS>
+            <CRS>EPSG:3883</CRS>
+            <CRS>EPSG:3884</CRS>
+            <CRS>EPSG:3885</CRS>
+            <EX_GeographicBoundingBox>
+                <westBoundLongitude>16.262269</westBoundLongitude>
+                <eastBoundLongitude>32.841294</eastBoundLongitude>
+                <southBoundLatitude>59.672742</southBoundLatitude>
+                <northBoundLatitude>70.094755</northBoundLatitude>
+            </EX_GeographicBoundingBox>
+            <BoundingBox CRS="CRS:84" minx="16.262269" miny="59.672742" maxx="32.841294" maxy="70.094755"/>
+            <BoundingBox CRS="EPSG:4326" minx="59.672742" miny="16.262269" maxx="70.094755" maxy="32.841294"/>
+            <BoundingBox CRS="EPSG:3067" minx="87429.945000" miny="6637805.902000" maxx="722684.189000" maxy="7776440.030000"/>
+            <BoundingBox CRS="EPSG:102139" minx="87429.945000" miny="6637805.902000" maxx="722684.189000" maxy="7776440.030000"/>
+            <BoundingBox CRS="EPSG:4258" minx="59.672742" miny="16.262269" maxx="70.094755" maxy="32.841294"/>
+            <BoundingBox CRS="EPSG:3034" minx="3663665.821416" miny="4249378.895374" maxx="4920244.545278" maxy="5135964.402043"/>
+            <BoundingBox CRS="EPSG:3035" minx="4100673.576365" miny="4565401.348277" maxx="5352676.738590" maxy="5480449.468442"/>
+            <BoundingBox CRS="EPSG:3046" minx="6615721.549499" miny="317307.105452" maxx="7809606.601562" maxy="1057870.352621"/>
+            <BoundingBox CRS="EPSG:3047" minx="6637805.902000" miny="87429.945000" maxx="7776440.030000" maxy="722684.189000"/>
+            <BoundingBox CRS="EPSG:3048" minx="6632869.236943" miny="-247723.999948" maxx="7828382.514172" maxy="493941.710213"/>
+            <BoundingBox CRS="EPSG:3873" minx="6617801.266803" miny="19394326.319925" maxx="7828775.253381" maxy="20169270.836766"/>
+            <BoundingBox CRS="EPSG:3874" minx="6617660.617315" miny="20355763.421535" maxx="7820442.802420" maxy="21113729.994960"/>
+            <BoundingBox CRS="EPSG:3875" minx="6618368.897058" miny="21317233.999052" maxx="7812731.694240" maxy="22058093.590057"/>
+            <BoundingBox CRS="EPSG:3876" minx="6619926.221078" miny="22278747.033802" maxx="7805642.708639" maxy="23002370.790014"/>
+            <BoundingBox CRS="EPSG:3877" minx="6622332.841891" miny="23240311.524791" maxx="7799176.550931" maxy="23946570.631754"/>
+            <BoundingBox CRS="EPSG:3878" minx="6625589.148526" miny="24201936.492323" maxx="7793333.854789" maxy="24890702.034173"/>
+            <BoundingBox CRS="EPSG:3879" minx="6629695.665062" miny="25163630.981562" maxx="7788115.184842" maxy="25834773.811186"/>
+            <BoundingBox CRS="EPSG:3880" minx="6634653.048619" miny="26125404.066017" maxx="7783521.039036" maxy="26778794.684818"/>
+            <BoundingBox CRS="EPSG:3881" minx="6640462.086835" miny="27087264.850940" maxx="7779551.850740" maxy="27722773.298319"/>
+            <BoundingBox CRS="EPSG:3882" minx="6637522.024061" miny="28031175.064445" maxx="7786644.196321" maxy="28684712.525500"/>
+            <BoundingBox CRS="EPSG:3883" minx="6635429.050701" miny="28975156.623212" maxx="7794364.890344" maxy="29646608.547763"/>
+            <BoundingBox CRS="EPSG:3884" minx="6634182.836471" miny="29919218.454154" maxx="7802713.188836" maxy="30608470.309250"/>
+            <BoundingBox CRS="EPSG:3885" minx="6633783.184191" miny="30863369.608365" maxx="7811688.272450" maxy="31570306.740382"/>
+            <Layer queryable="1">
+                <Name>LayerName</Name>
+                <Title>LayerTitle</Title>
+                <Abstract/>
+                <KeywordList>
+                    <Keyword>keyword</Keyword>
+                </KeywordList>
+                <CRS>CRS:84</CRS>
+                <CRS>EPSG:4326</CRS>
+                <CRS>EPSG:3067</CRS>
+                <CRS>EPSG:4258</CRS>
+                <CRS>EPSG:3034</CRS>
+                <CRS>EPSG:3035</CRS>
+                <CRS>EPSG:3046</CRS>
+                <CRS>EPSG:3047</CRS>
+                <CRS>EPSG:3048</CRS>
+                <CRS>EPSG:3873</CRS>
+                <CRS>EPSG:3874</CRS>
+                <CRS>EPSG:3875</CRS>
+                <CRS>EPSG:3876</CRS>
+                <CRS>EPSG:3877</CRS>
+                <CRS>EPSG:3878</CRS>
+                <CRS>EPSG:3879</CRS>
+                <CRS>EPSG:3880</CRS>
+                <CRS>EPSG:3881</CRS>
+                <CRS>EPSG:3882</CRS>
+                <CRS>EPSG:3883</CRS>
+                <CRS>EPSG:3884</CRS>
+                <CRS>EPSG:3885</CRS>
+                <EX_GeographicBoundingBox>
+                    <westBoundLongitude>19.158138</westBoundLongitude>
+                    <eastBoundLongitude>31.417899</eastBoundLongitude>
+                    <southBoundLatitude>59.756708</southBoundLatitude>
+                    <northBoundLatitude>68.910986</northBoundLatitude>
+                </EX_GeographicBoundingBox>
+                <BoundingBox CRS="CRS:84" minx="19.158138" miny="59.756708" maxx="31.417899" maxy="68.910986"/>
+                <BoundingBox CRS="EPSG:4326" minx="59.756708" miny="19.158138" maxx="68.910986" maxy="31.417899"/>
+                <BoundingBox CRS="EPSG:3067" minx="183251.284000" miny="6637805.902000" maxx="677734.276000" maxy="7644436.775000"/>
+                <BoundingBox CRS="EPSG:102139" minx="183251.284000" miny="6637805.902000" maxx="677734.276000" maxy="7644436.775000"/>
+                <BoundingBox CRS="EPSG:4258" minx="59.756708" miny="19.158138" maxx="68.910986" maxy="31.417899"/>
+                <BoundingBox CRS="EPSG:3034" minx="3685932.108698" miny="4378934.028234" maxx="4777560.625665" maxy="5093087.482821"/>
+                <BoundingBox CRS="EPSG:3035" minx="4124000.934198" miny="4694707.418189" maxx="5215280.148714" maxy="5436944.230836"/>
+                <BoundingBox CRS="EPSG:3046" minx="6624371.175751" miny="425441.144624" maxx="7673583.652550" maxy="1012970.497542"/>
+                <BoundingBox CRS="EPSG:3047" minx="6637805.902000" miny="183251.284000" maxx="7644436.775000" maxy="677734.276000"/>
+                <BoundingBox CRS="EPSG:3048" minx="6636933.135598" miny="-151882.737075" maxx="7687210.388725" maxy="436310.567883"/>
+                <BoundingBox CRS="EPSG:3873" minx="6629324.117643" miny="19506404.810980" maxx="7691603.073710" maxy="20124426.403123"/>
+                <BoundingBox CRS="EPSG:3874" minx="6627749.227306" miny="20465904.233953" maxx="7683802.411733" maxy="21068845.220997"/>
+                <BoundingBox CRS="EPSG:3875" minx="6627021.984545" miny="21425411.309148" maxx="7676654.314276" maxy="22013175.767850"/>
+                <BoundingBox CRS="EPSG:3876" minx="6627142.272941" miny="22384935.129985" maxx="7670159.320496" maxy="22957427.110467"/>
+                <BoundingBox CRS="EPSG:3877" minx="6628110.111760" miny="23344484.798326" maxx="7664317.910170" maxy="23901608.195215"/>
+                <BoundingBox CRS="EPSG:3878" minx="6629925.655876" miny="24304069.429037" maxx="7659130.506562" maxy="24845727.861058"/>
+                <BoundingBox CRS="EPSG:3879" minx="6632589.195181" miny="25263698.154512" maxx="7654597.479012" maxy="25789794.852613"/>
+                <BoundingBox CRS="EPSG:3880" minx="6636101.153475" miny="26223380.129157" maxx="7650719.145230" maxy="26733817.833240"/>
+                <BoundingBox CRS="EPSG:3881" minx="6640462.086835" miny="27183124.533814" maxx="7647495.773309" maxy="27677805.398159"/>
+                <BoundingBox CRS="EPSG:3882" minx="6638200.856457" miny="28127075.446306" maxx="7652986.628049" maxy="28637599.335629"/>
+                <BoundingBox CRS="EPSG:3883" minx="6636786.074434" miny="29071082.989024" maxx="7659134.490978" maxy="29597362.227824"/>
+                <BoundingBox CRS="EPSG:3884" minx="6636217.517865" miny="30015155.929334" maxx="7665938.929204" maxy="30557103.168427"/>
+                <BoundingBox CRS="EPSG:3885" minx="6636495.097033" miny="30959303.135752" maxx="7673399.453507" maxy="31516831.240294"/>
+                <Identifier authority="FI">1002017</Identifier>
+                <MetadataURL type="ISO19115:2003">
+                    <Format>text/xml</Format>
+                    <OnlineResource xlink:href="http://www.test.domain//csw?request=GetRecordById&amp;service=CSW&amp;id=AAAAA1234-1234-1234-1AAA-1A1A1A111A1&amp;elementSetName=full&amp;outputSchema=http%3A%2F%2Fwww.isotc211.org%2F2005%2Fgmd" xlink:type="simple"/>
+                </MetadataURL>
+                <MetadataURL type="ISO19115:2003">
+                    <Format>text/html</Format>
+                    <OnlineResource xlink:href="http://www.test.domain/geonetwork/srv/fi/metadata.show.portti?uuid=AAAAA1234-1234-1234-1AAA-1A1A1A111A1" xlink:type="simple"/>
+                </MetadataURL>
+                <Style>
+                    <Name>default</Name>
+                    <Title>LayerName</Title>
+                    <LegendURL width="16" height="16">
+                        <Format>image/png</Format>
+                        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.test.domain/wms?request=GetLegendGraphic%26version=1.3.0%26format=image/png%26layer=LayerName" xlink:type="simple"/>
+                    </LegendURL>
+                </Style>
+                <MinScaleDenominator>4724.702381</MinScaleDenominator>
+                <MaxScaleDenominator>18898809.523810</MaxScaleDenominator>
+                <Dimension name="time" default="1932-12-31T00:00:00Z" units="ISO8601">1931-12-31T00:00:00.000Z,1932-12-31T00:00:00.000Z,1933-12-31T00:00:00.000Z,1934-12-31T00:00:00.000Z</Dimension>
+            </Layer>
+        </Layer>
+    </Capability>
+</WMS_Capabilities>


### PR DESCRIPTION
Parse metadataUuid to layer.capabilities json instead of layer.metadataId. For layer json use capabilities.metadataUuid if metadataId isn't set.

Use geotools WMSCapabilities and Layer for parsing capabilities json instead of fi.mml.map.mapwindow.service.wms.*.  getCapabilitiesResults used geotools already for parsing values for new layer except capabilities json.

Deprecate unused capabilities classes and methods.