### PR TITLE
Update capabilities before sending layer data for admin to edit

### DIFF
--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerAdminHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerAdminHandler.java
@@ -69,8 +69,9 @@ public class LayerAdminHandler extends AbstractLayerAdminHandler {
     public void handleGet(ActionParameters params) throws ActionException {
         final int layerId = params.getRequiredParamInt(PARAM_LAYER_ID);
         OskariLayer ml = getMapLayer(params.getUser(), layerId);
+        boolean capabilitiesUpdated = updateCapabilities(ml);
         MapLayerAdminOutput output = getLayerForEdit(params.getUser(), ml);
-        if (!updateCapabilities(ml)) {
+        if (!capabilitiesUpdated) {
             output.setWarn(KEY_UPDATE_CAPA_FAIL);
         }
         writeResponse(params, output);

--- a/service-admin/src/main/java/org/oskari/admin/LayerCapabilitiesHelper.java
+++ b/service-admin/src/main/java/org/oskari/admin/LayerCapabilitiesHelper.java
@@ -14,17 +14,13 @@ import fi.nls.oskari.wms.WMSCapabilitiesService;
 import fi.nls.oskari.wmts.WMTSCapabilitiesService;
 import fi.nls.oskari.wmts.domain.WMTSCapabilities;
 import org.geotools.data.wfs.WFSDataStore;
-import org.oskari.maplayer.admin.LayerAdminJSONHelper;
 import org.oskari.maplayer.model.ServiceCapabilitiesResult;
-import org.oskari.maplayer.model.ServiceCapabilitiesResultWMS;
-import org.oskari.maplayer.model.ServiceCapabilitiesResultWMTS;
 import org.oskari.service.wfs3.WFS3Service;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public class LayerCapabilitiesHelper {
 

--- a/service-map/src/main/java/fi/nls/oskari/wmts/WMTSCapabilitiesService.java
+++ b/service-map/src/main/java/fi/nls/oskari/wmts/WMTSCapabilitiesService.java
@@ -6,19 +6,14 @@ import fi.nls.oskari.service.ServiceException;
 import fi.nls.oskari.service.capabilities.CapabilitiesCacheService;
 import fi.nls.oskari.service.capabilities.OskariLayerCapabilities;
 import fi.nls.oskari.service.capabilities.OskariLayerCapabilitiesHelper;
-import fi.nls.oskari.util.JSONHelper;
-import fi.nls.oskari.wmts.domain.TileMatrixSet;
 import fi.nls.oskari.wmts.domain.WMTSCapabilities;
 import fi.nls.oskari.wmts.domain.WMTSCapabilitiesLayer;
-import org.json.JSONObject;
 import org.oskari.maplayer.admin.LayerAdminJSONHelper;
 import org.oskari.maplayer.model.ServiceCapabilitiesResultWMTS;
 import org.oskari.service.util.ServiceFactory;
 
 import java.util.*;
 import java.util.stream.Collectors;
-
-import static fi.nls.oskari.service.capabilities.CapabilitiesConstants.*;
 
 public class WMTSCapabilitiesService {
     private CapabilitiesCacheService capabilitiesService = ServiceFactory.getCapabilitiesCacheService();


### PR DESCRIPTION
Instead of first creating the response and then updating the capabilities data.