### PR TITLE
Allow passing additional options for search

### DIFF
--- a/service-search/src/main/java/fi/mml/portti/service/search/SearchCriteria.java
+++ b/service-search/src/main/java/fi/mml/portti/service/search/SearchCriteria.java
@@ -1,5 +1,6 @@
 package fi.mml.portti.service.search;
 
+import fi.nls.oskari.SearchWorker;
 import fi.nls.oskari.domain.User;
 import fi.nls.oskari.service.ServiceException;
 import fi.nls.oskari.service.UserService;
@@ -147,7 +148,7 @@ public class SearchCriteria implements Serializable {
     }
 
     public void setMaxResults(int maxResults) {
-        this.maxResults = maxResults;
+        this.maxResults = SearchWorker.getMaxResults(maxResults);
     }
 
     public List<String> getChannels() {

--- a/service-search/src/main/java/fi/mml/portti/service/search/SearchService.java
+++ b/service-search/src/main/java/fi/mml/portti/service/search/SearchService.java
@@ -8,60 +8,59 @@ import org.json.JSONObject;
 
 import java.util.Map;
 
-
 /**
  * Interface to service that searches all the channels.
  */
 public abstract class SearchService extends OskariComponent {
 
-	private int maxCount = -1;
-	private int hardLimit = -1;
+    private int maxCount = -1;
+    private int hardLimit = -1;
 
-	@Override
-	public void init() {
-		super.init();
-	}
+    @Override
+    public void init() {
+        super.init();
+    }
 
-	/**
-	 * Makes a search with given criteria
-	 * 
-	 * @param searchCriteria
-	 * @return Query
-	 */
-	public abstract Query doSearch(SearchCriteria searchCriteria);
-	public abstract JSONObject doSearchAutocomplete(SearchCriteria searchCriteria);
-	public abstract void addChannel(String channelId, SearchableChannel searchableChannel);
+    /**
+     * Makes a search with given criteria
+     *
+     * @param searchCriteria
+     * @return Query
+     */
+    public abstract Query doSearch(SearchCriteria searchCriteria);
+    public abstract JSONObject doSearchAutocomplete(SearchCriteria searchCriteria);
+    public abstract void addChannel(String channelId, SearchableChannel searchableChannel);
     public abstract Map<String, SearchableChannel> getAvailableChannels();
 
-	/**
-	 * Returns a generic maximum results instruction for search functions.
-	 * SearchChannels/implementations may opt to use this to
-	 * Can be configured with search.max.results property.
-	 * Defaults to 100.
-	 * @return maxCount  - Search results max count
+    /**
+     * Returns a generic maximum results instruction for search functions.
+     * SearchChannels/implementations may opt to use this to
+     * Can be configured with search.max.results property.
+     * Defaults to 100.
+     * @return maxCount  - Search results max count
      */
-	public int getMaxResultsCount() {
-		if (maxCount == -1) {
-			maxCount = ConversionHelper.getInt(PropertyUtil.getOptional("search.max.results"), 100);
-		}
-		if (hardLimit > 0 && maxCount > hardLimit) {
-			// sanity-check limit can't be bigger than hard limit if it has been configured
-			maxCount = hardLimit;
-		}
-		return maxCount;
-	}
+    public int getMaxResultsCount() {
+        if (maxCount == -1) {
+            maxCount = ConversionHelper.getInt(PropertyUtil.getOptional("search.max.results"), 100);
+        }
+        if (hardLimit > 0 && maxCount > hardLimit) {
+            // sanity-check limit can't be bigger than hard limit if it has been configured
+            maxCount = hardLimit;
+        }
+        return maxCount;
+    }
 
-	/**
-	 * Returns instance limit for maximum results instruction for search functions.
-	 * SearchChannels/implementations may opt to use this to.
-	 * Can be configured with search.max.results.hardlimit property.
-	 * Defaults to 10x max count.
-	 * @return hard limit for search results. Client can't ask more than this
-	 */
-	public int getMaxResultsHardLimit() {
-		if (hardLimit == -1) {
-			hardLimit = ConversionHelper.getInt(PropertyUtil.getOptional("search.max.results.hardlimit"), getMaxResultsCount() * 10);
-		}
-		return hardLimit;
-	}
+    /**
+     * Returns instance limit for maximum results instruction for search functions.
+     * SearchChannels/implementations may opt to use this to.
+     * Can be configured with search.max.results.hardlimit property.
+     * Defaults to 10x max count.
+     * @return hard limit for search results. Client can't ask more than this
+     */
+    public int getMaxResultsHardLimit() {
+        if (hardLimit == -1) {
+            hardLimit = ConversionHelper.getInt(PropertyUtil.getOptional("search.max.results.hardlimit"), getMaxResultsCount() * 10);
+        }
+        return hardLimit;
+    }
 }

--- a/service-search/src/main/java/fi/mml/portti/service/search/SearchService.java
+++ b/service-search/src/main/java/fi/mml/portti/service/search/SearchService.java
@@ -15,6 +15,7 @@ import java.util.Map;
 public abstract class SearchService extends OskariComponent {
 
 	private int maxCount = -1;
+	private int hardLimit = -1;
 
 	@Override
 	public void init() {
@@ -35,12 +36,32 @@ public abstract class SearchService extends OskariComponent {
 	/**
 	 * Returns a generic maximum results instruction for search functions.
 	 * SearchChannels/implementations may opt to use this to
+	 * Can be configured with search.max.results property.
+	 * Defaults to 100.
 	 * @return maxCount  - Search results max count
      */
 	public int getMaxResultsCount() {
 		if (maxCount == -1) {
 			maxCount = ConversionHelper.getInt(PropertyUtil.getOptional("search.max.results"), 100);
 		}
+		if (hardLimit > 0 && maxCount > hardLimit) {
+			// sanity-check limit can't be bigger than hard limit if it has been configured
+			maxCount = hardLimit;
+		}
 		return maxCount;
+	}
+
+	/**
+	 * Returns instance limit for maximum results instruction for search functions.
+	 * SearchChannels/implementations may opt to use this to.
+	 * Can be configured with search.max.results.hardlimit property.
+	 * Defaults to 10x max count.
+	 * @return hard limit for search results. Client can't ask more than this
+	 */
+	public int getMaxResultsHardLimit() {
+		if (hardLimit == -1) {
+			hardLimit = ConversionHelper.getInt(PropertyUtil.getOptional("search.max.results.hardlimit"), getMaxResultsCount() * 10);
+		}
+		return hardLimit;
 	}
 }

--- a/service-search/src/main/java/fi/nls/oskari/SearchWorker.java
+++ b/service-search/src/main/java/fi/nls/oskari/SearchWorker.java
@@ -52,13 +52,23 @@ public class SearchWorker {
     }
 
     /**
+     * Returns the maximum amount of search results that should be queried.
+     * If requested is negative value, returns configured max results count.
+     * Requested count is checked against result hard limit which might be lower than the client requests
      * Returns the parameter value if it's not -1 or more than the maximum result count.
      * @param requested
      * @return maximum value of results or requested, which ever is smaller.
      */
     public static int getMaxResults(int requested) {
+        int hardLimit = searchService.getMaxResultsHardLimit();
         int maximum = searchService.getMaxResultsCount();
-        if(requested != -1 && requested < maximum) {
+        if (requested < 0) {
+            return maximum;
+        }
+        if(requested != -1) {
+            if (requested > hardLimit) {
+                return hardLimit;
+            }
             return requested;
         }
         return maximum;
@@ -71,7 +81,7 @@ public class SearchWorker {
      * @return result - Search results
      */
     public static JSONObject doSearch(final SearchCriteria sc) {
-        
+
         Query query = searchService.doSearch(sc);
         int maxResults = getMaxResults(sc.getMaxResults());
         List<SearchResultItem> items = query.getSortedResults(maxResults + 1);

--- a/service-search/src/main/java/fi/nls/oskari/SearchWorker.java
+++ b/service-search/src/main/java/fi/nls/oskari/SearchWorker.java
@@ -64,7 +64,7 @@ public class SearchWorker {
         int maximum = searchService.getMaxResultsCount();
         if (requested < 0) {
             return maximum;
-        } else if (requested > hardLimit) {
+        } else if (hardLimit > 0 && requested > hardLimit) {
             return hardLimit;
         }
         return requested;

--- a/service-search/src/main/java/fi/nls/oskari/SearchWorker.java
+++ b/service-search/src/main/java/fi/nls/oskari/SearchWorker.java
@@ -64,14 +64,10 @@ public class SearchWorker {
         int maximum = searchService.getMaxResultsCount();
         if (requested < 0) {
             return maximum;
+        } else if (requested > hardLimit) {
+            return hardLimit;
         }
-        if(requested != -1) {
-            if (requested > hardLimit) {
-                return hardLimit;
-            }
-            return requested;
-        }
-        return maximum;
+        return requested;
     }
 
     /**


### PR DESCRIPTION
And add common 'limit' option to request less or more results than instance default. The instance administrator can restrict the amount of results with a hard limit for searches. Related config in oskari-ext.properties:
```
# default limit for search results (this works like before)
search.max.results=100
# new option: hard limit for results regardless what client requests (defaults to 10x max results)
search.max.results.hardlimit=1000 
```
The parameters sent by the client are accessible in search channels so they can have special implementation specific handling based on the additional options/params.