### PR TITLE
Pass layer params to requests made by server

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/layer/GetLayerTileHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/GetLayerTileHandler.java
@@ -170,6 +170,7 @@ public class GetLayerTileHandler extends ActionHandler {
         final HttpServletRequest httpRequest = params.getRequest();
         if (OskariLayer.TYPE_WMTS.equalsIgnoreCase(layer.getType())) {
             // check for rest url
+            // TODO: look at GetLayerCapabilitiesHandler and get resource url from capabilities instead
             final String urlTemplate = JSONHelper.getStringFromJSON(layer.getOptions(), "urlTemplate", null);
             if(urlTemplate != null) {
                 LOG.debug("REST WMTS layer proxy");
@@ -262,8 +263,9 @@ public class GetLayerTileHandler extends ActionHandler {
         try {
             final String username = layer.getUsername();
             final String password = layer.getPassword();
-            LOG.debug("Getting layer tile from url:", url);
-            return IOHelper.getConnection(url, username, password);
+            String urlWithExtraParams = IOHelper.constructUrl(url, JSONHelper.getObjectAsMap(layer.getParams()));
+            LOG.debug("Getting layer tile from url:", urlWithExtraParams);
+            return IOHelper.getConnection(urlWithExtraParams, username, password);
         } catch (Exception e) {
             throw new ActionException("Couldn't get connection to service", e);
         }

--- a/service-capabilities-update/src/main/java/org/oskari/capabilities/CapabilitiesUpdateService.java
+++ b/service-capabilities-update/src/main/java/org/oskari/capabilities/CapabilitiesUpdateService.java
@@ -18,6 +18,8 @@ import fi.nls.oskari.map.layer.OskariLayerService;
 import fi.nls.oskari.service.ServiceException;
 import fi.nls.oskari.service.capabilities.CapabilitiesCacheService;
 import fi.nls.oskari.service.capabilities.OskariLayerCapabilitiesHelper;
+import fi.nls.oskari.util.IOHelper;
+import fi.nls.oskari.util.JSONHelper;
 import fi.nls.oskari.wms.WMSCapabilitiesService;
 import fi.nls.oskari.wmts.WMTSCapabilitiesParser;
 import fi.nls.oskari.wmts.domain.WMTSCapabilities;
@@ -77,11 +79,13 @@ public class CapabilitiesUpdateService {
 
     private void updateCapabilities(UrlTypeVersion utv,
             List<OskariLayer> layers, Set<String> systemCRSs, List<CapabilitiesUpdateResult> results) {
-        final String url = utv.url;
+
+        OskariLayer credentialsLayer = layers.get(0);
+        final String url = IOHelper.constructUrl(utv.url, JSONHelper.getObjectAsMap(credentialsLayer.getParams()));
         final String type = utv.type;
         final String version = utv.version;
-        final String user = layers.get(0).getUsername();
-        final String pass = layers.get(0).getPassword();
+        final String user = credentialsLayer.getUsername();
+        final String pass = credentialsLayer.getPassword();
 
         int[] ids = layers.stream().mapToInt(OskariLayer::getId).toArray();
         LOG.debug("Updating Capabilities for a group of layers - url:", url,

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
@@ -98,6 +98,7 @@ public class LayerJSONFormatter {
 
         JSONHelper.putValue(layerJson, KEY_ID, layer.getId());
 
+        boolean useProxy = useProxy(layer);
         //LOG.debug("Type", layer.getType());
         if(layer.isCollection()) {
             // fixing frontend type for collection layers
@@ -138,8 +139,10 @@ public class LayerJSONFormatter {
             JSONHelper.putValue(layerJson, "maxScale", layer.getMaxScale());
         }
         JSONObject attributes = layer.getAttributes();
-
-        JSONHelper.putValue(layerJson, "params", layer.getParams());
+        if (!useProxy) {
+            // don't write additional params for proxied urls
+            JSONHelper.putValue(layerJson, "params", layer.getParams());
+        }
         JSONHelper.putValue(layerJson, KEY_OPTIONS, layer.getOptions());
         JSONHelper.putValue(layerJson, "attributes", attributes);
 

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS110Client.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS110Client.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import fi.nls.oskari.util.JSONHelper;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.xsd.Encoder;
@@ -35,6 +36,8 @@ public class OskariWFS110Client {
         boolean tryGeoJSON = OskariWFSClient.tryGeoJSON(layer);
         int maxFeatures = OskariWFSClient.getMaxFeatures(layer);
         Map<String, String> query = getQueryParams(typeName, bbox, crs, maxFeatures, filter);
+        // attach any extra params added for layer (for example properties=[prop name we are interested in])
+        query.putAll(JSONHelper.getObjectAsMap(layer.getParams()));
         return OskariWFSClient.getFeatures(endPoint, user, pass, query, crs, tryGeoJSON, OSKARI_GML);
     }
 

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS2Client.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFS2Client.java
@@ -2,6 +2,7 @@ package org.oskari.service.wfs.client;
 
 import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.service.ServiceRuntimeException;
+import fi.nls.oskari.util.JSONHelper;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.xsd.Encoder;
@@ -34,6 +35,8 @@ public class OskariWFS2Client {
         boolean tryGeoJSON = OskariWFSClient.tryGeoJSON(layer);
         int maxFeatures = OskariWFSClient.getMaxFeatures(layer);
         Map<String, String> query = getQueryParams(typeName, bbox, crs, maxFeatures, filter);
+        // attach any extra params added for layer (for example properties=[prop name we are interested in])
+        query.putAll(JSONHelper.getObjectAsMap(layer.getParams()));
         return OskariWFSClient.getFeatures(endPoint, user, pass, query, crs, tryGeoJSON, OSKARI_GML32);
     }
 


### PR DESCRIPTION
OGC API Features client already used this so added the same for WFS 1.1.0 and 2.0.0. Added generic params addition for GetLayerTile which fixes proxying map tile requests for WMS, WMTS and MVT and legend requests. Attach params for capabilities updating as well so we can pass apikey etc for those requests as well.