### PR TITLE
Update libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,14 +49,14 @@
         <!-- Value comes from profile when needed -->
         <module.build.config></module.build.config>
 
-        <spring.version>5.3.5</spring.version>
-        <spring-security.version>5.4.6</spring-security.version>
+        <spring.version>5.3.11</spring.version>
+        <spring-security.version>5.5.3</spring-security.version>
         <!--
-        session-bom 2020.0.4 uses 2.4.x from session
-        which is aligned with core 5.3.5 and security 5.4.6 versions
-        https://github.com/spring-projects/spring-session/releases/tag/2.4.3
-        https://search.maven.org/artifact/org.springframework.session/spring-session-bom/2020.0.4/pom -->
-        <spring.session.version>2020.0.4</spring.session.version>
+        session-bom 2021.0.3 uses 2.5.3 from session
+        which is aligned with core 5.3.11 and security 5.5.3 versions
+        https://github.com/spring-projects/spring-session/releases/tag/2.5.3
+        https://search.maven.org/artifact/org.springframework.session/spring-session-bom/2021.0.3/pom -->
+        <spring.session.version>2021.0.3</spring.session.version>
 
         <javax.servlet.version>3.1.0</javax.servlet.version>
         <javax.servlet.jsp.version>2.3.3</javax.servlet.jsp.version>
@@ -89,7 +89,7 @@
         <mybatis.version>3.5.7</mybatis.version>
         <flyway.version>6.5.7</flyway.version>
         <postgresql.version>42.2.16</postgresql.version>
-        <jedis.version>3.5.1</jedis.version>
+        <jedis.version>3.6.3</jedis.version>
         <quartz-scheduler.version>2.3.2</quartz-scheduler.version>
 
         <geotools.version>25.1</geotools.version>

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <xmlunit.version>1.6</xmlunit.version>
         <h2database.version>1.4.199</h2database.version>
 
-        <log4j.version>2.16.0</log4j.version>
+        <log4j.version>2.17.0</log4j.version>
         <slf4j.version>1.7.32</slf4j.version>
         <metrics.version>4.1.0</metrics.version>
         <xom.version>1.2.5</xom.version>


### PR DESCRIPTION
Restore accidentally rollbacked updates from #760 and update Log4J 2.16 -> 2.17.