### PR TITLE
Don't try to proxy requests to empty urls

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/layer/GetLayerTileHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/GetLayerTileHandler.java
@@ -74,14 +74,6 @@ public class GetLayerTileHandler extends ActionHandler {
         final int layerId = params.getRequiredParamInt(KEY_ID);
         final OskariLayer layer = permissionHelper.getLayer(layerId, params.getUser());
 
-        final MetricRegistry metrics = ActionControl.getMetrics();
-
-        Timer.Context actionTimer = null;
-        if(GATHER_METRICS) {
-            final com.codahale.metrics.Timer timer = metrics.timer(METRICS_PREFIX + "." + layerId);
-            actionTimer = timer.time();
-        }
-
         String httpMethod = params.getRequest().getMethod();
         String url;
         String postParams = null;
@@ -97,6 +89,14 @@ public class GetLayerTileHandler extends ActionHandler {
             // -> not an error really, but we don't want to go any further either
             ResponseHelper.writeError(params, "No URL configured", HttpServletResponse.SC_NOT_FOUND);
             return;
+        }
+
+        final MetricRegistry metrics = ActionControl.getMetrics();
+
+        Timer.Context actionTimer = null;
+        if (GATHER_METRICS) {
+            final com.codahale.metrics.Timer timer = metrics.timer(METRICS_PREFIX + "." + layerId);
+            actionTimer = timer.time();
         }
         // TODO: we should handle redirects here or in IOHelper or start using a lib that handles 301/302 properly
         HttpURLConnection con = getConnection(url, layer);

--- a/control-base/src/main/java/fi/nls/oskari/control/layer/GetLayerTileHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/GetLayerTileHandler.java
@@ -13,6 +13,7 @@ import fi.nls.oskari.util.IOHelper;
 import fi.nls.oskari.util.JSONHelper;
 import fi.nls.oskari.util.PropertyUtil;
 
+import fi.nls.oskari.util.ResponseHelper;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.oskari.permissions.PermissionService;
@@ -90,6 +91,12 @@ public class GetLayerTileHandler extends ActionHandler {
             postParams = IOHelper.getParams(getUrlParams(params.getRequest()));
         } else {
             url = getURL(params, layer);
+        }
+        if (url == null || url.trim().isEmpty()) {
+            // For example legend url for proxied layers can be empty
+            // -> not an error really, but we don't want to go any further either
+            ResponseHelper.writeError(params, "No URL configured", HttpServletResponse.SC_NOT_FOUND);
+            return;
         }
         // TODO: we should handle redirects here or in IOHelper or start using a lib that handles 301/302 properly
         HttpURLConnection con = getConnection(url, layer);

--- a/control-base/src/test/java/fi/nls/oskari/control/layer/GetWFSLayerFieldsHandlerTest.java
+++ b/control-base/src/test/java/fi/nls/oskari/control/layer/GetWFSLayerFieldsHandlerTest.java
@@ -5,7 +5,6 @@ import fi.nls.oskari.control.ActionParameters;
 import fi.nls.oskari.control.ActionParamsException;
 import fi.nls.oskari.domain.User;
 import fi.nls.oskari.domain.map.OskariLayer;
-import fi.nls.oskari.service.ServiceException;
 import fi.nls.oskari.util.WFSGetLayerFields;
 import fi.nls.test.control.JSONActionRouteTest;
 import fi.nls.test.util.ResourceHelper;


### PR DESCRIPTION
For example legends can be as empty strings which caused:
```
2021-04-22 10:41:48,238 ERROR fi.nls.oskari.AjaxController - Couldn't handle action: GetLayerTile Message:  Couldn't get connection to service . Parameters:  {action_route=[GetLayerTile],style=[xxx],id=[xxx],legend=[true]}
java.net.MalformedURLException: no protocol:
        at java.net.URL.<init>(URL.java:645) ~[?:?]
        at java.net.URL.<init>(URL.java:541) ~[?:?]
        at java.net.URL.<init>(URL.java:488) ~[?:?]
        at fi.nls.oskari.util.IOHelper.getConnection(IOHelper.java:330) ~[service-base-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
        at fi.nls.oskari.util.IOHelper.getConnection(IOHelper.java:346) ~[service-base-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
        at fi.nls.oskari.control.layer.GetLayerTileHandler.getConnection(GetLayerTileHandler.java:259) ~[control-base-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]