### PR TITLE
Cache layerlist results

### DIFF
--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerAdminHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerAdminHandler.java
@@ -1,10 +1,12 @@
 package fi.nls.oskari.control.admin;
 
 import fi.nls.oskari.annotation.OskariActionRoute;
+import fi.nls.oskari.cache.CacheManager;
 import fi.nls.oskari.control.ActionDeniedException;
 import fi.nls.oskari.control.ActionException;
 import fi.nls.oskari.control.ActionParameters;
 import fi.nls.oskari.control.ActionParamsException;
+import fi.nls.oskari.control.layer.GetMapLayerGroupsHandler;
 import fi.nls.oskari.domain.User;
 import fi.nls.oskari.domain.map.DataProvider;
 import fi.nls.oskari.domain.map.OskariLayer;
@@ -57,6 +59,10 @@ public class LayerAdminHandler extends AbstractLayerAdminHandler {
             throw new ServiceRuntimeException("Exception occured while initializing data provider service", e);
         }
         super.init();
+    }
+
+    private void flushLayerListCache() {
+        CacheManager.getCache(GetMapLayerGroupsHandler.CACHE_NAME).flush(true);
     }
 
     /**
@@ -112,7 +118,7 @@ public class LayerAdminHandler extends AbstractLayerAdminHandler {
             // NOTE! only tell if permissions failed, this probably needs some refactoring to be useful
             output.setWarn(KEY_PERMISSIONS_FAIL);
         }
-
+        flushLayerListCache();
         writeResponse(params, output);
     }
 
@@ -135,6 +141,7 @@ public class LayerAdminHandler extends AbstractLayerAdminHandler {
                     .deleted(AuditLog.ResourceType.MAPLAYER);
 
             writeResponse(params, output);
+            flushLayerListCache();
         } catch (Exception e) {
             throw new ActionException("Couldn't delete map layer - id:" + id, e);
         }

--- a/control-base/src/main/java/fi/nls/oskari/control/layer/DataProviderHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/DataProviderHandler.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import fi.nls.oskari.cache.CacheManager;
 import org.oskari.log.AuditLog;
 import org.oskari.service.util.ServiceFactory;
 
@@ -75,8 +76,6 @@ public class DataProviderHandler extends RestActionHandler {
 	 * Method deletes data provider.
 	 * Cascade in db will handle that layers for the data provider are also deleted
 	 *
-	 * @param int id
-	 * @param ActionParameters params
 	 * @throws ActionException
 	 */
 	private void deleteDataProvider(List<OskariLayer> layers, boolean deleteLayers, int id, ActionParameters params) throws ActionException {
@@ -95,11 +94,15 @@ public class DataProviderHandler extends RestActionHandler {
 					.withParam("name", dataProvider.getName(PropertyUtil.getDefaultLanguage()))
 					.withMsg("map layers " + layerNamesToBeDeleted + " deleted with data provider" )
 					.deleted(AuditLog.ResourceType.DATAPROVIDER);
-
+			flushLayerListCache();
 			// write deleted organization as response
 			ResponseHelper.writeResponse(params, dataProvider.getAsJSON());
 		} catch (Exception e) {
 			throw new ActionException("Couldn't delete data provider with id:" + id, e);
 		}
+	}
+
+	private void flushLayerListCache() {
+		CacheManager.getCache(GetMapLayerGroupsHandler.CACHE_NAME).flush(true);
 	}
 }

--- a/control-base/src/main/java/fi/nls/oskari/control/layer/DeleteLayerHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/DeleteLayerHandler.java
@@ -1,6 +1,7 @@
 package fi.nls.oskari.control.layer;
 
 import fi.nls.oskari.annotation.OskariActionRoute;
+import fi.nls.oskari.cache.CacheManager;
 import fi.nls.oskari.cache.JedisManager;
 import fi.nls.oskari.control.*;
 import fi.nls.oskari.domain.map.OskariLayer;
@@ -38,7 +39,6 @@ public class DeleteLayerHandler extends AbstractLayerAdminHandler {
 
         try {
             mapLayerService.delete(layer.getId());
-
             AuditLog.user(params.getClientIp(), params.getUser())
                     .withParam("id", layer.getId())
                     .withParam("uiName", layer.getName(PropertyUtil.getDefaultLanguage()))
@@ -46,9 +46,13 @@ public class DeleteLayerHandler extends AbstractLayerAdminHandler {
                     .withParam("name", layer.getName())
                     .deleted(AuditLog.ResourceType.MAPLAYER);
 
+            flushLayerListCache();
         } catch (Exception e) {
             throw new ActionException("Couldn't delete map layer - id:" + layer.getId(), e);
         }
     }
 
+    private void flushLayerListCache() {
+        CacheManager.getCache(GetMapLayerGroupsHandler.CACHE_NAME).flush(true);
+    }
 }

--- a/control-base/src/main/java/fi/nls/oskari/control/layer/GetMapLayerGroupsHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/GetMapLayerGroupsHandler.java
@@ -5,9 +5,14 @@ import static fi.nls.oskari.control.ActionConstants.PARAM_LANGUAGE;
 import static fi.nls.oskari.control.ActionConstants.PARAM_SRS;
 import static fi.nls.oskari.control.ActionConstants.PARAM_ID;
 
+import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import fi.nls.oskari.cache.Cache;
+import fi.nls.oskari.cache.CacheManager;
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.map.layer.OskariLayerService;
 import fi.nls.oskari.service.OskariComponentManager;
 import fi.nls.oskari.util.ConversionHelper;
@@ -37,16 +42,21 @@ import org.oskari.service.util.ServiceFactory;
 @OskariActionRoute("GetHierarchicalMapLayerGroups")
 public class GetMapLayerGroupsHandler extends ActionHandler {
 
+    public static final String CACHE_NAME = "LayerList";
     private static final String KEY_GROUPS = "groups";
     private static final String KEY_LAYERS = "layers";
     private static final String KEY_ID = "id";
     private static final String KEY_ORDER_NUMBER = "orderNumber";
+    private static final Logger LOG = LogFactory.getLogger(GetMapLayerGroupsHandler.class);
+
 
     private static final List<String> PROXY_LYR_TYPES = Arrays.asList(
             OskariLayer.TYPE_WMS,
             OskariLayer.TYPE_WMTS,
             OskariLayer.TYPE_ARCGIS93,
             OskariLayer.TYPE_VECTOR_TILE);
+
+    private static final Cache<String> cache = CacheManager.getCache(CACHE_NAME);
 
     private OskariLayerService layerService;
     private OskariMapLayerGroupService groupService;
@@ -82,7 +92,34 @@ public class GetMapLayerGroupsHandler extends ActionHandler {
         final User user = params.getUser();
         final String lang = params.getHttpParam(PARAM_LANGUAGE, params.getLocale().getLanguage());
         final String crs = params.getHttpParam(PARAM_SRS);
-        final boolean isSecure = EnvHelper.isSecure(params);
+        final String requestedIds = params.getHttpParam(PARAM_ID);
+        final boolean forceProxy = params.getHttpParam(PARAM_FORCE_PROXY, false);
+        String response = null;
+        String cacheKey = getCacheKey(user, lang, crs, forceProxy);
+        if (requestedIds == null) {
+            // only use cache when the whole listing is requested
+            // FIXME!! Cache isn't flushed when permissions/layers are changed
+            response = cache.get(cacheKey);
+        }
+        if (response == null) {
+            // NOTE, isSecure doesn't change in instances without restarting it so it's safe to skip on the cache key
+            response = getList(user, lang, crs, requestedIds, forceProxy, EnvHelper.isSecure(params));
+            if (requestedIds == null) {
+                // only use cache when the whole listing is requested
+                cache.put(cacheKey, response);
+            }
+        }
+        try {
+            params.getResponse().setCharacterEncoding("UTF-8");
+            params.getResponse().setContentType("application/json;charset=UTF-8");
+            params.getResponse().getWriter().print(response);
+        } catch (IOException e) {
+            LOG.info("Couldn't write answer:", e.getMessage());
+            LOG.debug(e);
+        }
+    }
+
+    public String getList(User user, String lang, String crs, String requestedIds, boolean forceProxy, boolean isSecure) throws ActionException {
         final boolean isPublished = false;
 
         Map<Integer, List<MaplayerGroup>> groupsByParentId = groupService.findAll().stream()
@@ -92,8 +129,8 @@ public class GetMapLayerGroupsHandler extends ActionHandler {
                 .collect(Collectors.groupingBy(OskariLayerGroupLink::getGroupId));
 
         // Get all layers instead of using OskariLayerWorker.getLayersForUser() so we don't check permissions twice
-        List<OskariLayer> layers = getLayers(params.getHttpParam(PARAM_ID));
-        if (params.getHttpParam(PARAM_FORCE_PROXY, false)) {
+        List<OskariLayer> layers = getLayers(requestedIds);
+        if (forceProxy) {
             layers.stream()
                     .filter(layer -> PROXY_LYR_TYPES.contains(layer.getType()))
                     .forEach(layer -> layer.addAttribute("forceProxy", true));
@@ -105,7 +142,7 @@ public class GetMapLayerGroupsHandler extends ActionHandler {
             // getListOfMapLayers checks permissions
             JSONObject response = OskariLayerWorker.getListOfMapLayers(layers, user, lang, crs, isPublished, isSecure);
             response.put(KEY_GROUPS, getGroupJSON(groupsByParentId, linksByGroupId, sortedLayerIds, -1));
-            ResponseHelper.writeResponse(params, response);
+            return response.toString();
         } catch (JSONException e) {
             throw new ActionException("Failed to add groups", e);
         }
@@ -182,6 +219,21 @@ public class GetMapLayerGroupsHandler extends ActionHandler {
 
     private boolean contains(int[] sortedLayerIds, int layerId) {
         return Arrays.binarySearch(sortedLayerIds, layerId) >= 0;
+    }
+
+    private String getCacheKey(User user, String lang, String crs, boolean forceProxy) {
+        return "layers_"
+                + lang + "_"
+                + crs + "_"
+                + forceProxy + "_"
+                + getUserRolesKey(user);
+    }
+
+    private String getUserRolesKey(User user) {
+        return user.getRoles().stream()
+                .map(r -> Long.toString(r.getId()))
+                .sorted()
+                .collect(Collectors.joining("_"));
     }
 
 }

--- a/control-base/src/main/java/fi/nls/oskari/control/layer/GetMapLayerGroupsHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/GetMapLayerGroupsHandler.java
@@ -98,7 +98,7 @@ public class GetMapLayerGroupsHandler extends ActionHandler {
         String cacheKey = getCacheKey(user, lang, crs, forceProxy);
         if (requestedIds == null) {
             // only use cache when the whole listing is requested
-            // FIXME!! Cache isn't flushed when permissions/layers are changed
+            // Note! Cache needs to be flushed externally on other routes when permissions/layers are changed
             response = cache.get(cacheKey);
         }
         if (response == null) {

--- a/control-base/src/main/java/fi/nls/oskari/control/layer/SaveLayerPermissionHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/SaveLayerPermissionHandler.java
@@ -1,6 +1,7 @@
 package fi.nls.oskari.control.layer;
 
 import fi.nls.oskari.annotation.OskariActionRoute;
+import fi.nls.oskari.cache.CacheManager;
 import fi.nls.oskari.control.ActionException;
 import fi.nls.oskari.control.ActionParameters;
 import fi.nls.oskari.control.ActionParamsException;
@@ -75,6 +76,7 @@ public class SaveLayerPermissionHandler extends RestActionHandler {
             }
             // TODO: previously didn't respond at all. Should respond with updated data
             ResponseHelper.writeResponse(params, "success");
+            flushLayerListCache();
         } catch (JSONException e) {
             throw new ActionParamsException("Invalid input");
         } finally {
@@ -92,6 +94,9 @@ public class SaveLayerPermissionHandler extends RestActionHandler {
         }
     }
 
+    private void flushLayerListCache() {
+        CacheManager.getCache(GetMapLayerGroupsHandler.CACHE_NAME).flush(true);
+    }
 }
 
 

--- a/control-base/src/main/java/fi/nls/oskari/control/layer/SaveOrganizationHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/SaveOrganizationHandler.java
@@ -1,6 +1,7 @@
 package fi.nls.oskari.control.layer;
 
 import fi.nls.oskari.annotation.OskariActionRoute;
+import fi.nls.oskari.cache.CacheManager;
 import fi.nls.oskari.control.*;
 import fi.nls.oskari.domain.map.DataProvider;
 import fi.nls.oskari.log.LogFactory;
@@ -78,9 +79,13 @@ public class SaveOrganizationHandler extends RestActionHandler {
             } else {
                 throw new ActionDeniedException("Unauthorized user tried to update layer dataprovider - id=" + dataProvider.getId());
             }
-
+            flushLayerListCache();
         } catch (Exception e) {
             throw new ActionException("Couldn't update/insert map layer dataprovider", e);
         }
+    }
+
+    private void flushLayerListCache() {
+        CacheManager.getCache(GetMapLayerGroupsHandler.CACHE_NAME).flush(true);
     }
 }


### PR DESCRIPTION
If the whole layerlist is requested (most cases in geoportal) -> cache the result by lang/projection/user roles. 

On most instances the result will be the same for guest users and another set for logged in "normal users" but without caching the result is always calculated from the ground up which is expensive due to the amount of processing required especially when there are a lot of layers in the instance.

Draft towards master atm as we might want to patch this in for 2.3.x still.

Caching in GetMapLayerGroupsHandler.java. Other changes are related to flushing the cached results when admin does changes to the db.