### PR TITLE
Initialize locale for myplaces default layer to prevent Mybatis npe

### DIFF
--- a/control-myplaces/src/main/java/fi/nls/oskari/control/myplaces/handler/MyPlacesLayersHandler.java
+++ b/control-myplaces/src/main/java/fi/nls/oskari/control/myplaces/handler/MyPlacesLayersHandler.java
@@ -170,6 +170,7 @@ public class MyPlacesLayersHandler extends RestActionHandler {
         MyPlaceCategory category = new MyPlaceCategory();
         category.setName("");
         category.setDefault(true);
+        category.setLocale(new JSONObject());
         category.getWFSLayerOptions().setDefaultFeatureStyle(WFSLayerOptions.getDefaultOskariStyle());
         return category;
     }


### PR DESCRIPTION
Fixes an error preventing new users to add myplaces (faulty default layer):
```
2021-04-14 19:16:51,269 ERROR fi.nls.oskari.AjaxController - Couldn't handle action: MyPlacesLayers Message:  Unhandled exception occured . Parameters:  {action_route=[MyPlacesLayers],_=[1618417010528]}
org.apache.ibatis.exceptions.PersistenceException:
### Error querying database.  Cause: org.apache.ibatis.executor.result.ResultMapException: Error attempting to get column 'locale' from result set.  Cause: java.lang.NullPointerException
### The error may exist in org/oskari/myplaces/service/mybatis/MyPlaceCategoryMapper.java (best guess)
### The error may involve org.oskari.myplaces.service.mybatis.MyPlaceCategoryMapper.getByUserId
### The error occurred while handling results
### SQL: SELECT id, uuid, "default", publisher_name, category_name, options, locale FROM categories WHERE uuid = ?