### PR TITLE
Allow OAPIF requests for properties (without geometries)

### DIFF
--- a/geotools-ext/gt-geojson/src/main/java/org/oskari/geojson/GeoJSONSchemaDetector.java
+++ b/geotools-ext/gt-geojson/src/main/java/org/oskari/geojson/GeoJSONSchemaDetector.java
@@ -69,8 +69,11 @@ public class GeoJSONSchemaDetector {
         SimpleFeatureTypeBuilder sftb = new SimpleFeatureTypeBuilder();
         sftb.setName("FeatureType");
         sftb.setNamespaceURI("http://oskari.org");
-        sftb.setDefaultGeometry(GeoJSONUtil.DEFAULT_GEOMETRY_ATTRIBUTE_NAME);
-        sftb.setCRS(crs);
+        // check if we expect request to return geometry (with properties param it might not)
+        if (bindings.containsKey(GeoJSONUtil.DEFAULT_GEOMETRY_ATTRIBUTE_NAME)) {
+            sftb.setDefaultGeometry(GeoJSONUtil.DEFAULT_GEOMETRY_ATTRIBUTE_NAME);
+            sftb.setCRS(crs);
+        }
 
         for (Map.Entry<String, Class<?>> attribute : bindings.entrySet()) {
             String name = attribute.getKey();

--- a/service-wfs3/src/main/java/org/oskari/service/wfs3/OskariWFS3Client.java
+++ b/service-wfs3/src/main/java/org/oskari/service/wfs3/OskariWFS3Client.java
@@ -111,6 +111,9 @@ public class OskariWFS3Client {
 
         String path = getItemsPath(endPoint, collectionId);
         Map<String, String> query = getQueryParams(crsURI, bbox, bboxCrsURI, hardLimit);
+        // attach any extra params added for layer (for example properties=[prop name we are interested in])
+        query.putAll(JSONHelper.getObjectAsMap(layer.getParams()));
+
         Map<String, String> headers = Collections.singletonMap("Accept", CONTENT_TYPE_GEOJSON);
 
         List<SimpleFeatureCollection> pages = new ArrayList<>();


### PR DESCRIPTION
Configuring a layer in oskari_maplayer.params with `{"properties": "id"}` will now include "properties=id" to requests for OGC API features requests. This will return the requested feature property without geometry. This can be used to optimize usage of these layers for example on scattered timeseries metadata.

Base branch is master since we might want to make 2.3.1 "hotfix" for enabling this.