### PR TITLE
Spring and Jedis updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,14 +49,14 @@
         <!-- Value comes from profile when needed -->
         <module.build.config></module.build.config>
 
-        <spring.version>5.3.11</spring.version>
-        <spring-security.version>5.5.3</spring-security.version>
+        <spring.version>5.3.14</spring.version>
+        <spring-security.version>5.6.1</spring-security.version>
         <!--
-        session-bom 2021.0.3 uses 2.5.3 from session
-        which is aligned with core 5.3.11 and security 5.5.3 versions
-        https://github.com/spring-projects/spring-session/releases/tag/2.5.3
-        https://search.maven.org/artifact/org.springframework.session/spring-session-bom/2021.0.3/pom -->
-        <spring.session.version>2021.0.3</spring.session.version>
+        session-bom 2021.1.1 uses 2.6.1 from session
+        which is aligned with core 5.3.14 and security 5.6.1 versions
+        https://github.com/spring-projects/spring-session/releases/tag/2.6.1
+        https://search.maven.org/artifact/org.springframework.session/spring-session-bom/2021.1.1/pom -->
+        <spring.session.version>2021.1.1</spring.session.version>
 
         <javax.servlet.version>3.1.0</javax.servlet.version>
         <javax.servlet.jsp.version>2.3.3</javax.servlet.jsp.version>
@@ -89,7 +89,7 @@
         <mybatis.version>3.5.7</mybatis.version>
         <flyway.version>6.5.7</flyway.version>
         <postgresql.version>42.2.16</postgresql.version>
-        <jedis.version>3.6.3</jedis.version>
+        <jedis.version>3.8.0</jedis.version>
         <quartz-scheduler.version>2.3.2</quartz-scheduler.version>
 
         <geotools.version>25.1</geotools.version>


### PR DESCRIPTION
Spring 5.3.11 -> 5.3.14
Spring Security 5.5.3 -> 5.6.1
Spring Session 2021.0.3 -> 2021.1.1
Jedis 3.6.3 -> 3.8.0

Note! Sessions serialized by older version can't be resumed after update. Sessions should be flushed from Redis before restarting the server with the new version.