### PR TITLE
Userdata parseAttributes fix

### DIFF
--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterANALYSIS.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterANALYSIS.java
@@ -82,11 +82,14 @@ public class LayerJSONFormatterANALYSIS extends LayerJSONFormatterUSERDATA {
                 // Don't add geom if some value is missing or invalid
             }
         }
-        parseAttributes(layerJson, analysis, analyseJson, lang);
+        JSONObject baseAttributes = JSONHelper.getJSONObject(layerJson, "attributes");
+        JSONObject layerAttributes = parseAttributes(analysis, analyseJson, lang);
+        // baseAttributes comes from baseLayer merge layer attributes
+        JSONHelper.putValue(layerJson, "attributes", JSONHelper.merge(baseAttributes, layerAttributes));
         return layerJson;
     }
-    private static JSONObject parseAttributes (JSONObject layerJson, Analysis analysis, JSONObject analysisJSON, String lang) {
-        JSONObject attributes = JSONHelper.getJSONObject(layerJson, "attributes");
+    private static JSONObject parseAttributes (Analysis analysis, JSONObject analysisJSON, String lang) {
+        JSONObject attributes = new JSONObject();
         JSONObject data = new JSONObject();
         JSONObject params = JSONHelper.getJSONObject(analysisJSON, JSKEY_METHODPARAMS);
         if (params != null) {

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERLAYER.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERLAYER.java
@@ -22,17 +22,18 @@ public class LayerJSONFormatterUSERLAYER extends LayerJSONFormatterUSERDATA {
         addLayerCoverageWKT(layerJson, ulayer.getWkt(), srs);
         JSONHelper.putValue(layerJson, "description", ulayer.getLayer_desc());
         JSONHelper.putValue(layerJson, "source", ulayer.getLayer_source());
-
-        parseFields(layerJson, ulayer.getFields());
-
+        JSONObject baseAttributes = JSONHelper.getJSONObject(layerJson, "attributes");
+        JSONObject layerAttributes = parseAttributes(ulayer.getFields());
+        // baseAttributes comes from baseLayer merge layer attributes
+        JSONHelper.putValue(layerJson, "attributes", JSONHelper.merge(baseAttributes, layerAttributes));
         return layerJson;
     }
     // parse fields like WFSLayerAttributes
-    private static void parseFields(JSONObject layerJson, final JSONArray fields) {
+    private static JSONObject parseAttributes(final JSONArray fields) {
+        JSONObject attributes = new JSONObject();
         if (fields == null || fields.length() == 0){
-            return;
+            return attributes;
         }
-        JSONObject attributes = JSONHelper.getJSONObject(layerJson, "attributes");
         JSONObject data = new JSONObject();
         JSONObject types = new JSONObject();
         Map<String, JSONObject> locale = new HashMap<>();
@@ -64,6 +65,6 @@ public class LayerJSONFormatterUSERLAYER extends LayerJSONFormatterUSERDATA {
         JSONObject loc = new JSONObject();
         locale.keySet().forEach(lang -> JSONHelper.putValue(loc, lang, locale.get(lang)));
         JSONHelper.putValue(data, "locale", loc);
-
+        return attributes;
     }
 }

--- a/service-map/src/test/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERLAYERTest.java
+++ b/service-map/src/test/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERLAYERTest.java
@@ -67,4 +67,23 @@ public class LayerJSONFormatterUSERLAYERTest {
         Assert.assertEquals("the_geom", data.getString("geometryName"));
         Assert.assertEquals("MultiPolygon", data.getString("geometryType"));
     }
+
+    @Test
+    public void parseAttributes() throws JSONException {
+        OskariLayer baseLayer = new OskariLayer();
+        baseLayer.getAttributes().put("namespaceURL", NAMESPACE);
+        UserLayer ulayer = new UserLayer();
+        JSONArray fields = new JSONArray(FIELDS);
+        ulayer.setFields(fields);
+        JSONObject json = FORMATTER_USERLAYER.getJSON(baseLayer, ulayer, SRS, LANG);
+        fields.remove(2);
+        JSONObject anotherJson = FORMATTER_USERLAYER.getJSON(baseLayer, ulayer, SRS, LANG);
+
+        WFSLayerAttributes attr = new WFSLayerAttributes(json.getJSONObject("attributes"));
+        WFSLayerAttributes anotherAttr = new WFSLayerAttributes(anotherJson.getJSONObject("attributes"));
+
+        Assert.assertEquals(attr.getNamespaceURL(), anotherAttr.getNamespaceURL());
+        Assert.assertEquals(2, attr.getSelectedAttributes().size());
+        Assert.assertEquals(1, anotherAttr.getSelectedAttributes().size());
+    }
 }


### PR DESCRIPTION
Userlayer and analysis LayerJSONFormatter uses attributes from layerJson which comes from base layer (max features, namespace,..). Referencing to base layer attributes caused that every layerJson object gets attributes from last layer. Fixed issue by adding merged attributes to layerJson.

Problematic reference:
https://github.com/oskariorg/oskari-server/blob/develop/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERLAYER.java#L35