### PR TITLE
Add dataprovider id for map layers

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/layer/GetMapLayerGroupsHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/GetMapLayerGroupsHandler.java
@@ -15,6 +15,7 @@ import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.map.layer.DataProviderService;
 import fi.nls.oskari.map.layer.OskariLayerService;
+import fi.nls.oskari.map.layer.formatters.LayerJSONFormatter;
 import fi.nls.oskari.service.OskariComponentManager;
 import fi.nls.oskari.util.ConversionHelper;
 import fi.nls.oskari.util.JSONHelper;
@@ -35,7 +36,6 @@ import fi.nls.oskari.map.layer.group.link.OskariLayerGroupLink;
 import fi.nls.oskari.map.layer.group.link.OskariLayerGroupLinkService;
 import fi.nls.oskari.map.layer.group.link.OskariLayerGroupLinkServiceMybatisImpl;
 import fi.nls.oskari.util.EnvHelper;
-import fi.nls.oskari.util.ResponseHelper;
 import org.oskari.service.util.ServiceFactory;
 
 /**
@@ -153,7 +153,7 @@ public class GetMapLayerGroupsHandler extends ActionHandler {
             // getListOfMapLayers checks permissions
             JSONObject response = OskariLayerWorker.getListOfMapLayers(layers, user, lang, crs, isPublished, isSecure);
             response.put(KEY_GROUPS, getGroupJSON(groupsByParentId, linksByGroupId, sortedLayerIds, -1));
-            response.put(KEY_PROVIDERS, getProvidersJSON(lang));
+            response.put(KEY_PROVIDERS, getProvidersJSON(lang, getProviderIds(response)));
             return response.toString();
         } catch (JSONException e) {
             throw new ActionException("Failed to add groups", e);
@@ -216,11 +216,35 @@ public class GetMapLayerGroupsHandler extends ActionHandler {
         return json;
     }
 
-    private JSONObject getProvidersJSON(String language) {
+    /**
+     * Constructs a set of dataprovider ids that are used in the layers that will be returned to the user.
+     * FIXME: This is terrible. We need to refactor how we write this stuff for the frontend...
+     * @param response
+     * @return
+     */
+    private Set<Integer> getProviderIds(JSONObject response) {
+        Set<Integer> providerIds = new HashSet<>();
+        JSONArray layers = response.optJSONArray(OskariLayerWorker.KEY_LAYERS);
+        for (int i = 0; i < layers.length(); i++) {
+            providerIds.add(layers.optJSONObject(i).optInt(LayerJSONFormatter.KEY_DATA_PROVIDER_ID, -1));
+        }
+        return providerIds;
+    }
+    /**
+     * Constructs an object that only has provider mapping for ids included in usedProviders parameter.
+     * @param language
+     * @param usedProviders
+     * @return
+     */
+    private JSONObject getProvidersJSON(String language, Set<Integer> usedProviders) {
         JSONObject result = new JSONObject();
         dataProviderService.findAll().stream()
-                .forEach(provider ->
-                        JSONHelper.putValue(result, Integer.toString(provider.getId()), provider.getName(language)));
+                .forEach(provider -> {
+                    int id = provider.getId();
+                    if (usedProviders.contains(id)) {
+                        JSONHelper.putValue(result, Integer.toString(id), provider.getName(language));
+                    }
+                });
         return result;
     }
 

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/DataProviderService.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/DataProviderService.java
@@ -3,7 +3,6 @@ package fi.nls.oskari.map.layer;
 import fi.nls.oskari.domain.User;
 import fi.nls.oskari.domain.map.DataProvider;
 import fi.nls.oskari.service.OskariComponent;
-import org.json.JSONObject;
 
 import java.util.List;
 

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
@@ -33,6 +33,7 @@ public class LayerJSONFormatter {
     public static final String KEY_LEGENDS = "legends";
     public static final String KEY_GLOBAL_LEGEND = "legendImage";
     public static final String KEY_TYPE = "type";
+    public static final String KEY_DATA_PROVIDER_ID = "dataproviderId";
     protected static final String KEY_ID = "id";
     protected static final String KEY_NAME = "layerName"; // FIXME: name
     protected static final String KEY_LOCALIZED_NAME = "name"; // FIXME: title
@@ -40,7 +41,6 @@ public class LayerJSONFormatter {
     protected static final String KEY_OPTIONS = "options";
     protected static final String KEY_ADMIN = "admin";
     protected static final String KEY_DATA_PROVIDER = "orgName";
-    protected static final String KEY_DATA_PROVIDER_ID = "dataproviderId";
     protected static final String[] STYLE_KEYS ={"name", "title", "legend"};
 
     // There working only plain text and html so ranked up

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
@@ -40,6 +40,7 @@ public class LayerJSONFormatter {
     protected static final String KEY_OPTIONS = "options";
     protected static final String KEY_ADMIN = "admin";
     protected static final String KEY_DATA_PROVIDER = "orgName";
+    protected static final String KEY_DATA_PROVIDER_ID = "dataproviderId";
     protected static final String[] STYLE_KEYS ={"name", "title", "legend"};
 
     // There working only plain text and html so ranked up
@@ -125,6 +126,7 @@ public class LayerJSONFormatter {
         JSONHelper.putValue(layerJson, KEY_SUBTITLE, layer.getTitle(lang));
         if(layer.getGroup() != null) {
             JSONHelper.putValue(layerJson, KEY_DATA_PROVIDER, layer.getGroup().getName(lang));
+            JSONHelper.putValue(layerJson, KEY_DATA_PROVIDER_ID, layer.getGroup().getId());
         }
 
         if(layer.getOpacity() != null && layer.getOpacity() > -1 && layer.getOpacity() <= 100) {


### PR DESCRIPTION
Adds an id -> name mapping for dataproviders on layerlisting response and the dataprovider id for layers (in addition to the dataprovider name for now).

The way we need to filter out information about dataproviders that are not part of the listing is horrible, hence draft for now. I might make another ActionHandler instead that will not use OskariLayerWorker to construct the layers JSON.