### PR TITLE
MIF/MID: handle projection type codes over 2000

### DIFF
--- a/geotools-ext/gt-mif/src/main/java/org/geotools/mif/MIFHeader.java
+++ b/geotools-ext/gt-mif/src/main/java/org/geotools/mif/MIFHeader.java
@@ -180,10 +180,19 @@ public class MIFHeader {
                 int type = Integer.parseInt(parts[2]);
                 int datumId = Integer.parseInt(parts[3]);
                 // String unitname = parts[4];
+
+                // Projection numbers in the MAPINFOW.PRJ may be modified by the addition of a constant value to the
+                // base number listed in the Projection table, above. Valid values and their meanings are in the next table:
+                // 1000, System has affine transformations
+                // 2000, System has explicit bounds
+                // 3000, System with both affine and bounds
+                // -- just ignore these
+                type %= 1000;
+
                 int n = parts.length - 5;
-                double[] projectionParams = new double[n];
+                String[] projectionParams = new String[n];
                 for (int i = 0; i < n; i++) {
-                    projectionParams[i] = Double.parseDouble(parts[5 + i]);
+                    projectionParams[i] = parts[5 + i];
                 }
                 MIFProjection projection = MIFProjection.find(type);
                 MIFDatum datum = MIFDatum.find(datumId);

--- a/geotools-ext/gt-mif/src/main/java/org/geotools/mif/MIFProjection.java
+++ b/geotools-ext/gt-mif/src/main/java/org/geotools/mif/MIFProjection.java
@@ -19,24 +19,30 @@ public enum MIFProjection {
 
     WGS84(1) {
         @Override
-        public CoordinateReferenceSystem toCRS(MIFDatum datum, double[] params) throws FactoryException {
+        public CoordinateReferenceSystem toCRS(MIFDatum datum, String[] params) throws FactoryException {
             return datum.toGeographicCRS();
         }
     },
     Transverse_Mercator(8, 24) {
         @Override
-        public CoordinateReferenceSystem toCRS(MIFDatum datum, double[] params) throws FactoryException {
+        public CoordinateReferenceSystem toCRS(MIFDatum datum, String[] params) throws FactoryException {
             GeographicCRS geoCRS = datum.toGeographicCRS();
 
             CartesianCS cartCS = DefaultCartesianCS.PROJECTED;
 
+            double origin_longitude = Double.parseDouble(params[0]);
+            double origin_latitude = Double.parseDouble(params[1]);
+            double scale_factor = Double.parseDouble(params[2]);
+            double false_easting = Double.parseDouble(params[3]);
+            double false_northing = Double.parseDouble(params[4]);
+
             MathTransformFactory mtFactory = ReferencingFactoryFinder.getMathTransformFactory(null);
             ParameterValueGroup parameters = mtFactory.getDefaultParameters("Transverse_Mercator");
-            parameters.parameter("central_meridian").setValue(params[0]);
-            parameters.parameter("latitude_of_origin").setValue(params[1]);
-            parameters.parameter("scale_factor").setValue(params[2]);
-            parameters.parameter("false_easting").setValue(params[3]);
-            parameters.parameter("false_northing").setValue(params[4]);
+            parameters.parameter("central_meridian").setValue(origin_longitude);
+            parameters.parameter("latitude_of_origin").setValue(origin_latitude);
+            parameters.parameter("scale_factor").setValue(scale_factor);
+            parameters.parameter("false_easting").setValue(false_easting);
+            parameters.parameter("false_northing").setValue(false_northing);
             Conversion conversion = new DefiningConversion("Transverse_Mercator", parameters);
 
             Map<String, Object> properties = Collections.singletonMap("name", "unnamed");
@@ -63,6 +69,6 @@ public enum MIFProjection {
         return null;
     }
 
-    public abstract CoordinateReferenceSystem toCRS(MIFDatum datum, double[] params) throws FactoryException;
+    public abstract CoordinateReferenceSystem toCRS(MIFDatum datum, String[] params) throws FactoryException;
 
 }

--- a/geotools-ext/gt-mif/src/test/java/org/geotools/mif/MIFHeaderTest.java
+++ b/geotools-ext/gt-mif/src/test/java/org/geotools/mif/MIFHeaderTest.java
@@ -35,4 +35,16 @@ public class MIFHeaderTest {
         assertEquals("modify_time", header.getColumns()[i++].getName());
     }
 
+    @Test
+    public void testCoordSysWithExplicitBoundsTypeCode() throws URISyntaxException, IOException, NoSuchAuthorityCodeException, FactoryException, TransformException {
+        File mif = new File(getClass().getResource("has_explicit_bounds.mif").toURI());
+        MIFDataStore store = new MIFDataStore(mif, null);
+        MIFHeader header = store.readHeader();
+        assertEquals(750, header.getVersion());
+        assertEquals(StandardCharsets.ISO_8859_1, header.getCharset());
+        CoordinateReferenceSystem actual = header.getCoordSys();
+        CoordinateReferenceSystem expected = CRS.decode("EPSG:3067", true);
+        assertTrue(CRS.equalsIgnoreMetadata(expected, actual));
+    }
+
 }

--- a/geotools-ext/gt-mif/src/test/java/org/geotools/mif/MIFHeaderTest.java
+++ b/geotools-ext/gt-mif/src/test/java/org/geotools/mif/MIFHeaderTest.java
@@ -1,15 +1,18 @@
 package org.geotools.mif;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 
+import org.geotools.referencing.CRS;
 import org.junit.Test;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.NoSuchAuthorityCodeException;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.opengis.referencing.operation.TransformException;
 
 public class MIFHeaderTest {

--- a/geotools-ext/gt-mif/src/test/java/org/geotools/mif/MIFHeaderTest.java
+++ b/geotools-ext/gt-mif/src/test/java/org/geotools/mif/MIFHeaderTest.java
@@ -1,7 +1,7 @@
 package org.geotools.mif;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -13,6 +13,7 @@ import org.junit.Test;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.NoSuchAuthorityCodeException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.referencing.operation.MathTransform;
 import org.opengis.referencing.operation.TransformException;
 
 public class MIFHeaderTest {
@@ -46,8 +47,13 @@ public class MIFHeaderTest {
         assertEquals(750, header.getVersion());
         assertEquals(StandardCharsets.ISO_8859_1, header.getCharset());
         CoordinateReferenceSystem actual = header.getCoordSys();
-        CoordinateReferenceSystem expected = CRS.decode("EPSG:3067", true);
-        assertTrue(CRS.equalsIgnoreMetadata(expected, actual));
+        MathTransform t = CRS.findMathTransform(actual, CRS.decode("EPSG:3067", true));
+        double[] src = new double[2];
+        double[] dst = new double[2];
+        src[0] = 357517.2;
+        src[1] = 6860602.8;
+        t.transform(src, 0, dst, 0, 1);
+        assertArrayEquals(src, dst, 0.0);
     }
 
 }

--- a/geotools-ext/gt-mif/src/test/resources/org/geotools/mif/has_explicit_bounds.mif
+++ b/geotools-ext/gt-mif/src/test/resources/org/geotools/mif/has_explicit_bounds.mif
@@ -1,0 +1,13 @@
+Version   750
+Charset "WindowsLatin1"
+Delimiter ","
+CoordSys Earth Projection 2008, 115, "m", 27, 0, 0.9996, 500000, 0 Bounds (-100000, 6000000) (1000000, 8000000)
+Columns 1
+  Koeala Char(200)
+Data
+Region 1
+4
+357517.2 6860602.8
+357539.1 6860613.8
+357556.1 6860578.1
+357533.8 6860567.8


### PR DESCRIPTION
Projection codes in MapInfo software may be modified by addition of 1000 or 2000 (or both) to indicate that the used system has affine transformation parameters or explicit bounds (respectively) defined. Also not all projection codes require the same number of parameters so move logic parsing double from MIFHeader to MIFProjection.

This fixes codes over 2000 but doesn't really address Affine Transforms, which we probably have to fix sometime in the future.