### PR TITLE
Allow cleaner urls

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/data/SearchHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/data/SearchHandler.java
@@ -1,0 +1,8 @@
+package fi.nls.oskari.control.data;
+
+import fi.nls.oskari.annotation.OskariActionRoute;
+
+@OskariActionRoute("Search")
+public class SearchHandler extends GetSearchResultHandler {
+    // Alternative route name for search backend
+}

--- a/servlet-map/src/main/java/fi/nls/oskari/AjaxController.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/AjaxController.java
@@ -3,11 +3,11 @@ package fi.nls.oskari;
 import fi.nls.oskari.control.*;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
-import fi.nls.oskari.service.ServiceUnauthorizedException;
 import fi.nls.oskari.spring.extension.OskariParam;
 import fi.nls.oskari.util.ResponseHelper;
 import org.oskari.log.AuditLog;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -21,6 +21,12 @@ import javax.servlet.http.HttpServletResponse;
 public class AjaxController {
 
     private final static Logger log = LogFactory.getLogger(AjaxController.class);
+
+    @RequestMapping("/action/{route}")
+    @ResponseBody
+    public void handleRoute(@OskariParam ActionParameters params, @PathVariable String route) {
+        handleAction(params, route);
+    }
 
     @RequestMapping("/action")
     @ResponseBody


### PR DESCRIPTION
Small change to allow calling action handlers with `/action/[route]` instead of `/action?action_route=[route]`. And adding a parallel route for searching with `Search` in addition to the backwards compatible `GetSearchResult`.

This allows calling search with `https://domain-with-oskari/action/Search?q=finland` while still allowing the regular way of calling the same code with `https://domain-with-oskari/action?action_route=GetSearchResult&searchKey=finland`