### PR TITLE
Clone indicator data model for PX-web instead of passing by ref

### DIFF
--- a/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/data/StatisticalIndicatorDataDimension.java
+++ b/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/data/StatisticalIndicatorDataDimension.java
@@ -1,5 +1,6 @@
 package fi.nls.oskari.control.statistics.data;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import fi.nls.oskari.control.statistics.plugins.APIException;
 
@@ -75,7 +76,10 @@ public class StatisticalIndicatorDataDimension {
         return id;
     }
     public void setValue(String value) {
-
+        if (value == null) {
+            this.value = null;
+            return;
+        }
         if (allowedValues.contains(new IdNamePair(value))) {
             this.value = value;
         } else {
@@ -116,5 +120,13 @@ public class StatisticalIndicatorDataDimension {
             comparator = Collections.reverseOrder();
         }
         Collections.sort(allowedValues, comparator);
+    }
+
+    public StatisticalIndicatorDataDimension clone() {
+        StatisticalIndicatorDataDimension model = new StatisticalIndicatorDataDimension(id);
+        model.setName(getName());
+        getAllowedValues().forEach(pair -> model.addAllowedValue(pair.getKey(), pair.getValue()));
+        model.setValue(getValue());
+        return model;
     }
 }

--- a/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/data/StatisticalIndicatorDataModel.java
+++ b/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/data/StatisticalIndicatorDataModel.java
@@ -70,4 +70,13 @@ public class StatisticalIndicatorDataModel {
         }
         return null;
     }
+
+    @JsonIgnore
+    public StatisticalIndicatorDataModel clone() {
+        StatisticalIndicatorDataModel model = new StatisticalIndicatorDataModel();
+        model.setHasRegionInfo(hasRegionInfo);
+        model.setTimeVariable(timeVariable);
+        getDimensions().forEach(d -> model.addDimension(d.clone()));
+        return model;
+    }
 }

--- a/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/parser/PxwebIndicatorsParser.java
+++ b/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/parser/PxwebIndicatorsParser.java
@@ -276,6 +276,9 @@ public class PxwebIndicatorsParser {
             indicator.setId(createIndicatorId(table, item.getKey()));
             indicator.addName(lang, item.getValue());
             indicator.addDescription(lang, table.getTitle());
+            // clone the model since we might need to modify it based on metadata
+            //  and without cloning the indicators share the reference
+            //  making changes to one bleed over to another one
             indicator.setDataModel(selectors.clone());
             list.add(indicator);
         }

--- a/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/parser/PxwebIndicatorsParser.java
+++ b/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/parser/PxwebIndicatorsParser.java
@@ -268,7 +268,7 @@ public class PxwebIndicatorsParser {
         final StatisticalIndicatorDataModel selectors = getModel(table);
         // actual indicators list is one of the "variables"
         VariablesItem indicatorList = table.getVariable(config.getIndicatorKey());
-        if(indicatorList == null) {
+        if (indicatorList == null) {
             return list;
         }
         for(IdNamePair item: indicatorList.getLabels()) {
@@ -276,7 +276,7 @@ public class PxwebIndicatorsParser {
             indicator.setId(createIndicatorId(table, item.getKey()));
             indicator.addName(lang, item.getValue());
             indicator.addDescription(lang, table.getTitle());
-            indicator.setDataModel(selectors);
+            indicator.setDataModel(selectors.clone());
             list.add(indicator);
         }
 


### PR DESCRIPTION
Clone the indicator data model when the are parsed from the same .px ending url with indicatorKey config. Cloning is required as we might need to modify it based on the optional metadata. Without cloning the indicators share the reference and making changes to one bleeds over to another one.