### PR TITLE
Don't override search results metadata that is already filled in by the channel

### DIFF
--- a/service-search/src/main/java/fi/mml/portti/service/search/SearchResultItem.java
+++ b/service-search/src/main/java/fi/mml/portti/service/search/SearchResultItem.java
@@ -468,7 +468,11 @@ public class SearchResultItem implements Comparable<SearchResultItem>, Serializa
      * @return
      */
     public JSONObject toJSON() {
-        return toJSON(getResourceId());
+        String id = getResourceId();
+        if (id == null || id.isEmpty()) {
+            id = Long.toString(System.nanoTime());
+        }
+        return toJSON(id);
     }
 
     /**

--- a/service-search/src/main/java/fi/nls/oskari/SearchWorker.java
+++ b/service-search/src/main/java/fi/nls/oskari/SearchWorker.java
@@ -84,11 +84,10 @@ public class SearchWorker {
 
         JSONArray itemArray = new JSONArray();
 
-        int itemCount = 0;
         for (SearchResultItem sri : items) {
-            itemArray.put(sri.toJSON(itemCount++));
+            itemArray.put(sri.toJSON());
         }
-        JSONHelper.putValue(result, KEY_TOTAL_COUNT, itemCount);
+        JSONHelper.putValue(result, KEY_TOTAL_COUNT, items.size());
         JSONHelper.putValue(result, KEY_LOCATIONS, itemArray);
 
         JSONArray methodArray = new JSONArray();

--- a/service-search/src/main/java/fi/nls/oskari/search/channel/SearchChannel.java
+++ b/service-search/src/main/java/fi/nls/oskari/search/channel/SearchChannel.java
@@ -154,7 +154,10 @@ public abstract class SearchChannel extends OskariComponent implements Searchabl
             types.add(type);
             log.debug("Configurable zoom/rank for channel", getName(), "type:", type);
         }
-        item.setZoomScale(getZoomScale(type));
+        if (item.getZoomScale() == -1d) {
+            // try getting scale from common config
+            item.setZoomScale(getZoomScale(type));
+        }
         if(item.getRank() == -1) {
             item.setRank(getRank(type));
         }


### PR DESCRIPTION
While generating values for common fields on search generate id only when it's not set by the channel. Also try getting zoom scale tips from configuration only when channel has not provided any.