### PR TITLE
Recognize more WFS attributes as geometries

### DIFF
--- a/service-base/src/main/java/fi/nls/oskari/util/WFSConversionHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/WFSConversionHelper.java
@@ -38,7 +38,9 @@ public class WFSConversionHelper {
                 "MultiPointPropertyType",
                 "MultiLinePropertyType",
                 "MultiPolygonPropertyType",
-                "SurfacePropertyType"
+                "MultiLineStringPropertyType",
+                "SurfacePropertyType",
+                "MultiSurfacePropertyType"
             )
     );
     private static final Set<String> STRING_TYPES = new HashSet<>(Arrays.asList("string", "date", "time"));


### PR DESCRIPTION
Add support for:
- MultiLineStringPropertyType
- MultiSurfacePropertyType

Allows the new WFS action route to recognize more geometry field types as geometry.
See:
- https://github.com/oskariorg/oskari-server/blob/2.4.0/control-base/src/main/java/fi/nls/oskari/control/layer/GetWFSLayerFieldsHandler.java#L61
-> 
- https://github.com/oskariorg/oskari-server/blob/2.4.0/control-base/src/main/java/fi/nls/oskari/util/WFSGetLayerFields.java#L137

Without the change WFSLayerFields returns 
```
{
  types: {
    geom: "unknown",
    ...
  }
}
```
When recognized properly it will give
```
{
  types: {
     ... no mention of geom here
  },
  geometryName: "geom",
  geometryType: "MultiLineStringPropertyType"
}