### PR TITLE
WFSLayer WPS params migration to JSONObject

### DIFF
--- a/content-resources/src/main/java/flyway/oskari/V2_3_1__migrate_wps_params.java
+++ b/content-resources/src/main/java/flyway/oskari/V2_3_1__migrate_wps_params.java
@@ -1,0 +1,64 @@
+package flyway.oskari;
+
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.util.JSONHelper;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.json.JSONObject;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class V2_3_1__migrate_wps_params extends BaseJavaMigration {
+    private static final Logger LOG = LogFactory.getLogger(V2_3_1__migrate_wps_params.class);
+    public static final String WPS_PARAMS = "wpsParams";
+
+    @Override
+    public void migrate(Context context) throws Exception {
+        Connection conn = context.getConnection();
+        getLayerAttributes(conn).forEach((id, attr) -> migrateWpsParams(conn, id, attr));
+    }
+    private void migrateWpsParams (Connection conn, int id, JSONObject attr) {
+        String wpsString = attr.optString(WPS_PARAMS);
+        if (wpsString.isEmpty()) {
+            //skip
+            return;
+        }
+        try {
+            JSONObject wpsParams = new JSONObject(wpsString);
+            JSONHelper.putValue(attr, WPS_PARAMS, wpsParams);
+            updateAttributes(conn, id, attr);
+        } catch (Exception ignored) {
+            LOG.warn("Failed to migrate WPS params String:", wpsString, "to JSONObject for layer:", id);
+        }
+    }
+    private void updateAttributes (Connection conn, int layerId, JSONObject attributes) throws SQLException {
+        final String sql = "UPDATE oskari_maplayer SET attributes=? where id=?";
+        try(PreparedStatement statement = conn.prepareStatement(sql)) {
+            statement.setString(1, attributes.toString());
+            statement.setInt(2, layerId);
+            statement.execute();
+        }
+    }
+    private Map<Integer, JSONObject> getLayerAttributes(Connection conn) throws SQLException {
+        Map<Integer, JSONObject> attributes = new HashMap<>();
+        // only WFS layers have WPS params
+        final String sql = "SELECT id, attributes FROM oskari_maplayer where type = 'wfslayer'";
+        try(PreparedStatement statement = conn.prepareStatement(sql)) {
+            try (ResultSet rs = statement.executeQuery()) {
+                while(rs.next()) {
+                    int id = rs.getInt("id");
+                    JSONObject attr = JSONHelper.createJSONObject(rs.getString("attributes"));
+                    attributes.put(id, attr);
+                }
+            }
+        }
+        LOG.info("Found", attributes.size(), "WFS layers for WPS migration");
+        return attributes;
+    }
+}

--- a/content-resources/src/main/java/flyway/oskari/V2_3_1__migrate_wps_params.java
+++ b/content-resources/src/main/java/flyway/oskari/V2_3_1__migrate_wps_params.java
@@ -51,7 +51,7 @@ public class V2_3_1__migrate_wps_params extends BaseJavaMigration {
                     data.put(key, wpsParams.get(key));
                 }
             }
-
+            attr.remove(WPS_PARAMS);
             updateAttributes(conn, id, attr);
         } catch (Exception ignored) {
             LOG.warn("Failed to migrate WPS params String:", wpsString, "to JSONObject for layer:", id);

--- a/content-resources/src/main/java/flyway/oskari/V2_3_1__migrate_wps_params.java
+++ b/content-resources/src/main/java/flyway/oskari/V2_3_1__migrate_wps_params.java
@@ -44,9 +44,10 @@ public class V2_3_1__migrate_wps_params extends BaseJavaMigration {
                 } else if ("join_key".equals(key)) {
                     data.putOpt("commonId", wpsParams.optString(key, null));
                 } else if ("input_type".equals(key)) {
-                    data.putOpt("wpsType", wpsParams.optString(key, null));
+                    data.putOpt("wpsInputType", wpsParams.optString(key, null));
                 } else {
                     // if wps params has additional keys, store them
+                    LOG.info("Found", key, "in layer:", id, "stored it to attributes.data but it not used");
                     data.put(key, wpsParams.get(key));
                 }
             }

--- a/control-base/src/main/java/fi/nls/oskari/control/layer/GetWFSDescribeFeatureHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/GetWFSDescribeFeatureHandler.java
@@ -80,7 +80,7 @@ public class GetWFSDescribeFeatureHandler extends ActionHandler {
         }
         // Add WPS params
         WFSLayerAttributes attrs = new WFSLayerAttributes(layer.getAttributes());
-        JSONHelper.putValue(response, WPS_PARAMS, JSONHelper.createJSONObject(attrs.getWpsParams()));
+        JSONHelper.putValue(response, WPS_PARAMS, attrs.getWpsParams());
         return response;
     }
 

--- a/control-base/src/main/java/fi/nls/oskari/control/layer/GetWFSDescribeFeatureHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/GetWFSDescribeFeatureHandler.java
@@ -4,6 +4,7 @@ import fi.nls.oskari.control.ActionParamsException;
 import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.domain.map.wfs.WFSLayerAttributes;
 import fi.nls.oskari.map.layer.OskariLayerService;
+import org.json.JSONException;
 import org.json.JSONObject;
 
 import fi.nls.oskari.annotation.OskariActionRoute;
@@ -79,8 +80,14 @@ public class GetWFSDescribeFeatureHandler extends ActionHandler {
             }
         }
         // Add WPS params
-        WFSLayerAttributes attrs = new WFSLayerAttributes(layer.getAttributes());
-        JSONHelper.putValue(response, WPS_PARAMS, attrs.getWpsParams());
+        JSONObject wps =  new JSONObject();
+        try {
+            WFSLayerAttributes attrs = new WFSLayerAttributes(layer.getAttributes());
+            wps.putOpt("no_data", attrs.getNoDataValue());
+            wps.putOpt("join_key", attrs.getCommonId());
+            JSONHelper.putValue(response, WPS_PARAMS, wps);
+        } catch (JSONException ignored) {}
+
         return response;
     }
 

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/wfs/WFSLayerAttributes.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/wfs/WFSLayerAttributes.java
@@ -51,7 +51,8 @@ import java.util.*;
  *             }
  *         },
  *         "noDataValue": -1,
- *         "commonId": "grd_id"
+ *         "commonId": "grd_id",
+ *         "wpsInputType": "gs_vector"
  *     },
  *     "maxFeatures": 100,
  *     "namespaceURL": "http://oskari.org"
@@ -70,7 +71,6 @@ public class WFSLayerAttributes {
     private int maxFeatures = 100000;
     private Integer noDataValue;
     private String commonId;
-    private String wpsType;
     private JSONObject attributes;
 
 
@@ -106,7 +106,6 @@ public class WFSLayerAttributes {
                 noDataValue = data.optInt(KEY_NO_DATA_VALUE, -1);
             }
             commonId = data.optString(KEY_COMMON_ID, commonId);
-            wpsType = data.optString(KEY_WPS_TYPE, wpsType);
         }
     }
     public Optional<JSONObject> getLocalization() {
@@ -161,11 +160,15 @@ public class WFSLayerAttributes {
     public String getCommonId() {
         return commonId;
     }
-    public String getWpsType() {
-        return wpsType;
-    }
 
     public JSONObject getAttributes() {
         return attributes;
+    }
+    public JSONObject getAttributesData() {
+        if (attributes == null) {
+            return new JSONObject();
+        }
+        JSONObject data = JSONHelper.getJSONObject(attributes, "data");
+        return data == null ? new JSONObject() : data;
     }
 }

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/wfs/WFSLayerAttributes.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/wfs/WFSLayerAttributes.java
@@ -65,7 +65,7 @@ public class WFSLayerAttributes {
     private String namespaceURL;
     private int maxFeatures = 100000;
     private JSONObject attributes;
-    private String wpsParams;
+    private JSONObject wpsParams;
 
     public WFSLayerAttributes(JSONObject wfsAttrs) {
         if (wfsAttrs == null) {
@@ -78,7 +78,7 @@ public class WFSLayerAttributes {
         // Parsing failed for maxFeatures: java.lang.IllegalArgumentException: positiveInteger value '0' must be positive.
         maxFeatures = wfsAttrs.optInt("maxFeatures", maxFeatures);
         namespaceURL = wfsAttrs.optString("namespaceURL", namespaceURL);
-        wpsParams = wfsAttrs.optString("wpsParams", wpsParams);
+        wpsParams = wfsAttrs.optJSONObject("wpsParams");
         JSONObject data = wfsAttrs.optJSONObject("data");
         if (data != null) {
             locales = data.optJSONObject("locale");
@@ -129,7 +129,10 @@ public class WFSLayerAttributes {
     public String getNamespaceURL() {
         return namespaceURL;
     }
-    public String getWpsParams() {
+    public JSONObject getWpsParams() {
+        if (wpsParams == null) {
+            return new JSONObject();
+        }
         return wpsParams;
     }
 

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/wfs/WFSLayerAttributes.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/wfs/WFSLayerAttributes.java
@@ -49,7 +49,9 @@ import java.util.*;
  *                 "kunta_en": "Municipality",
  *                 "id_nro": "ID No."
  *             }
- *         }
+ *         },
+ *         "noDataValue": -1,
+ *         "commonId": "grd_id"
  *     },
  *     "maxFeatures": 100,
  *     "namespaceURL": "http://oskari.org"
@@ -58,14 +60,19 @@ import java.util.*;
 public class WFSLayerAttributes {
     public static final String KEY_NAMESPACEURL = "namespaceURL";
     public static final String KEY_MAXFEATURES = "maxFeatures";
-    public static final String KEY_WPS_PARAMS = "wpsParams";
+    public static final String KEY_NO_DATA_VALUE = "noDataValue";
+    public static final String KEY_COMMON_ID = "commonId";
+    public static final String KEY_WPS_TYPE = "wpsType";
 
     private Map<String, List<String>> params = new HashMap<>();
     private JSONObject locales = null;
     private String namespaceURL;
     private int maxFeatures = 100000;
+    private Integer noDataValue;
+    private String commonId;
+    private String wpsType;
     private JSONObject attributes;
-    private JSONObject wpsParams;
+
 
     public WFSLayerAttributes(JSONObject wfsAttrs) {
         if (wfsAttrs == null) {
@@ -78,7 +85,6 @@ public class WFSLayerAttributes {
         // Parsing failed for maxFeatures: java.lang.IllegalArgumentException: positiveInteger value '0' must be positive.
         maxFeatures = wfsAttrs.optInt("maxFeatures", maxFeatures);
         namespaceURL = wfsAttrs.optString("namespaceURL", namespaceURL);
-        wpsParams = wfsAttrs.optJSONObject("wpsParams");
         JSONObject data = wfsAttrs.optJSONObject("data");
         if (data != null) {
             locales = data.optJSONObject("locale");
@@ -96,6 +102,11 @@ public class WFSLayerAttributes {
                     params.put(lang, JSONHelper.getArrayAsList(localizedFilter.optJSONArray(lang)));
                 }
             }
+            if (data.has(KEY_NO_DATA_VALUE)) {
+                noDataValue = data.optInt(KEY_NO_DATA_VALUE, -1);
+            }
+            commonId = data.optString(KEY_COMMON_ID, commonId);
+            wpsType = data.optString(KEY_WPS_TYPE, wpsType);
         }
     }
     public Optional<JSONObject> getLocalization() {
@@ -129,12 +140,6 @@ public class WFSLayerAttributes {
     public String getNamespaceURL() {
         return namespaceURL;
     }
-    public JSONObject getWpsParams() {
-        if (wpsParams == null) {
-            return new JSONObject();
-        }
-        return wpsParams;
-    }
 
     public int getMaxFeatures() {
         return maxFeatures;
@@ -148,6 +153,16 @@ public class WFSLayerAttributes {
     public void setNamespaceURL(String namespaceURL) {
         this.namespaceURL = namespaceURL;
         JSONHelper.putValue(this.attributes, "namespaceURL", namespaceURL);
+    }
+    public Integer getNoDataValue() {
+        return noDataValue;
+    }
+
+    public String getCommonId() {
+        return commonId;
+    }
+    public String getWpsType() {
+        return wpsType;
     }
 
     public JSONObject getAttributes() {

--- a/service-base/src/test/java/fi/nls/oskari/domain/map/wfs/WFSLayerAttributesTest.java
+++ b/service-base/src/test/java/fi/nls/oskari/domain/map/wfs/WFSLayerAttributesTest.java
@@ -13,9 +13,9 @@ public class WFSLayerAttributesTest {
             "    \"randomKey\": \"for testing\",\n" +
             "    \"maxFeatures\": 2000,\n" +
             "    \"namespaceURL\": \"http://oskari.org\",\n" +
-            "    \"wpsParams\":{\n" +
-            "       \"no_data\":-1,\n" +
-            "       \"join_key\":\"grid_id\"\n" +
+            "    \"data\":{\n" +
+            "       \"noDataValue\":-1,\n" +
+            "       \"commonId\":\"grid_id\"\n" +
             "    }\n" +
             "}";
 
@@ -167,7 +167,8 @@ public class WFSLayerAttributesTest {
         assertNull("Params was null", attrs.getAttributes());
         assertFalse("Filter wasn't given", attrs.hasFilter());
         assertFalse("Localization wasn't given", attrs.getLocalization("en").isPresent());
-        assertEquals("WPS params was empty", 0, attrs.getWpsParams().length());
+        assertNull("noDataValue was null", attrs.getNoDataValue());
+        assertNull("commonId was null", attrs.getCommonId());
     }
 
     @Test
@@ -204,9 +205,8 @@ public class WFSLayerAttributesTest {
         assertEquals("Namespace set", "http://oskari.org", attrs.getNamespaceURL());
         assertTrue("Input & output match", JSONHelper.isEqual(input, attrs.getAttributes()));
 
-        JSONObject wpsParams = attrs.getWpsParams();
-        assertEquals("No data set", -1, wpsParams.optInt("no_data"));
-        assertEquals("Join key set", "grid_id", wpsParams.optString("join_key"));
+        assertEquals("noDataValue set", -1, attrs.getNoDataValue().intValue());
+        assertEquals("commonId set", "grid_id", attrs.getCommonId());
 
         assertFalse("Filter wasn't given", attrs.hasFilter());
         assertFalse("Localization wasn't given", attrs.getLocalization("en").isPresent());

--- a/service-base/src/test/java/fi/nls/oskari/domain/map/wfs/WFSLayerAttributesTest.java
+++ b/service-base/src/test/java/fi/nls/oskari/domain/map/wfs/WFSLayerAttributesTest.java
@@ -9,6 +9,16 @@ import static org.junit.Assert.*;
 
 public class WFSLayerAttributesTest {
 
+    String simpleAttributes = "{\n" +
+            "    \"randomKey\": \"for testing\",\n" +
+            "    \"maxFeatures\": 2000,\n" +
+            "    \"namespaceURL\": \"http://oskari.org\",\n" +
+            "    \"wpsParams\":{\n" +
+            "       \"no_data\":-1,\n" +
+            "       \"join_key\":\"grid_id\"\n" +
+            "    }\n" +
+            "}";
+
     String attributesSimpleFilter = "{\n" +
             "    \"randomKey\": \"for testing\",\n" +
             "    \"data\": {\n" +
@@ -157,6 +167,7 @@ public class WFSLayerAttributesTest {
         assertNull("Params was null", attrs.getAttributes());
         assertFalse("Filter wasn't given", attrs.hasFilter());
         assertFalse("Localization wasn't given", attrs.getLocalization("en").isPresent());
+        assertEquals("WPS params was empty", 0, attrs.getWpsParams().length());
     }
 
     @Test
@@ -183,5 +194,22 @@ public class WFSLayerAttributesTest {
         assertTrue("Input & output match", JSONHelper.isEqual(input, attrs.getAttributes()));
         assertTrue("Filter was given", attrs.hasFilter());
         assertTrue("English locale wasn't given", attrs.getLocalization("en").isPresent());
+    }
+    @Test
+    public void testSimpleAttributes() throws JSONException {
+        JSONObject input = new JSONObject(simpleAttributes);
+        WFSLayerAttributes attrs = new WFSLayerAttributes(input);
+
+        assertEquals("Max features set", 2000, attrs.getMaxFeatures());
+        assertEquals("Namespace set", "http://oskari.org", attrs.getNamespaceURL());
+        assertTrue("Input & output match", JSONHelper.isEqual(input, attrs.getAttributes()));
+
+        JSONObject wpsParams = attrs.getWpsParams();
+        assertEquals("No data set", -1, wpsParams.optInt("no_data"));
+        assertEquals("Join key set", "grid_id", wpsParams.optString("join_key"));
+
+        assertFalse("Filter wasn't given", attrs.hasFilter());
+        assertFalse("Localization wasn't given", attrs.getLocalization("en").isPresent());
+        assertTrue("No attributes selected", attrs.getSelectedAttributes().isEmpty());
     }
 }

--- a/service-map/src/main/java/fi/nls/oskari/analysis/AnalysisParser.java
+++ b/service-map/src/main/java/fi/nls/oskari/analysis/AnalysisParser.java
@@ -1322,7 +1322,7 @@ public class AnalysisParser {
             return false;
         }
         WFSLayerAttributes attr = new WFSLayerAttributes(layer.getAttributes());
-        return ANALYSIS_INPUT_TYPE_GS_VECTOR.equals(attr.getWpsParams().optString(WPS_INPUT_TYPE));
+        return ANALYSIS_INPUT_TYPE_GS_VECTOR.equals(attr.getWpsType());
     }
     /**
      * Set analysis field types

--- a/service-map/src/main/java/fi/nls/oskari/analysis/AnalysisParser.java
+++ b/service-map/src/main/java/fi/nls/oskari/analysis/AnalysisParser.java
@@ -67,7 +67,7 @@ public class AnalysisParser {
     private static final String ANALYSIS_RENDERING_ELEMENT = "analysis.rendering.element";
     private static final String ANALYSIS_WPS_ELEMENT_LOCALNAME = "analysis_data";
     private static final String ANALYSIS_PROPERTY_NAME = "analysis_id";
-    private static final String WPS_INPUT_TYPE = "input_type";
+    private static final String WPS_INPUT_TYPE = "wpsInputType";
 
     private static final String MYPLACES_BASELAYER_ID = "myplaces.baselayer.id";
     private static final String MYPLACES_PROPERTY_NAME = "category_id";
@@ -245,6 +245,10 @@ public class AnalysisParser {
             analysisLayer.setAnalysisMethodParams(method);
 
             //TODO: better input type mapping
+            // could be handled by:
+            // - adding gs_vector type for analysis, myplaces, userlayer baselayer
+            // - getWpsInputLayerType to get value from attributes.data.wpsInputType and default to wfs
+            // - check if geojson type matters
             method.setWps_reference_type(analysisLayer.getInputType());
             if (sid.indexOf(ANALYSIS_LAYER_PREFIX) == 0 || sid.indexOf(MYPLACES_LAYER_PREFIX) == 0 || sid.indexOf(USERLAYER_PREFIX) == 0) {
                 method.setWps_reference_type2(ANALYSIS_INPUT_TYPE_GS_VECTOR);
@@ -1321,8 +1325,8 @@ public class AnalysisParser {
         if (layer == null) {
             return false;
         }
-        WFSLayerAttributes attr = new WFSLayerAttributes(layer.getAttributes());
-        return ANALYSIS_INPUT_TYPE_GS_VECTOR.equals(attr.getWpsType());
+        JSONObject data = new WFSLayerAttributes(layer.getAttributes()).getAttributesData();
+        return ANALYSIS_INPUT_TYPE_GS_VECTOR.equals(JSONHelper.optString(data, WPS_INPUT_TYPE));
     }
     /**
      * Set analysis field types

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterANALYSIS.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterANALYSIS.java
@@ -4,6 +4,7 @@ import fi.mml.map.mapwindow.util.OskariLayerWorker;
 import fi.nls.oskari.analysis.AnalysisHelper;
 import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.domain.map.analysis.Analysis;
+import fi.nls.oskari.domain.map.wfs.WFSLayerAttributes;
 import fi.nls.oskari.util.JSONHelper;
 import fi.nls.oskari.util.PropertyUtil;
 import fi.nls.oskari.util.WFSConversionHelper;
@@ -26,7 +27,6 @@ public class LayerJSONFormatterANALYSIS extends LayerJSONFormatterUSERDATA {
     private static final String JSKEY_MAXSCALE = "maxScale";
     private static final String JSKEY_METHODPARAMS = "methodParams";
     private static final String JSKEY_NO_DATA = "no_data";
-    private static final String JSKEY_WPS_PARAMS = "wpsParams";
     private static final String JSKEY_METHOD = "method";
     private static final String JSKEY_BBOX = "bbox";
     private static final String JSKEY_BOTTOM = "bottom";
@@ -87,11 +87,12 @@ public class LayerJSONFormatterANALYSIS extends LayerJSONFormatterUSERDATA {
     }
     private static JSONObject parseAttributes (JSONObject layerJson, Analysis analysis, JSONObject analysisJSON, String lang) {
         JSONObject attributes = JSONHelper.getJSONObject(layerJson, "attributes");
+        JSONObject data = new JSONObject();
         JSONObject params = JSONHelper.getJSONObject(analysisJSON, JSKEY_METHODPARAMS);
         if (params != null) {
             Object noData = JSONHelper.get(params, JSKEY_NO_DATA);
             if (noData != null) {
-                JSONHelper.putValue(attributes, JSKEY_WPS_PARAMS, JSONHelper.createJSONObject(JSKEY_NO_DATA, noData));
+                JSONHelper.putValue(data, WFSLayerAttributes.KEY_NO_DATA_VALUE, noData);
             }
         }
         String method = JSONHelper.optString(analysisJSON, JSKEY_METHOD);
@@ -112,7 +113,7 @@ public class LayerJSONFormatterANALYSIS extends LayerJSONFormatterUSERDATA {
                 JSONHelper.putValue(types, field, type);
             }
         }
-        JSONObject data = new JSONObject();
+
         JSONHelper.put(data, "filter", filter);
         JSONHelper.putValue(data, "types", types);
         JSONHelper.putValue(data, "locale", JSONHelper.createJSONObject(lang, locale));

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWFS.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWFS.java
@@ -35,8 +35,6 @@ import static fi.nls.oskari.service.capabilities.CapabilitiesConstants.*;
  */
 public class LayerJSONFormatterWFS extends LayerJSONFormatter {
 
-    private static final String KEY_WPS_PARAMS = "wps_params";
-
     private static Logger log = LogFactory.getLogger(LayerJSONFormatterWFS.class);
 
     public JSONObject getJSON(OskariLayer layer,
@@ -54,8 +52,6 @@ public class LayerJSONFormatterWFS extends LayerJSONFormatter {
             JSONHelper.putValue(layerJson, KEY_STYLE, layer.getStyle());
         }
         JSONHelper.putValue(layerJson, KEY_ISQUERYABLE, true);
-        WFSLayerAttributes attr = new WFSLayerAttributes(layer.getAttributes());
-        JSONHelper.putValue(layerJson, KEY_WPS_PARAMS, getWpsParams(attr.getWpsParams()) );
 
         return layerJson;
     }
@@ -68,19 +64,6 @@ public class LayerJSONFormatterWFS extends LayerJSONFormatter {
         JSONHelper.putValue(layerJson, KEY_STYLES, wfsOpts.getStyles().names());
     }
 
-    /**
-     * Constructs wps params json
-     *
-     * @param  wpsParams wfs layer configuration
-     */
-    private JSONObject getWpsParams(String wpsParams) {
-
-        JSONObject json = new JSONObject();
-        if (wpsParams == null) return json;
-
-        return JSONHelper.createJSONObject(wpsParams);
-
-    }
 
     public static JSONObject createCapabilitiesJSON(final WFSGetCapabilities capa, SimpleFeatureSource source, Set<String> systemCRSs) throws ServiceException {
 


### PR DESCRIPTION
WFS layers' WPS params json is stored as String in db (inside attributes column). Frontend getWpsLayerParams gets WPS params from attributes object instead of wps_params (created JSONObject from String to own key to layerjson) which causes problems if attributes contains String wps params.

To fix the issue and clarify code:
migrate attributes.wpsParams to under attributes.data so it's not "analyze-specific"
Update WFSLayerAttributes to handle commonId and noDataValue
wpsInputType isn't added to WFSLayerAttributes because it's analysis specific but changed analysis to use WFSLayerAttributes.getData to link code together
Remove unused wps_params from wfslayer json formatter

Didn't update wpsInputType parsing/handling in AnalysisParser. Only updated to get value from layer.attributes.data.wpsInputType and added comment how it could be handled.
Method -> wpsReferenceType
AnalysisLayer -> wpsInputType
possible values: wfs, gs_vector, geojson
User own data layers' uses gs_vector and temp layers uses geojson.