### PR TITLE
UserLayer allow imported files to be inside directory

### DIFF
--- a/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java
+++ b/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java
@@ -241,11 +241,6 @@ public class CreateUserLayerHandler extends RestActionHandler {
             return null;
         }
         String name = ze.getName();
-        if (name.indexOf('/') >= 0) {
-            ignored.put(name, "folder");
-            log.debug(name, "is inside a directory, ignoring");
-            return null;
-        }
         if (name.indexOf('.') == 0) {
             ignored.put(name, "hidden");
             log.debug(name, "starts with '.', ignoring");


### PR DESCRIPTION
Don't ignore files that are inside directory. This should be safe because files are limited to 10 and there shouldn't be two main files or  files with same file extension:
https://github.com/oskariorg/oskari-server/blob/develop/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java#L216
https://github.com/oskariorg/oskari-server/blob/develop/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java#L269
https://github.com/oskariorg/oskari-server/blob/develop/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java#L261
https://github.com/oskariorg/oskari-server/blob/develop/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java#L366