### PR TITLE
GeoTools downgrade to 24.2

### DIFF
--- a/geotools-ext/gt-mif/src/main/java/org/geotools/mif/MIFDataStoreFactory.java
+++ b/geotools-ext/gt-mif/src/main/java/org/geotools/mif/MIFDataStoreFactory.java
@@ -3,6 +3,7 @@ package org.geotools.mif;
 import java.awt.RenderingHints.Key;
 import java.io.File;
 import java.io.IOException;
+import java.io.Serializable;
 import java.net.URL;
 import java.util.Collections;
 import java.util.Map;
@@ -51,7 +52,7 @@ public class MIFDataStoreFactory implements DataStoreFactorySpi {
     }
 
     @Override
-    public boolean canProcess(Map<String, ?> params) {
+    public boolean canProcess(Map<String, Serializable> params) {
         try {
             URL url = (URL) MIF_FILE_PARAM.lookUp(params);
             if (url == null) {
@@ -84,7 +85,7 @@ public class MIFDataStoreFactory implements DataStoreFactorySpi {
     }
 
     @Override
-    public DataStore createDataStore(Map<String, ?> params) throws IOException {
+    public DataStore createDataStore(Map<String, Serializable> params) throws IOException {
         URL url = (URL) MIF_FILE_PARAM.lookUp(params);
         String crs = (String) CRS_PARAM.lookUp(params);
         File mif = URLs.urlToFile(url);
@@ -113,7 +114,7 @@ public class MIFDataStoreFactory implements DataStoreFactorySpi {
     }
 
     @Override
-    public DataStore createNewDataStore(Map<String, ?> params) throws IOException {
+    public DataStore createNewDataStore(Map<String, Serializable> params) throws IOException {
         throw new UnsupportedOperationException("MIF Datastore is read only");
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -92,8 +92,8 @@
         <jedis.version>3.5.1</jedis.version>
         <quartz-scheduler.version>2.3.2</quartz-scheduler.version>
 
-        <geotools.version>25.0</geotools.version>
-        <jts.version>1.18.1</jts.version>
+        <geotools.version>24.2</geotools.version>
+        <jts.version>1.17.1</jts.version>
         <mvt.version>3.1.0</mvt.version>
         <flexjson.version>2.0</flexjson.version>
 


### PR DESCRIPTION
GeoTools 25.0 has new HTTPClientFinder which causes UnsupportedOperationException when WFSDataStoreFactory.getHttpClient is called and system property http.proxyHost is set. Downgrading GeoTools to 24.2 fixes the issue with fetching WFS layer capabilities.