### PR TITLE
UpdateCapabilities by dataprovider or group id

### DIFF
--- a/service-map/src/main/java/org/oskari/maplayer/admin/LayerAdminJSONHelper.java
+++ b/service-map/src/main/java/org/oskari/maplayer/admin/LayerAdminJSONHelper.java
@@ -139,6 +139,7 @@ public class LayerAdminJSONHelper {
 
         out.setCreated(layer.getCreated());
         out.setUpdated(layer.getUpdated());
+        out.setCapabilities_last_updated(layer.getCapabilitiesLastUpdated());
 
         // TODO: handle sublayers layer.getSublayers()
         // TODO: handle groups -> MapLayerGroupsHelper.findGroupsForNames_dangerzone_() + setGroupsForLayer()

--- a/service-map/src/main/java/org/oskari/maplayer/model/MapLayerAdminOutput.java
+++ b/service-map/src/main/java/org/oskari/maplayer/model/MapLayerAdminOutput.java
@@ -11,6 +11,7 @@ public class MapLayerAdminOutput extends MapLayer {
     private Map<String, Object> capabilities;
     private Date created;
     private Date updated;
+    private Date capabilities_last_updated;
 
     public Map<String, Object> getCapabilities() {
         return capabilities;
@@ -46,5 +47,13 @@ public class MapLayerAdminOutput extends MapLayer {
 
     public void setWarn(String warn) {
         this.warn = warn;
+    }
+
+    public Date getCapabilities_last_updated() {
+        return capabilities_last_updated;
+    }
+
+    public void setCapabilities_last_updated(Date capabilities_last_updated) {
+        this.capabilities_last_updated = capabilities_last_updated;
     }
 }


### PR DESCRIPTION
Updating all layers seems to be heavy operation if there's lot of layers and it's hard to inspect results. Allow to update capabilities by dataprovider and group ids. Add capabilities_last_updated to admin layer output.