### PR TITLE
Don't filter out bundles without config when fetching views

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/view/GetViewsHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/view/GetViewsHandler.java
@@ -98,25 +98,21 @@ public class GetViewsHandler extends ActionHandler {
         // The old publisher and normal view listing need them.
         final JSONObject state = new JSONObject();
         for (Bundle bundle : bundles) {
-            JSONObject bundleNode = bundleToJSONObjet(bundle);
+            JSONObject bundleNode = bundleToJSONObject(bundle);
             // If bundleNode is null putValue will actually eventually call remove, which is fine here
             JSONHelper.putValue(state, bundle.getBundleinstance(), bundleNode);
         }
         return state;
     }
 
-    private JSONObject bundleToJSONObjet(Bundle bundle) {
+    private JSONObject bundleToJSONObject(Bundle bundle) {
         JSONObject state = JSONHelper.createJSONObject(bundle.getState());
         if (state == null) {
             return null;
         }
-        JSONObject config = JSONHelper.createJSONObject(bundle.getConfig());
-        if (config == null) {
-            return null;
-        }
         JSONObject bundleNode = new JSONObject();
         JSONHelper.putValue(bundleNode, KEY_STATE, state);
-        JSONHelper.putValue(bundleNode, KEY_CONFIG, config);
+        JSONHelper.putValue(bundleNode, KEY_CONFIG, JSONHelper.createJSONObject(bundle.getConfig()));
         return bundleNode;
     }
 


### PR DESCRIPTION
The My data listings use GetViews to fetch the saved appsetups that the user can switch between. There's probably some bundle that can't handle it's config being undefined but it's best to fix on that bundle instead of filtering out bundles without config. Most bundles don't have config but do have a state. Most recent example is the timeseries bundle. Let all the bundles that have state even if they don't have config pass through to the frontend when views are requested for listing purposes.