### PR TITLE
Clean up GFI error logging

### DIFF
--- a/service-map/src/main/java/fi/nls/oskari/map/data/service/GetGeoPointDataService.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/data/service/GetGeoPointDataService.java
@@ -137,11 +137,13 @@ public class GetGeoPointDataService {
             log.debug("Calling GFI url:", url);
             HttpURLConnection conn = IOHelper.getConnection(url, user, pw);
             IOHelper.addIdentifierHeaders(conn);
+            if (conn.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
+                log.info("Nothing found on:", url);
+                return null;
+            }
             String gfiResponse = IOHelper.getURL(conn, Collections.EMPTY_MAP, IOHelper.DEFAULT_CHARSET);
             log.debug("Got GFI response:", gfiResponse);
             return gfiResponse;
-        } catch (FileNotFoundException e) {
-            log.warn("404 - message:", e.getMessage());
         } catch (IOException e) {
             log.warn("Couldn't call GFI with url:", url, "Message:", e.getMessage());
             log.debug(e, "GFI IOException");

--- a/service-map/src/main/java/fi/nls/oskari/map/data/service/GetGeoPointDataService.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/data/service/GetGeoPointDataService.java
@@ -134,7 +134,8 @@ public class GetGeoPointDataService {
         return response;
     }
 
-    private String makeGFIcall(final String url,final String user,final String pw) {
+    private String makeGFIcall(final String url, final String user, final String pw) {
+
         try {
             log.debug("Calling GFI url:", url);
             HttpURLConnection conn = IOHelper.getConnection(url, user, pw);
@@ -143,7 +144,8 @@ public class GetGeoPointDataService {
             log.debug("Got GFI response:", gfiResponse);
             return gfiResponse;
         } catch (IOException e) {
-            log.error(e, "Couldn't call GFI URL with url:", url);
+            log.warn("Couldn't call GFI with url:", url, "Message:", e.getMessage());
+            log.debug(e, "GFI IOException");
         }
         return null;
     }

--- a/service-map/src/main/java/fi/nls/oskari/map/data/service/GetGeoPointDataService.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/data/service/GetGeoPointDataService.java
@@ -22,10 +22,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.StringWriter;
-import java.io.Writer;
+import java.io.*;
 import java.net.HttpURLConnection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -143,6 +140,8 @@ public class GetGeoPointDataService {
             String gfiResponse = IOHelper.getURL(conn, Collections.EMPTY_MAP, IOHelper.DEFAULT_CHARSET);
             log.debug("Got GFI response:", gfiResponse);
             return gfiResponse;
+        } catch (FileNotFoundException e) {
+            log.warn("404 - message:", e.getMessage());
         } catch (IOException e) {
             log.warn("Couldn't call GFI with url:", url, "Message:", e.getMessage());
             log.debug(e, "GFI IOException");


### PR DESCRIPTION
Reduce logging where it's pretty common but doesn't really give any insight towards debugging. Stack trace for error is no longer logged normally but is available for logging on debug level.

Draft towards master atm as we might want to patch this in for 2.3.x still.