### PR TITLE
Handle invalid layer id in timeseries metadata

### DIFF
--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerAdminHelper.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerAdminHelper.java
@@ -2,41 +2,38 @@ package fi.nls.oskari.control.admin;
 
 import fi.nls.oskari.control.ActionException;
 import fi.nls.oskari.domain.map.OskariLayer;
-import fi.nls.oskari.log.LogFactory;
-import fi.nls.oskari.log.Logger;
-import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class LayerAdminHelper {
-    private static final Logger LOG = LogFactory.getLogger(LayerAdminHelper.class);
 
     protected static Set<OskariLayer> getTimeseriesReferencedLayers(int layerId, List<OskariLayer> layers) throws ActionException {
-        Set<OskariLayer> timeseriesLayers = new HashSet<>();
-        for (OskariLayer layer : layers) {
-            JSONObject options = layer.getOptions();
-            try {
-                if (options != null && options.has("timeseries")) {
-                    JSONObject timeseriesOptions = options.getJSONObject("timeseries");
-                    JSONObject timeseriesMetadata = timeseriesOptions.optJSONObject("metadata");
-                    if (timeseriesMetadata == null) {
-                        continue;
-                    }
-                    Integer metadataLayerId = timeseriesMetadata.getInt("layer");
-                    if (metadataLayerId == layerId) {
-                        LOG.debug("Found timeseries referenced layer, layerId: " + layerId);
-                        timeseriesLayers.add(layer);
-                    }
-                }
-            } catch (JSONException e) {
-                throw new ActionException("Cannot parse layer metadata options for layer: " +
-                        layer.getName() + ", id: " + layer.getId());
-            }
+        return layers.stream()
+                .filter(it -> isReferencedByTimeseriesMetadata(layerId, it))
+                .collect(Collectors.toSet());
+    }
+
+    protected static boolean isReferencedByTimeseriesMetadata(int layerId, OskariLayer layer) {
+        JSONObject options = layer.getOptions();
+        if (options == null) {
+            return false;
         }
-        return timeseriesLayers;
+
+        JSONObject timeseriesOptions = options.optJSONObject("timeseries");
+        if (timeseriesOptions == null) {
+            return false;
+        }
+
+        JSONObject timeseriesMetadata = timeseriesOptions.optJSONObject("metadata");
+        if (timeseriesMetadata == null) {
+            return false;
+        }
+
+        int metadataLayerId = timeseriesMetadata.optInt("layer", -1);
+        return metadataLayerId == layerId;
     }
 
 }

--- a/control-admin/src/test/java/fi/nls/oskari/control/admin/LayerAdminHelperTest.java
+++ b/control-admin/src/test/java/fi/nls/oskari/control/admin/LayerAdminHelperTest.java
@@ -1,0 +1,102 @@
+package fi.nls.oskari.control.admin;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import fi.nls.oskari.domain.map.OskariLayer;
+
+public class LayerAdminHelperTest {
+
+    @Test
+    public void testNullOptions() {
+        int layerId = 1;
+
+        OskariLayer mock = Mockito.mock(OskariLayer.class);
+
+        assertFalse(LayerAdminHelper.isReferencedByTimeseriesMetadata(layerId, mock));
+    }
+
+    @Test
+    public void testEmptyOptions() {
+        int layerId = 1;
+
+        JSONObject options = new JSONObject();
+
+        OskariLayer mock = Mockito.mock(OskariLayer.class);
+        Mockito.when(mock.getOptions()).thenReturn(options);
+
+        assertFalse(LayerAdminHelper.isReferencedByTimeseriesMetadata(layerId, mock));
+    }
+
+    @Test
+    public void testLayerIsEmptyString() throws JSONException {
+        int layerId = 1;
+
+        String json = ""
+                + "{"
+                + "  'timeseries': {"
+                + "    'metadata': {"
+                + "      'layer': ''"
+                + "    },"
+                + "    'ui': 'range'"
+                + "  }"
+                + "}";
+        json = json.replace('\'', '"');
+        JSONObject options = new JSONObject(json);
+
+        OskariLayer mock = Mockito.mock(OskariLayer.class);
+        Mockito.when(mock.getOptions()).thenReturn(options);
+
+        assertFalse(LayerAdminHelper.isReferencedByTimeseriesMetadata(layerId, mock));
+    }
+
+    @Test
+    public void testValidOptionsButDifferentLayerId() throws JSONException {
+        int layerId = 1;
+
+        String json = ""
+                + "{"
+                + "  'timeseries': {"
+                + "    'metadata': {"
+                + "      'layer': 5"
+                + "    },"
+                + "    'ui': 'range'"
+                + "  }"
+                + "}";
+        json = json.replace('\'', '"');
+        JSONObject options = new JSONObject(json);
+
+        OskariLayer mock = Mockito.mock(OskariLayer.class);
+        Mockito.when(mock.getOptions()).thenReturn(options);
+
+        assertFalse(LayerAdminHelper.isReferencedByTimeseriesMetadata(layerId, mock));
+    }
+
+    @Test
+    public void testHappyCase() throws JSONException {
+        int layerId = 5;
+
+        String json = ""
+                + "{"
+                + "  'timeseries': {"
+                + "    'metadata': {"
+                + "      'layer': 5"
+                + "    },"
+                + "    'ui': 'range'"
+                + "  }"
+                + "}";
+        json = json.replace('\'', '"');
+        JSONObject options = new JSONObject(json);
+
+        OskariLayer mock = Mockito.mock(OskariLayer.class);
+        Mockito.when(mock.getOptions()).thenReturn(options);
+
+        assertTrue(LayerAdminHelper.isReferencedByTimeseriesMetadata(layerId, mock));
+    }
+
+}


### PR DESCRIPTION
Fix bug that blocks deleting any layer from an Oskari instance that has a misconfigured timeseries layer. For more information, see https://github.com/oskariorg/oskari-docs/issues/260