### PR TITLE
WIP: Refactoring layerlisting

### DIFF
--- a/control-base/src/main/java/org/oskari/control/layer/DescribeLayerHandler.java
+++ b/control-base/src/main/java/org/oskari/control/layer/DescribeLayerHandler.java
@@ -1,38 +1,21 @@
 package org.oskari.control.layer;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import fi.nls.oskari.annotation.OskariActionRoute;
-import fi.nls.oskari.control.ActionCommonException;
 import fi.nls.oskari.control.ActionException;
 import fi.nls.oskari.control.ActionParameters;
 import fi.nls.oskari.control.RestActionHandler;
 import fi.nls.oskari.control.layer.PermissionHelper;
 import fi.nls.oskari.domain.map.OskariLayer;
-import fi.nls.oskari.log.LogFactory;
-import fi.nls.oskari.log.Logger;
-import fi.nls.oskari.map.geometry.WKTHelper;
 import fi.nls.oskari.map.layer.OskariLayerService;
-import fi.nls.oskari.map.layer.formatters.LayerJSONFormatter;
 import fi.nls.oskari.service.OskariComponentManager;
 import fi.nls.oskari.service.ServiceRuntimeException;
-import fi.nls.oskari.util.IOHelper;
-import fi.nls.oskari.util.JSONHelper;
-import fi.nls.oskari.util.PropertyUtil;
 import fi.nls.oskari.util.ResponseHelper;
-import org.json.JSONObject;
-import org.oskari.control.layer.model.LayerExtendedOutput;
 import org.oskari.control.layer.model.LayerOutput;
+import org.oskari.control.layer.util.ModelHelper;
 import org.oskari.permissions.PermissionService;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import static fi.nls.oskari.control.ActionConstants.PARAM_ID;
 import static fi.nls.oskari.control.ActionConstants.PARAM_SRS;
-import static fi.nls.oskari.domain.map.OskariLayer.PROPERTY_AJAXURL;
-import static fi.nls.oskari.service.capabilities.CapabilitiesConstants.KEY_ISQUERYABLE;
-import static fi.nls.oskari.service.capabilities.CapabilitiesConstants.KEY_VERSION;
 
 /**
  * An action route that returns metadata for layers
@@ -40,9 +23,6 @@ import static fi.nls.oskari.service.capabilities.CapabilitiesConstants.KEY_VERSI
 @OskariActionRoute("DescribeLayer")
 public class DescribeLayerHandler extends RestActionHandler {
     private PermissionHelper permissionHelper;
-    private final ObjectMapper MAPPER = new ObjectMapper();
-
-    private static final Logger LOG = LogFactory.getLogger(DescribeLayerHandler.class);
 
     @Override
     public void init() {
@@ -67,147 +47,8 @@ public class DescribeLayerHandler extends RestActionHandler {
         final int layerId = params.getRequiredParamInt(PARAM_ID);
         final OskariLayer layer = permissionHelper.getLayer(layerId, params.getUser());
         final String crs = params.getHttpParam(PARAM_SRS);
-        LayerOutput output = getLayerDetails(layer, params.getLocale().getLanguage(), crs);
+        LayerOutput output = ModelHelper.getLayerDetails(layer, params.getLocale().getLanguage(), crs);
 
-        writeResponse(params, output);
-    }
-
-    private void writeResponse(ActionParameters params, LayerOutput output) throws ActionCommonException {
-        try {
-            ResponseHelper.writeResponse(params, MAPPER.writeValueAsString(output));
-        } catch (Exception e) {
-            throw new ActionCommonException("Error writing response", e);
-        }
-    }
-
-    private LayerOutput getLayerDetails(OskariLayer layer, String lang, String crs) {
-        LayerOutput output = new LayerExtendedOutput();
-        output.id = layer.getId();
-        output.name = layer.getName();
-        output.version = layer.getVersion();
-        if (output.version == null) {
-            output.version = layer.getCapabilities().optString(KEY_VERSION);
-        }
-        if (useProxy(layer)) {
-            output.url = getProxyUrl(layer);
-        } else {
-            output.url = layer.getUrl();
-        }
-        output.type = layer.getType();
-        if (layer.isCollection()) {
-            // fixing frontend type for collection layers
-            output.type = layer.isBaseMap() ? "base" : "groupMap";
-        }
-        output.title = layer.getName(lang);
-        output.dataprovider = layer.getDataproviderId();
-        output.opacity = layer.getOpacity();
-        output.minScale = layer.getMinScale();
-        output.maxScale = layer.getMaxScale();
-        // TODO: move refreshRate & realtime to options?
-        output.refreshRate = layer.getRefreshRate();
-        output.realtime = layer.getRealtime();
-        output.baseLayerId = layer.getParentId();
-        output.options = JSONHelper.getObjectAsMap(layer.getOptions());
-        output.params = JSONHelper.getObjectAsMap(layer.getParams());
-        output.metadataId = LayerJSONFormatter.getMetadataUuid(layer);
-        output.srs = LayerJSONFormatter.getSRSs(layer.getAttributes(), layer.getCapabilities());
-        output.created = layer.getCreated();
-
-        output.sublayers = layer.getSublayers().stream()
-                .map(sublayer -> getLayerDetails(sublayer, lang, crs))
-                .collect(Collectors.toList());
-
-        // cast for convenience so it's easier to separate between base info and extended in the IDE
-        LayerExtendedOutput extended = (LayerExtendedOutput) output;
-        // extended metadata
-        extended.desc = layer.getTitle(lang);
-        extended.gfiContent = layer.getGfiContent();
-        JSONObject attributes = layer.getAttributes();
-        if (!attributes.optBoolean(LayerJSONFormatter.KEY_ATTRIBUTE_IGNORE_COVERAGE, false)) {
-            extended.coverage = getCoverageWKT(layer.getGeometry(), crs);
-        }
-        extended.attributes = JSONHelper.getObjectAsMap(attributes);
-
-        if (attributes.has(KEY_ISQUERYABLE)) {
-            // attributes can be used to force GFI for layer even if capabilities allow it or enable it not
-            extended.isQueryable = attributes.optBoolean(KEY_ISQUERYABLE);
-        } else {
-            extended.isQueryable = layer.getCapabilities().optBoolean(KEY_ISQUERYABLE);
-        }
-        return cleanupModel(extended);
-    }
-
-    /**
-     * Sets default/empty values to null so they don't get written on the JSON output
-     * @param output
-     * @return
-     */
-    private LayerOutput cleanupModel(LayerOutput output) {
-
-        if (output.opacity == 100) {
-            output.opacity = null;
-        }
-        if (output.minScale == -1) {
-            output.minScale = null;
-        }
-        if (output.maxScale == -1) {
-            output.maxScale = null;
-        }
-        if (output.refreshRate == 0) {
-            output.refreshRate = null;
-        }
-        if (output.baseLayerId == -1) {
-            output.baseLayerId = null;
-        }
-        if (!output.realtime) {
-            output.realtime = null;
-        }
-
-        output.sublayers = output.sublayers.stream()
-                .map(sublayer -> cleanupModel(sublayer))
-                .collect(Collectors.toList());
-
-        // remove style if there is only one style available?
-        if (!(output instanceof LayerExtendedOutput)) {
-            // anything beyond this point is extended so we can return early
-            return output;
-        }
-
-        // cast for convenience so it's easier to separate between base info and extended in the IDE
-        LayerExtendedOutput extended = (LayerExtendedOutput) output;
-
-        if (!extended.isQueryable) {
-            extended.isQueryable = null;
-        }
-        return extended;
-    }
-
-    protected boolean useProxy(final OskariLayer layer) {
-        boolean forceProxy = false;
-        if (layer.getAttributes() != null) {
-            forceProxy = layer.getAttributes().optBoolean("forceProxy", false);
-        }
-        return ((layer.getUsername() != null) && (layer.getUsername().length() > 0)) || forceProxy;
-    }
-
-    public String getProxyUrl(final OskariLayer layer) {
-        Map<String, String> urlParams = new HashMap<>();
-        urlParams.put("action_route", "GetLayerTile");
-        urlParams.put(LayerJSONFormatter.KEY_ID, Integer.toString(layer.getId()));
-        return IOHelper.constructUrl(PropertyUtil.get(PROPERTY_AJAXURL), urlParams);
-    }
-
-    // value will be not added if transform failed, that's ok since client can't handle it if it's in unknown projection
-    private String getCoverageWKT(final String wktWGS84, final String mapSRS) {
-        if (wktWGS84 == null || wktWGS84.isEmpty() || mapSRS == null || mapSRS.isEmpty()) {
-            return null;
-        }
-        try {
-            // WTK is saved as EPSG:4326 in database
-            return WKTHelper.transformLayerCoverage(wktWGS84, mapSRS);
-        } catch (Exception ex) {
-            LOG.debug("Error transforming coverage to", mapSRS, "from", wktWGS84);
-        }
-        return null;
+        ResponseHelper.writeResponse(params, ModelHelper.getString(output));
     }
 }

--- a/control-base/src/main/java/org/oskari/control/layer/DescribeLayerHandler.java
+++ b/control-base/src/main/java/org/oskari/control/layer/DescribeLayerHandler.java
@@ -15,15 +15,24 @@ import fi.nls.oskari.map.layer.OskariLayerService;
 import fi.nls.oskari.map.layer.formatters.LayerJSONFormatter;
 import fi.nls.oskari.service.OskariComponentManager;
 import fi.nls.oskari.service.ServiceRuntimeException;
+import fi.nls.oskari.util.IOHelper;
 import fi.nls.oskari.util.JSONHelper;
+import fi.nls.oskari.util.PropertyUtil;
 import fi.nls.oskari.util.ResponseHelper;
 import org.json.JSONObject;
 import org.oskari.control.layer.model.LayerExtendedOutput;
 import org.oskari.control.layer.model.LayerOutput;
 import org.oskari.permissions.PermissionService;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import static fi.nls.oskari.control.ActionConstants.PARAM_ID;
 import static fi.nls.oskari.control.ActionConstants.PARAM_SRS;
+import static fi.nls.oskari.domain.map.OskariLayer.PROPERTY_AJAXURL;
+import static fi.nls.oskari.service.capabilities.CapabilitiesConstants.KEY_ISQUERYABLE;
+import static fi.nls.oskari.service.capabilities.CapabilitiesConstants.KEY_VERSION;
 
 /**
  * An action route that returns metadata for layers
@@ -58,7 +67,7 @@ public class DescribeLayerHandler extends RestActionHandler {
         final int layerId = params.getRequiredParamInt(PARAM_ID);
         final OskariLayer layer = permissionHelper.getLayer(layerId, params.getUser());
         final String crs = params.getHttpParam(PARAM_SRS);
-        LayerExtendedOutput output = getLayerDetails(layer, params.getLocale().getLanguage(), crs);
+        LayerOutput output = getLayerDetails(layer, params.getLocale().getLanguage(), crs);
 
         writeResponse(params, output);
     }
@@ -71,38 +80,121 @@ public class DescribeLayerHandler extends RestActionHandler {
         }
     }
 
-    private LayerExtendedOutput getLayerDetails(OskariLayer layer, String lang, String crs) {
+    private LayerOutput getLayerDetails(OskariLayer layer, String lang, String crs) {
         LayerOutput output = new LayerExtendedOutput();
         output.id = layer.getId();
         output.name = layer.getName();
-        output.url = layer.getUrl();
+        output.version = layer.getVersion();
+        if (output.version == null) {
+            output.version = layer.getCapabilities().optString(KEY_VERSION);
+        }
+        if (useProxy(layer)) {
+            output.url = getProxyUrl(layer);
+        } else {
+            output.url = layer.getUrl();
+        }
+        output.type = layer.getType();
+        if (layer.isCollection()) {
+            // fixing frontend type for collection layers
+            output.type = layer.isBaseMap() ? "base" : "groupMap";
+        }
         output.title = layer.getName(lang);
         output.dataprovider = layer.getDataproviderId();
+        output.opacity = layer.getOpacity();
+        output.minScale = layer.getMinScale();
+        output.maxScale = layer.getMaxScale();
+        // TODO: move refreshRate & realtime to options?
+        output.refreshRate = layer.getRefreshRate();
+        output.realtime = layer.getRealtime();
+        output.baseLayerId = layer.getParentId();
         output.options = JSONHelper.getObjectAsMap(layer.getOptions());
-        if (output.options.isEmpty()) {
-            // remove empty map so it's not written to response
-            output.options = null;
-        }
         output.params = JSONHelper.getObjectAsMap(layer.getParams());
-        if (output.params.isEmpty()) {
-            // remove empty map so it's not written to response
-            output.params = null;
-        }
+        output.metadataId = LayerJSONFormatter.getMetadataUuid(layer);
+        output.srs = LayerJSONFormatter.getSRSs(layer.getAttributes(), layer.getCapabilities());
+        output.created = layer.getCreated();
+
+        output.sublayers = layer.getSublayers().stream()
+                .map(sublayer -> getLayerDetails(sublayer, lang, crs))
+                .collect(Collectors.toList());
 
         // cast for convenience so it's easier to separate between base info and extended in the IDE
         LayerExtendedOutput extended = (LayerExtendedOutput) output;
         // extended metadata
         extended.desc = layer.getTitle(lang);
+        extended.gfiContent = layer.getGfiContent();
         JSONObject attributes = layer.getAttributes();
         if (!attributes.optBoolean(LayerJSONFormatter.KEY_ATTRIBUTE_IGNORE_COVERAGE, false)) {
             extended.coverage = getCoverageWKT(layer.getGeometry(), crs);
         }
         extended.attributes = JSONHelper.getObjectAsMap(attributes);
-        if (extended.attributes.isEmpty()) {
-            // remove empty map so it's not written to response
-            extended.attributes = null;
+
+        if (attributes.has(KEY_ISQUERYABLE)) {
+            // attributes can be used to force GFI for layer even if capabilities allow it or enable it not
+            extended.isQueryable = attributes.optBoolean(KEY_ISQUERYABLE);
+        } else {
+            extended.isQueryable = layer.getCapabilities().optBoolean(KEY_ISQUERYABLE);
+        }
+        return cleanupModel(extended);
+    }
+
+    /**
+     * Sets default/empty values to null so they don't get written on the JSON output
+     * @param output
+     * @return
+     */
+    private LayerOutput cleanupModel(LayerOutput output) {
+
+        if (output.opacity == 100) {
+            output.opacity = null;
+        }
+        if (output.minScale == -1) {
+            output.minScale = null;
+        }
+        if (output.maxScale == -1) {
+            output.maxScale = null;
+        }
+        if (output.refreshRate == 0) {
+            output.refreshRate = null;
+        }
+        if (output.baseLayerId == -1) {
+            output.baseLayerId = null;
+        }
+        if (!output.realtime) {
+            output.realtime = null;
+        }
+
+        output.sublayers = output.sublayers.stream()
+                .map(sublayer -> cleanupModel(sublayer))
+                .collect(Collectors.toList());
+
+        // remove style if there is only one style available?
+        if (!(output instanceof LayerExtendedOutput)) {
+            // anything beyond this point is extended so we can return early
+            return output;
+        }
+
+        // cast for convenience so it's easier to separate between base info and extended in the IDE
+        LayerExtendedOutput extended = (LayerExtendedOutput) output;
+
+        if (!extended.isQueryable) {
+            extended.isQueryable = null;
         }
         return extended;
+    }
+
+    protected boolean useProxy(final OskariLayer layer) {
+        boolean forceProxy = false;
+        if (layer.getAttributes() != null) {
+            forceProxy = layer.getAttributes().optBoolean("forceProxy", false);
+        }
+        return ((layer.getUsername() != null) && (layer.getUsername().length() > 0)) || forceProxy;
+    }
+
+    public String getProxyUrl(final OskariLayer layer) {
+        Map<String, String> urlParams = new HashMap<>();
+        urlParams.put("action_route", "GetLayerTile");
+        urlParams.put(LayerJSONFormatter.KEY_ID, Integer.toString(layer.getId()));
+        return IOHelper.constructUrl(PropertyUtil.get(PROPERTY_AJAXURL), urlParams);
     }
 
     // value will be not added if transform failed, that's ok since client can't handle it if it's in unknown projection

--- a/control-base/src/main/java/org/oskari/control/layer/LayerListHandler.java
+++ b/control-base/src/main/java/org/oskari/control/layer/LayerListHandler.java
@@ -1,0 +1,77 @@
+package org.oskari.control.layer;
+
+import fi.mml.map.mapwindow.util.OskariLayerWorker;
+import fi.nls.oskari.annotation.OskariActionRoute;
+import fi.nls.oskari.control.ActionCommonException;
+import fi.nls.oskari.control.ActionException;
+import fi.nls.oskari.control.ActionParameters;
+import fi.nls.oskari.control.RestActionHandler;
+import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.map.layer.DataProviderService;
+import fi.nls.oskari.service.OskariComponentManager;
+import fi.nls.oskari.util.ResponseHelper;
+import org.oskari.control.layer.model.LayerListResponse;
+import org.oskari.control.layer.model.LayerOutput;
+import org.oskari.control.layer.util.ModelHelper;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * An action route that returns layers for listing
+ */
+@OskariActionRoute("LayerList")
+public class LayerListHandler extends RestActionHandler {
+
+    private static final Logger LOG = LogFactory.getLogger(LayerListHandler.class);
+
+    private DataProviderService dataProviderService;
+
+    public void setDataProviderService(DataProviderService service) {
+        this.dataProviderService = service;
+    }
+
+    @Override
+    public void init() {
+        // setup services if they haven't been initialized
+        /*
+        if (layerService == null) {
+            setLayerService(OskariComponentManager.getComponentOfType(OskariLayerService.class));
+        }
+        if (groupService == null) {
+            setGroupService(ServiceFactory.getOskariMapLayerGroupService());
+        }
+        if (linkService == null) {
+            setLinkService(new OskariLayerGroupLinkServiceMybatisImpl());
+        }
+         */
+        if (dataProviderService == null) {
+            setDataProviderService(OskariComponentManager.getComponentOfType(DataProviderService.class));
+        }
+    }
+
+    @Override
+    public void handleAction(ActionParameters params) throws ActionException {
+        String language = params.getLocale().getLanguage();
+        List<OskariLayer> layers = OskariLayerWorker.getLayersForUser(params.getUser(), false);
+        // LayerOutput[] models =
+        List<LayerOutput> models = layers.stream()
+                .map(layer -> ModelHelper.getLayerForListing(layer, language))
+                // .toArray(LayerOutput[]::new);
+                .collect(Collectors.toList());
+        LayerListResponse response = new LayerListResponse(models);
+        response.setupProviders(dataProviderService.findAll(), language);
+        // TODO: groups
+        ResponseHelper.writeResponse(params, getString(response));
+    }
+
+    public static String getString(LayerListResponse output) throws ActionException {
+        try {
+            return ModelHelper.getMapper().writeValueAsString(output);
+        } catch (Exception e) {
+            throw new ActionCommonException("Error writing response", e);
+        }
+    }
+}

--- a/control-base/src/main/java/org/oskari/control/layer/model/LayerExtendedOutput.java
+++ b/control-base/src/main/java/org/oskari/control/layer/model/LayerExtendedOutput.java
@@ -1,6 +1,13 @@
 package org.oskari.control.layer.model;
 
+import java.util.Map;
+
 public class LayerExtendedOutput extends LayerOutput {
 
     public String coverage;
+    // previously subtitle
+    public String desc;
+    // Mostly server-side flags but
+    // can include ui labels for vector feature properties etc
+    public Map<String, Object> attributes;
 }

--- a/control-base/src/main/java/org/oskari/control/layer/model/LayerExtendedOutput.java
+++ b/control-base/src/main/java/org/oskari/control/layer/model/LayerExtendedOutput.java
@@ -7,6 +7,8 @@ public class LayerExtendedOutput extends LayerOutput {
     public String coverage;
     // previously subtitle
     public String desc;
+
+    public Boolean isQueryable;
     // Mostly server-side flags but
     // can include ui labels for vector feature properties etc
     public Map<String, Object> attributes;

--- a/control-base/src/main/java/org/oskari/control/layer/model/LayerExtendedOutput.java
+++ b/control-base/src/main/java/org/oskari/control/layer/model/LayerExtendedOutput.java
@@ -1,15 +1,19 @@
 package org.oskari.control.layer.model;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class LayerExtendedOutput extends LayerOutput {
 
     public String coverage;
+    // for convenience in mapfull layers -> datasources display
+    // prefixed with _ to notify tmp nature
+    public String _dataproviderName;
     // previously subtitle
     public String desc;
 
     public Boolean isQueryable;
     // Mostly server-side flags but
     // can include ui labels for vector feature properties etc
-    public Map<String, Object> attributes;
+    public Map<String, Object> attributes = new HashMap<>();
 }

--- a/control-base/src/main/java/org/oskari/control/layer/model/LayerListResponse.java
+++ b/control-base/src/main/java/org/oskari/control/layer/model/LayerListResponse.java
@@ -1,0 +1,43 @@
+package org.oskari.control.layer.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import fi.nls.oskari.domain.map.DataProvider;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class LayerListResponse {
+
+    // TODO: groups
+    private List<LayerOutput> layers;
+    private Map<String, String> providers = new HashMap<>();
+
+    public LayerListResponse(List<LayerOutput> layers) {
+        this.layers = layers;
+    }
+
+    public void setupProviders(List<DataProvider> allProviders, String language) {
+        Set<Integer> referencedProviders = getProviderIds(layers);
+
+        allProviders.stream()
+                .forEach(provider -> {
+                    int id = provider.getId();
+                    if (referencedProviders.contains(id)) {
+                        providers.put(Integer.toString(id), provider.getName(language));
+                    }
+                });
+    }
+
+    /**
+     * Constructs a set of dataprovider ids that are used in the layers that will be returned to the user.
+     */
+    @JsonIgnore
+    private Set<Integer> getProviderIds(List<LayerOutput> models) {
+        return models.stream()
+                .map(m -> m.dataprovider)
+                .collect(Collectors.toSet());
+    }
+}

--- a/control-base/src/main/java/org/oskari/control/layer/model/LayerOutput.java
+++ b/control-base/src/main/java/org/oskari/control/layer/model/LayerOutput.java
@@ -2,10 +2,25 @@ package org.oskari.control.layer.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import java.util.Map;
+
 // only include non-nulls (==don't include nulls)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class LayerOutput {
 
     public int id;
+    // technical name
     public String name;
+    public String url;
+    // ui label for user
+    public String title;
+
+    public Integer dataprovider;
+    // additional URL-params/querystring for requests to service
+    public Map<String, Object> params;
+    // flags for controlling frontend behavior (wrapX on WMTS, singleTile on WMS etc)
+    // styles for vector features
+    // TODO: consider moving options and params to extended. They should not be needed before the layer is on the map
+    //   AND having styles in options will make the listing bigger than it needs to be
+    public Map<String, Object> options;
 }

--- a/control-base/src/main/java/org/oskari/control/layer/model/LayerOutput.java
+++ b/control-base/src/main/java/org/oskari/control/layer/model/LayerOutput.java
@@ -2,25 +2,45 @@ package org.oskari.control.layer.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
-import java.util.Map;
+import java.util.*;
 
 // only include non-nulls (==don't include nulls)
-@JsonInclude(JsonInclude.Include.NON_NULL)
+// only include lists and maps that are NOT empty
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class LayerOutput {
 
     public int id;
     // technical name
     public String name;
     public String url;
+    public String type;
+    public String version;
     // ui label for user
     public String title;
 
+    public Double minScale;
+    public Double maxScale;
+
+    public Integer opacity;
+    public Integer refreshRate;
+    public Boolean realtime;
+    public String gfiContent;
+
     public Integer dataprovider;
     // additional URL-params/querystring for requests to service
-    public Map<String, Object> params;
+    public Map<String, Object> params = new HashMap<>();
     // flags for controlling frontend behavior (wrapX on WMTS, singleTile on WMS etc)
     // styles for vector features
     // TODO: consider moving options and params to extended. They should not be needed before the layer is on the map
     //   AND having styles in options will make the listing bigger than it needs to be
-    public Map<String, Object> options;
+    public Map<String, Object> options = new HashMap<>();
+
+    public Date created;
+
+    public String metadataId;
+    public Set<String> srs;
+    // do we still need "baseLayerId" or could we just put the sublayers and determine parent for them on the frontend?
+    public Integer baseLayerId;
+    // TODO: should sublayers be in extended output?
+    public List<LayerOutput> sublayers;
 }

--- a/control-base/src/main/java/org/oskari/control/layer/model/LayerOutput.java
+++ b/control-base/src/main/java/org/oskari/control/layer/model/LayerOutput.java
@@ -11,12 +11,12 @@ public class LayerOutput {
 
     public int id;
     // technical name
-    public String name;
+    public String layer;
     public String url;
     public String type;
     public String version;
     // ui label for user
-    public String title;
+    public String name;
 
     public Double minScale;
     public Double maxScale;

--- a/control-base/src/main/java/org/oskari/control/layer/util/ModelHelper.java
+++ b/control-base/src/main/java/org/oskari/control/layer/util/ModelHelper.java
@@ -1,0 +1,220 @@
+package org.oskari.control.layer.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fi.nls.oskari.control.ActionCommonException;
+import fi.nls.oskari.control.ActionException;
+import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.map.geometry.WKTHelper;
+import fi.nls.oskari.map.layer.formatters.LayerJSONFormatter;
+import fi.nls.oskari.util.IOHelper;
+import fi.nls.oskari.util.JSONHelper;
+import fi.nls.oskari.util.PropertyUtil;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.oskari.control.layer.model.LayerExtendedOutput;
+import org.oskari.control.layer.model.LayerOutput;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static fi.nls.oskari.domain.map.OskariLayer.PROPERTY_AJAXURL;
+import static fi.nls.oskari.service.capabilities.CapabilitiesConstants.*;
+import static fi.nls.oskari.service.capabilities.CapabilitiesConstants.KEY_TIMES;
+
+/**
+ * Note! Work-in-progress - a bunch of methods have been copy-pasted from LayerJSONFormatter
+ */
+public class ModelHelper {
+    private static final Logger LOG = LogFactory.getLogger(ModelHelper.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    public static ObjectMapper getMapper() {
+        return MAPPER;
+    }
+
+    public static LayerOutput getLayerForListing(OskariLayer layer, String lang) {
+        return fillModel(new LayerOutput(), layer, lang, null);
+    }
+
+    public static LayerOutput getLayerDetails(OskariLayer layer, String lang, String crs) {
+        // cast for convenience so it's easier to separate between base info and extended in the IDE
+        LayerExtendedOutput extended = fillModel(new LayerExtendedOutput(), layer, lang, crs);
+        // extended metadata
+        extended.desc = layer.getTitle(lang);
+        extended.gfiContent = layer.getGfiContent();
+        JSONObject attributes = layer.getAttributes();
+        if (!attributes.optBoolean(LayerJSONFormatter.KEY_ATTRIBUTE_IGNORE_COVERAGE, false)) {
+            extended.coverage = getCoverageWKT(layer.getGeometry(), crs);
+        }
+        extended.attributes = getAsMap(attributes);
+        extended._dataproviderName = layer.getGroup().getName(lang);
+
+        JSONObject capabilities = layer.getCapabilities();
+        if (attributes.has(KEY_ISQUERYABLE)) {
+            // attributes can be used to force GFI for layer even if capabilities allow it or enable it not
+            extended.isQueryable = attributes.optBoolean(KEY_ISQUERYABLE);
+        } else {
+            extended.isQueryable = capabilities.optBoolean(KEY_ISQUERYABLE);
+        }
+
+        // copy time from capabilities to attributes
+        // time data is merged into attributes  (times:{start:,end:,interval:}  or times: []
+        // this is used by the timeseries functionality for construction the UI
+        if (capabilities.has(KEY_TIMES) && isTimeseriesLayer(layer)) {
+            extended.attributes.put(KEY_TIMES, getAsList(capabilities.optJSONArray(KEY_TIMES)));
+        }
+        return cleanupModel(extended);
+    }
+
+    public static String getString(LayerOutput... output) throws ActionException {
+        try {
+            return MAPPER.writeValueAsString(output);
+        } catch (Exception e) {
+            throw new ActionCommonException("Error writing response", e);
+        }
+    }
+
+    // shovel in the basic stuff
+    private static <T extends LayerOutput> T fillModel(T output, OskariLayer layer, String lang, String crs) {
+        output.id = layer.getId();
+        output.layer = layer.getName();
+        output.version = layer.getVersion();
+        if (output.version == null) {
+            output.version = layer.getCapabilities().optString(KEY_VERSION);
+        }
+        if (useProxy(layer)) {
+            output.url = getProxyUrl(layer);
+        } else {
+            output.url = layer.getUrl();
+        }
+        output.type = layer.getType();
+        if (layer.isCollection()) {
+            // fixing frontend type for collection layers
+            output.type = layer.isBaseMap() ? "base" : "groupMap";
+        }
+        output.name = layer.getName(lang);
+        output.dataprovider = layer.getDataproviderId();
+        output.opacity = layer.getOpacity();
+        output.minScale = layer.getMinScale();
+        output.maxScale = layer.getMaxScale();
+        // TODO: move refreshRate & realtime to options?
+        output.refreshRate = layer.getRefreshRate();
+        output.realtime = layer.getRealtime();
+        output.baseLayerId = layer.getParentId();
+        output.options = getAsMap(layer.getOptions());
+        output.params = getAsMap(layer.getParams());
+        output.metadataId = LayerJSONFormatter.getMetadataUuid(layer);
+        output.srs = LayerJSONFormatter.getSRSs(layer.getAttributes(), layer.getCapabilities());
+        output.created = layer.getCreated();
+        // TODO: do we want updated as well?
+
+        output.sublayers = layer.getSublayers().stream()
+                .map(sublayer -> getLayerDetails(sublayer, lang, crs))
+                .collect(Collectors.toList());
+        return output;
+    }
+
+    private static Map<String, Object> getAsMap(JSONObject obj) {
+        if (obj == null) {
+            // since JSONHelper returns an immutable map for null -> we might add to the map later so handle it here instead
+            return new HashMap<>();
+        }
+        return JSONHelper.getObjectAsMap(obj);
+    }
+
+    private static List<Object> getAsList(JSONArray obj) {
+        return JSONHelper.getArrayAsList(obj);
+    }
+
+    /**
+     * Sets default/empty values to null so they don't get written on the JSON output
+     * @param output
+     * @return
+     */
+    private static LayerOutput cleanupModel(LayerOutput output) {
+
+        if (output.opacity == 100) {
+            output.opacity = null;
+        }
+        if (output.minScale == -1) {
+            output.minScale = null;
+        }
+        if (output.maxScale == -1) {
+            output.maxScale = null;
+        }
+        if (output.refreshRate == 0) {
+            output.refreshRate = null;
+        }
+        if (output.baseLayerId == -1) {
+            output.baseLayerId = null;
+        }
+        if (!output.realtime) {
+            output.realtime = null;
+        }
+
+        output.sublayers = output.sublayers.stream()
+                .map(sublayer -> cleanupModel(sublayer))
+                .collect(Collectors.toList());
+
+        // remove style if there is only one style available?
+        if (!(output instanceof LayerExtendedOutput)) {
+            // anything beyond this point is extended so we can return early
+            return output;
+        }
+
+        // cast for convenience so it's easier to separate between base info and extended in the IDE
+        LayerExtendedOutput extended = (LayerExtendedOutput) output;
+
+        if (!extended.isQueryable) {
+            extended.isQueryable = null;
+        }
+        return extended;
+    }
+
+    protected static boolean useProxy(final OskariLayer layer) {
+        boolean forceProxy = false;
+        if (layer.getAttributes() != null) {
+            forceProxy = layer.getAttributes().optBoolean("forceProxy", false);
+        }
+        return ((layer.getUsername() != null) && (layer.getUsername().length() > 0)) || forceProxy;
+    }
+
+    public static String getProxyUrl(final OskariLayer layer) {
+        Map<String, String> urlParams = new HashMap<>();
+        urlParams.put("action_route", "GetLayerTile");
+        urlParams.put(LayerJSONFormatter.KEY_ID, Integer.toString(layer.getId()));
+        return IOHelper.constructUrl(PropertyUtil.get(PROPERTY_AJAXURL), urlParams);
+    }
+
+    // value will be not added if transform failed, that's ok since client can't handle it if it's in unknown projection
+    private static String getCoverageWKT(final String wktWGS84, final String mapSRS) {
+        if (wktWGS84 == null || wktWGS84.isEmpty() || mapSRS == null || mapSRS.isEmpty()) {
+            return null;
+        }
+        try {
+            // WTK is saved as EPSG:4326 in database
+            return WKTHelper.transformLayerCoverage(wktWGS84, mapSRS);
+        } catch (Exception ex) {
+            LOG.debug("Error transforming coverage to", mapSRS, "from", wktWGS84);
+        }
+        return null;
+    }
+
+    private static boolean isTimeseriesLayer(final OskariLayer layer) {
+        JSONObject options = layer.getOptions();
+        if(options != null && options.has("timeseries")) {
+            JSONObject timeseriesOptions = options.optJSONObject("timeseries");
+            if(timeseriesOptions != null && timeseriesOptions.has("ui")) {
+                String ui = timeseriesOptions.optString("ui");
+                if(ui != null && ui.equals("none")) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/control-base/src/test/java/org/oskari/control/layer/util/ModelHelperTest.java
+++ b/control-base/src/test/java/org/oskari/control/layer/util/ModelHelperTest.java
@@ -1,0 +1,90 @@
+package org.oskari.control.layer.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fi.mml.map.mapwindow.util.OskariLayerWorker;
+import fi.nls.oskari.domain.GuestUser;
+import fi.nls.oskari.domain.User;
+import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.util.PropertyUtil;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.oskari.control.layer.model.LayerOutput;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
+
+public class ModelHelperTest {
+
+    private final static String LANG = "en";
+    private final static String SRS = "EPSG:3857";
+    private final ObjectMapper MAPPER = new ObjectMapper();
+
+    @BeforeClass
+    public static void init() throws Exception {
+        PropertyUtil.addProperty("db.username", "oskari");
+        PropertyUtil.addProperty("db.password", "oskari");
+    }
+    @AfterClass
+    public static void teardown() throws Exception {
+        PropertyUtil.clearProperties();
+    }
+
+    /**
+     * Testing how the proposal to render layer JSON differs.
+     * Initial testing shows that:
+     * orgName -> _dataproviderName (the name is only written for mapfull to get the name for data sources popup (prefixed with _ to emphasize temp nature)
+     * created -> created type changed for value from string "2021-01-11T17:37Z" -> long 1610379427259
+     * layerName -> layer
+     *
+     * these are left out if the value is an empty object or matches the default value
+     * "realtime": false,
+     * "refreshRate": 0,
+     * "baseLayerId": -1,
+     * "permissions": {},
+     * "params": {},
+     * "subtitle": "",
+     * "styles": [],
+     * "metadataUuid": "",
+     * "opacity": 100,
+     *
+     * These are left out because they aren't used by frontend(?)
+     * "srs_name": "EPSG:3857", // should be used only when requesting/writing data by the backend
+     * "updated": "2021-01-11T18:05Z" // might be used instead of created -> need to check
+     *
+     *
+     * @throws Exception
+     */
+    @Test
+    public void getLayerDetails() throws Exception {
+        //OskariLayerService service = new OskariLayerServiceMybatisImpl();
+        //List<OskariLayer> layers = service.findAll();
+        User user = new GuestUser();
+        user.addRole(1, "Guest");
+        List<OskariLayer> layers = OskariLayerWorker.getLayersForUser(user, false);
+        JSONArray oldJSON = new JSONArray(getOldJSON(layers, user));
+        JSONArray newJSON = new JSONArray(getNewJSON(layers));
+        for (int i = 0; i < oldJSON.length(); i++) {
+            JSONObject old = oldJSON.optJSONObject(i);
+            JSONObject describe = newJSON.optJSONObject(i);
+            assertEquals(old.optString("id"), describe.optString("id"));
+            assertEquals(MAPPER.readTree(old.toString()), MAPPER.readTree(describe.toString()));
+        }
+    }
+
+    private String getOldJSON(List<OskariLayer> layers, User user) throws Exception {
+        JSONArray oldJson = OskariLayerWorker.getListOfMapLayers(layers, user, LANG, SRS, false, false).optJSONArray("layers");
+        return oldJson.toString(2);
+    }
+
+    private String getNewJSON(List<OskariLayer> layers) throws Exception {
+        List<LayerOutput> models = layers.stream()
+                .map(layer -> ModelHelper.getLayerDetails(layer, LANG, SRS))
+                .collect(Collectors.toList());
+        return MAPPER.writeValueAsString(models);
+    }
+}

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/OskariLayer.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/OskariLayer.java
@@ -73,8 +73,8 @@ public class OskariLayer extends JSONLocalizedNameAndTitle implements Comparable
     private Date created = null;
     private Date updated = null;
 
-    private Set<DataProvider> dataProviders = new HashSet<DataProvider>();
-    private List<OskariLayer> sublayers = new ArrayList<OskariLayer>();
+    private Set<DataProvider> dataProviders = new HashSet<>();
+    private List<OskariLayer> sublayers = new ArrayList<>();
 
     private Date capabilitiesLastUpdated;
     private int capabilitiesUpdateRateSec;

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
@@ -34,7 +34,7 @@ public class LayerJSONFormatter {
     public static final String KEY_GLOBAL_LEGEND = "legendImage";
     public static final String KEY_TYPE = "type";
     public static final String KEY_DATA_PROVIDER_ID = "dataproviderId";
-    protected static final String KEY_ID = "id";
+    public static final String KEY_ID = "id";
     protected static final String KEY_NAME = "layerName"; // FIXME: name
     protected static final String KEY_LOCALIZED_NAME = "name"; // FIXME: title
     protected static final String KEY_SUBTITLE = "subtitle";
@@ -242,7 +242,7 @@ public class LayerJSONFormatter {
         }
         return IOHelper.constructUrl(PropertyUtil.get(PROPERTY_AJAXURL), urlParams);
     }
-    private String getMetadataUuid (OskariLayer layer) {
+    public static String getMetadataUuid (OskariLayer layer) {
         String fixed = LayerJSONFormatter.getFixedDataUrl(layer.getMetadataId());
         if (fixed != null) {
             return fixed;
@@ -291,7 +291,7 @@ public class LayerJSONFormatter {
      * @return null iff attributes.forcedSRS and capabilities.srs are both null
      *         otherwise a Set containing both (can be empty)
      */
-    protected static Set<String> getSRSs(JSONObject attributes, JSONObject capabilities) {
+    public static Set<String> getSRSs(JSONObject attributes, JSONObject capabilities) {
         JSONArray jsonForcedSRS = attributes != null ? attributes.optJSONArray(KEY_ATTRIBUTE_FORCED_SRS): null;
         JSONArray jsonCapabilitiesSRS = capabilities != null ? capabilities.optJSONArray(KEY_SRS): null;
         if (jsonForcedSRS == null && jsonCapabilitiesSRS == null) {

--- a/service-permissions/src/main/java/org/oskari/permissions/PermissionServiceMybatisImpl.java
+++ b/service-permissions/src/main/java/org/oskari/permissions/PermissionServiceMybatisImpl.java
@@ -33,7 +33,16 @@ public class PermissionServiceMybatisImpl extends PermissionService {
     private final Cache<Resource> cache;
 
     public PermissionServiceMybatisImpl() {
-        this(DatasourceHelper.getInstance().getDataSource());
+        this(getSource());
+    }
+
+    private static DataSource getSource() {
+        final DatasourceHelper helper = DatasourceHelper.getInstance();
+        DataSource dataSource = helper.getDataSource();
+        if (dataSource != null) {
+            return dataSource;
+        }
+        return helper.createDataSource();
     }
 
     public PermissionServiceMybatisImpl(DataSource ds) {


### PR DESCRIPTION
From JSONObject to classes serialized with Jackson. Work-in-progress etc. The idea is that LayerOutput could be used for data included in listing while LayerExtendedOutput could be used to add more metadata for the listing. Similar thing is currently done for the admin-layereditor backend with https://github.com/oskariorg/oskari-server/blob/master/service-map/src/main/java/org/oskari/maplayer/model/MapLayerAdminOutput.java

Now that we have cleared out the old admin functionalities we can concentrate on what OpenLayers and the "end-user" needs for the layers instead of throwing in everything to accommodate using the same layer object for both admin and "normal" users. This would allow us to streamline OskariLayer class, possible get rid of OskariLayerWorker and make the response format easier to see from the code (improving developer experience).

We might need to work even more on reducing the output and move things around since there are some things that rely on having options or attributes for layerlisting BUT they can be a HUGE json-fragment with vector styles included etc that are _mostly_ only needed when the layer is actually added to the map (not when it's being listed for users to choose from).