### PR TITLE
Match linecaps/joins and width to frontend default style

### DIFF
--- a/service-base/src/main/java/fi/nls/oskari/domain/map/wfs/WFSLayerOptions.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/wfs/WFSLayerOptions.java
@@ -133,6 +133,10 @@ public class WFSLayerOptions {
         JSONHelper.putValue(options, KEY_CLUSTER, cluster);
     }
 
+    /**
+     * Should match https://github.com/oskariorg/oskari-frontend/blob/master/src/react/components/StyleEditor/OskariDefaultStyle.js
+     * @return
+     */
     public static JSONObject getDefaultOskariStyle () {
         JSONObject json = new JSONObject();
         // dot
@@ -146,16 +150,16 @@ public class WFSLayerOptions {
         // line
         JSONObject stroke = new JSONObject();
         JSONHelper.putValue(stroke, "color", "#000000");
-        JSONHelper.putValue(stroke, "width",1);
+        JSONHelper.putValue(stroke, "width",3);
         JSONHelper.putValue(stroke, "lineDash", "solid");
-        JSONHelper.putValue(stroke, "lineCap", "butt" );
-        JSONHelper.putValue(stroke, "lineJoin", "mitre");
+        JSONHelper.putValue(stroke, "lineCap", "round" );
+        JSONHelper.putValue(stroke, "lineJoin", "round");
         // area
         JSONObject strokeArea = new JSONObject();
         JSONHelper.putValue(strokeArea, "color", "#000000");
-        JSONHelper.putValue(strokeArea, "width", 1);
+        JSONHelper.putValue(strokeArea, "width", 3);
         JSONHelper.putValue(strokeArea, "lineDash", "solid");
-        JSONHelper.putValue(strokeArea, "lineJoin", "mitre");
+        JSONHelper.putValue(strokeArea, "lineJoin", "round");
         JSONHelper.putValue(stroke, "area", strokeArea);
         JSONHelper.putValue(json, "stroke", stroke);
         JSONObject fill = new JSONObject();

--- a/service-base/src/test/java/fi/nls/oskari/domain/map/wfs/WFSLayerOptionsTest.java
+++ b/service-base/src/test/java/fi/nls/oskari/domain/map/wfs/WFSLayerOptionsTest.java
@@ -67,7 +67,7 @@ public class WFSLayerOptionsTest {
         assertTrue(defaultStyle.has("stroke"));
         assertFalse(defaultStyle.has("text"));
 
-        assertEquals("Oskari default style stroke width is 1", 1,defaultStyle.getJSONObject("stroke").getInt("width"));
+        assertEquals("Oskari default style stroke width is 3", 3,defaultStyle.getJSONObject("stroke").getInt("width"));
         assertTrue("Options should return oskari default style", JSONHelper.isEqual(defaultStyle, WFSLayerOptions.getDefaultOskariStyle()));
     }
     @Test


### PR DESCRIPTION
Sync default style settings with frontend. See oskariorg/oskari-frontend#1648