### PR TITLE
Legend url fixes

### DIFF
--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
@@ -237,9 +237,11 @@ public class LayerJSONFormatter {
             } else if (!globalLegend.isEmpty()) {
                 legend = globalLegend;
             }
-            boolean secureUrl = legend.toLowerCase().startsWith("https://") || legend.startsWith("/");
-            if((!secureUrl && isSecure) || useProxy(layer)) {
-                legend = buildLegendUrl(layer, name);
+            if (!legend.isEmpty()) {
+                boolean secureUrl = legend.toLowerCase().startsWith("https://") || legend.startsWith("/");
+                if ((!secureUrl && isSecure) || useProxy(layer)) {
+                    legend = buildLegendUrl(layer, name);
+                }
             }
             styles.put(createStylesJSON(name, title, legend));
         }

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWMTS.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWMTS.java
@@ -1,5 +1,7 @@
 package fi.nls.oskari.map.layer.formatters;
 
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.wms.WMSStyle;
 import fi.nls.oskari.wmts.domain.WMTSCapabilities;
 
@@ -16,6 +18,7 @@ import java.util.*;
 import static fi.nls.oskari.service.capabilities.CapabilitiesConstants.*;
 
 public class LayerJSONFormatterWMTS extends LayerJSONFormatter {
+    private static Logger log = LogFactory.getLogger(LayerJSONFormatterWMTS.class);
 
     public JSONObject getJSON(OskariLayer layer,
                               final String lang,
@@ -35,10 +38,11 @@ public class LayerJSONFormatterWMTS extends LayerJSONFormatter {
             styleName = "default";
         }
         JSONHelper.putValue(layerJson, "style", styleName);
-        JSONArray styles = new JSONArray();
-        // currently supporting only one style (default style)
-        styles.put(createStylesJSON(styleName, styleName, null));
-        JSONHelper.putValue(layerJson, "styles", styles);
+        try {
+            JSONHelper.putValue(layerJson, KEY_STYLES, createStylesJSON(layer, isSecure));
+        } catch (Exception e) {
+            log.warn(e, "Populating layer styles failed for id: " + layer.getId());
+        }
 
         // if options have urlTemplate -> use it (treat as a REST layer)
         final String urlTemplate = JSONHelper.getStringFromJSON(layer.getOptions(), "urlTemplate", null);


### PR DESCRIPTION
Don't create proxy url if legend is empty.

Create WMTS style json like WMS. Not 100% sure if this is safe way. Earlier WMTS added only default style without legend straight to json object. LayerJSONFormatter createStylesJSON uses OskariLayer (capabilities and options) and useProxy(layer) so splitting method wouldn't be pretty.
https://github.com/oskariorg/oskari-server/blob/master/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java#L218-L244

If empty styles array or name "default" or "" in styles or style (default style) causes problems then I think it should be handled more like WMS way than existing WMTS way. 
https://github.com/oskariorg/oskari-server/blob/master/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWMTS.java#L35-L41

Also createStylesJSON could do sometihing with layer.getStyle() (default style name)
