### PR TITLE
Configure NO_OP configuration to redis-session profile

### DIFF
--- a/servlet-map/src/main/java/fi/nls/oskari/spring/session/RedisSessionsConfigElasticCache.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/spring/session/RedisSessionsConfigElasticCache.java
@@ -1,0 +1,20 @@
+package fi.nls.oskari.spring.session;
+
+import fi.nls.oskari.cache.JedisManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.session.data.redis.config.ConfigureRedisAction;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+
+@Configuration
+@Profile(RedisSessionsConfigElasticCache.PROFILE)
+public class RedisSessionsConfigElasticCache  extends WebMvcConfigurerAdapter {
+    public static final String PROFILE = "redis-aws";
+
+    @Bean
+    @Profile(JedisManager.CLUSTERED_ENV_PROFILE)
+    ConfigureRedisAction configureRedisAction() {
+        return ConfigureRedisAction.NO_OP;
+    }
+}


### PR DESCRIPTION
## Support to use secured Redis (e.g AWS ElesticCache)

In a secured Redis environment, the CONFIG command is disabled. This means that Spring Session cannot configure Redis Keyspace events for you.  When Oskari is started environment where secured Redis is in use, application server cannot start because following  error come:  `redis.clients.jedis.exceptions.JedisDataException: ERR unknown command 'CONFIG'` .

This PR adds new `redis-aws` profile whitch disables automatic configuration for `redis-session` profile.

## Usage
Add `redis-aws` profile to oskari-ext.properties -file, also `redis-session` session profile needed there.
```
oskari.profiles=redis-session, redis-aws
```

## Testing

### Securing Redis

You can test secured redis environment following way:
- locate your redis configuration file, edit it or make new copy
- add `rename-command CONFIG ""` line there (disables CONFIG command in redis)
- run redis-server: `redis-server <configuration-file>`

### Test without `redis-aws` profile

Start application server without `oskari.profiles=redis-aws` configuration, 
error `ERR unknown command 'CONFIG'` appears in the log.

### Test within `redis-aws` profile

Start application server within `oskari.profiles=redis-session, redis-aws` configuration, 
application server start correctly.