### PR TITLE
Fix problems with SQL syntax caused by #787

### DIFF
--- a/service-myplaces/src/main/java/org/oskari/myplaces/service/mybatis/MyPlaceCategoryMapper.java
+++ b/service-myplaces/src/main/java/org/oskari/myplaces/service/mybatis/MyPlaceCategoryMapper.java
@@ -32,7 +32,7 @@ public interface MyPlaceCategoryMapper {
     public List<MyPlaceCategory> getByUserId(String uuid);
 
     @Insert("INSERT INTO categories (uuid, \"default\", publisher_name, category_name, options, locale)"
-            + " VALUES (#{uuid}, #{isDefault}, #{publisher_name}, #{category_name}, #{options} FORMAT JSON, #{locale} FORMAT JSON)")
+            + " VALUES (#{uuid}, #{isDefault}, #{publisher_name}, #{category_name}, CAST(#{options} as json), CAST(#{locale} as json))")
     @Options(useGeneratedKeys=true, keyColumn="id", keyProperty="id")
     public void insert(MyPlaceCategory category);
 
@@ -41,8 +41,8 @@ public interface MyPlaceCategoryMapper {
             + ",\"default\" = #{isDefault}"
             + ",publisher_name = #{publisher_name}"
             + ",category_name = #{category_name}"
-            + ",options = #{options} FORMAT JSON"
-            + ",locale = #{locale} FORMAT JSON"
+            + ",options = CAST(#{options} as json)"
+            + ",locale = CAST(#{locale} as json)"
             + " WHERE id = #{id}")
     public void update(MyPlaceCategory category);
 


### PR DESCRIPTION
Restore cast(col, json) syntax to fix problems with Postgres. Modified JSON-column adaptor for Mybatis to make an effort to decode H2 encoded JSON values before failing.