### PR TITLE
Userlayer locale name, desc and source

### DIFF
--- a/content-resources/src/main/java/flyway/userlayer/V1_0_19__source_and_desc_localization.java
+++ b/content-resources/src/main/java/flyway/userlayer/V1_0_19__source_and_desc_localization.java
@@ -1,0 +1,60 @@
+package flyway.userlayer;
+
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.util.JSONHelper;
+import fi.nls.oskari.util.PropertyUtil;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.json.JSONObject;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+/**
+ * Migrate name column to a locale JSONObject on user_layer table
+ */
+public class V1_0_19__source_and_desc_localization extends BaseJavaMigration {
+    private static final Logger LOG = LogFactory.getLogger(V1_0_19__source_and_desc_localization.class);
+    private static final String DFFAULT_LANGUAGE = PropertyUtil.getDefaultLanguage();
+
+    public void migrate(Context context) throws Exception {
+        Connection conn = context.getConnection();
+        updateLocale(conn);
+        LOG.info("Migrated user_layer table layer_source and layer_desc columns to locale with language:", DFFAULT_LANGUAGE );
+    }
+    public void updateLocale(Connection connection) throws Exception {
+        String select = "SELECT id, layer_desc, layer_source, locale::text FROM user_layer";
+        String update = "UPDATE user_layer SET locale=?::json WHERE id=?";
+
+        try (PreparedStatement psSelect = connection.prepareStatement(select);
+             ResultSet rs = psSelect.executeQuery();
+             PreparedStatement psUpdate = connection.prepareStatement(update)) {
+            while (rs.next()) {
+                long id = rs.getLong("id");
+                String desc = rs.getString("layer_desc");
+                String source = rs.getString("layer_source");
+                JSONObject locale = JSONHelper.createJSONObject(rs.getString("locale"));
+                updateDefaultLangValues(locale, desc, source);
+                psUpdate.setString(1, locale.toString());
+                psUpdate.setLong(2, id);
+                psUpdate.addBatch();
+            }
+            psUpdate.executeBatch();
+            connection.commit();
+        }
+    }
+    private void updateDefaultLangValues (JSONObject locale, String desc, String source) {
+        JSONObject values = JSONHelper.getJSONObject(locale, DFFAULT_LANGUAGE);
+        if (values == null) {
+            values = new JSONObject();
+        }
+        if (desc!= null && !desc.isEmpty()) {
+            JSONHelper.putValue(values, "desc", desc);
+        }
+        if (source !=null && !source.isEmpty()) {
+            JSONHelper.putValue(values, "source", source);
+        }
+    }
+}

--- a/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java
+++ b/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java
@@ -76,10 +76,8 @@ public class CreateUserLayerHandler extends RestActionHandler {
     };
 
     private static final String PARAM_SOURCE_EPSG_KEY = "sourceEpsg";
-    private static final String KEY_NAME = "layer-name";
-    private static final String KEY_DESC = "layer-desc";
-    private static final String KEY_SOURCE = "layer-source";
-    private static final String KEY_STYLE = "layer-style";
+    private static final String KEY_STYLE = "style";
+    private static final String KEY_LOCALE = "locale";
 
     private static final int KB = 1024;
     private static final int MB = 1024 * KB;
@@ -402,11 +400,9 @@ public class CreateUserLayerHandler extends RestActionHandler {
     }
 
     private UserLayer createUserLayer(SimpleFeatureCollection fc, String uuid, Map<String, String> formParams) {
-        String name = formParams.get(KEY_NAME);
-        String desc = formParams.get(KEY_DESC);
-        String source = formParams.get(KEY_SOURCE);
-        String style = formParams.get(KEY_STYLE);
-        return UserLayerDataService.createUserLayer(fc, uuid, name, desc, source, style);
+        JSONObject locale = JSONHelper.createJSONObject(formParams.get(KEY_LOCALE));
+        JSONObject style = JSONHelper.createJSONObject(formParams.get(KEY_STYLE));
+        return UserLayerDataService.createUserLayer(fc, uuid, locale, style);
     }
 
     private void writeResponse(ActionParameters params, UserLayer ulayer) {

--- a/control-userlayer/src/main/java/org/oskari/control/userlayer/EditUserLayerHandler.java
+++ b/control-userlayer/src/main/java/org/oskari/control/userlayer/EditUserLayerHandler.java
@@ -21,9 +21,7 @@ import org.oskari.map.userlayer.service.UserLayerException;
 @OskariActionRoute("EditUserLayer")
 public class EditUserLayerHandler extends RestActionHandler {
 
-    private static final String PARAM_DESC = "desc";
-    private static final String PARAM_NAME = "name";
-    private static final String PARAM_SOURCE = "source";
+    private static final String PARAM_LOCALE = "locale";
     private static final String PARAM_STYLE = "style";
 
     private UserLayerDbService userLayerDbService;
@@ -37,11 +35,9 @@ public class EditUserLayerHandler extends RestActionHandler {
     public void handlePost(ActionParameters params) throws ActionException {
         String mapSrs = params.getHttpParam(ActionConstants.PARAM_SRS);
         final UserLayer userLayer = UserLayerHandlerHelper.getUserLayer(userLayerDbService, params);
-        userLayer.setName(PropertyUtil.getDefaultLanguage(), params.getRequiredParam(PARAM_NAME)); // FIXME: userLayer.setLocale(locale);
-        userLayer.setLayer_desc(params.getHttpParam(PARAM_DESC, userLayer.getLayer_desc()));
-        userLayer.setLayer_source(params.getHttpParam(PARAM_SOURCE, userLayer.getLayer_source()));
+        userLayer.setLocale(params.getHttpParamAsJSON(PARAM_LOCALE));
         WFSLayerOptions wfsOptions = userLayer.getWFSLayerOptions();
-        wfsOptions.setDefaultFeatureStyle(JSONHelper.createJSONObject(params.getHttpParam(PARAM_STYLE)));
+        wfsOptions.setDefaultFeatureStyle(params.getHttpParamAsJSON(PARAM_STYLE));
         try {
             userLayerDbService.updateUserLayer(userLayer);
         } catch (UserLayerException e) {

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/UserDataLayer.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/UserDataLayer.java
@@ -7,7 +7,7 @@ import org.json.JSONObject;
 /**
  * Common model for layers consisting of user created data.
  */
-public abstract class UserDataLayer extends JSONLocalizedNameAndTitle {
+public abstract class UserDataLayer extends JSONLocalizedName {
 
     private long id;
     private String name;

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/userlayer/UserLayer.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/userlayer/UserLayer.java
@@ -1,10 +1,13 @@
 package fi.nls.oskari.domain.map.userlayer;
 
+import fi.nls.oskari.domain.map.JSONLocalizedName;
 import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.domain.map.UserDataLayer;
 import org.json.JSONArray;
 
 public class UserLayer extends UserDataLayer {
+    private static final String LOCALE_DESC = "desc";
+    private static final String LOCALE_SOURCE = "source";
 
     private String layer_desc;
     private String layer_source;
@@ -22,24 +25,23 @@ public class UserLayer extends UserDataLayer {
     public String getLayer_name() {
         return getName();
     }
-
     @Deprecated
     public void setLayer_name(String layer_name) {
         setName(layer_name);
     }
-
+    @Deprecated
     public String getLayer_desc() {
         return layer_desc;
     }
-
+    @Deprecated
     public void setLayer_desc(String layer_desc) {
         this.layer_desc = layer_desc;
     }
-
+    @Deprecated
     public String getLayer_source() {
         return layer_source;
     }
-
+    @Deprecated
     public void setLayer_source(String layer_source) {
         this.layer_source = layer_source;
     }
@@ -78,5 +80,19 @@ public class UserLayer extends UserDataLayer {
     public void setWkt(String wkt) {
         this.wkt = wkt;
     }
+
+
+    public String getDesc(final String language) {
+        return getLocalizedValue(language, LOCALE_DESC);
+    }
+    public void setDesc(final String language, final String desc) {
+        setLocalizedValue(language, LOCALE_DESC, desc);
+    }
+
+    public String getSource(final String language) {
+        return getLocalizedValue(language, LOCALE_SOURCE);
+    }
+    public void setSource(final String language, final String source) { setLocalizedValue(language, LOCALE_SOURCE, source); }
+
 
 }

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERDATA.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERDATA.java
@@ -15,6 +15,7 @@ public abstract class LayerJSONFormatterUSERDATA extends LayerJSONFormatterWFS {
 
     private static final boolean IS_SECURE = true;
     protected static final String KEY_PERMISSIONS = "permissions";
+    protected static final String KEY_LOCALE = "locale";
 
     public JSONObject getJSON(OskariLayer baseLayer, UserDataLayer layer, String srs) {
         return this.getJSON(baseLayer, layer, srs, PropertyUtil.getDefaultLanguage());

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERLAYER.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERLAYER.java
@@ -22,7 +22,6 @@ public class LayerJSONFormatterUSERLAYER extends LayerJSONFormatterUSERDATA {
     public JSONObject getJSON(final OskariLayer baseLayer, UserLayer ulayer, String srs, String lang) {
         final JSONObject layerJson = super.getJSON(baseLayer, ulayer, srs, lang);
         JSONHelper.putValue(layerJson, KEY_LAYER_COVERAGE, getLayerCoverageWKT(ulayer.getWkt(), srs));
-        JSONHelper.putValue(layerJson, KEY_LOCALE, ulayer.getLocale());
         JSONObject baseAttributes = JSONHelper.getJSONObject(layerJson, "attributes");
         JSONObject layerAttributes = parseAttributes(ulayer.getFields());
         // baseAttributes comes from baseLayer merge layer attributes

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERLAYER.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERLAYER.java
@@ -22,8 +22,7 @@ public class LayerJSONFormatterUSERLAYER extends LayerJSONFormatterUSERDATA {
     public JSONObject getJSON(final OskariLayer baseLayer, UserLayer ulayer, String srs, String lang) {
         final JSONObject layerJson = super.getJSON(baseLayer, ulayer, srs, lang);
         JSONHelper.putValue(layerJson, KEY_LAYER_COVERAGE, getLayerCoverageWKT(ulayer.getWkt(), srs));
-        JSONHelper.putValue(layerJson, "description", ulayer.getLayer_desc());
-        JSONHelper.putValue(layerJson, "source", ulayer.getLayer_source());
+        JSONHelper.putValue(layerJson, KEY_LOCALE, ulayer.getLocale());
         JSONObject baseAttributes = JSONHelper.getJSONObject(layerJson, "attributes");
         JSONObject layerAttributes = parseAttributes(ulayer.getFields());
         // baseAttributes comes from baseLayer merge layer attributes

--- a/service-userlayer/src/main/java/org/oskari/map/userlayer/service/UserLayerDataService.java
+++ b/service-userlayer/src/main/java/org/oskari/map/userlayer/service/UserLayerDataService.java
@@ -50,6 +50,7 @@ public class UserLayerDataService {
 
     private static final int USERLAYER_BASE_LAYER_ID = PropertyUtil.getOptional(USERLAYER_BASELAYER_ID, -1);
 
+    @Deprecated
     public static UserLayer createUserLayer(SimpleFeatureCollection fc,
             String uuid, String name, String desc, String source, String style) {
         final SimpleFeatureType ft = fc.getSchema();
@@ -62,6 +63,18 @@ public class UserLayerDataService {
         userLayer.setLayer_source(ConversionHelper.getString(source, ""));
         WFSLayerOptions wfsOptions = userLayer.getWFSLayerOptions();
         wfsOptions.setDefaultFeatureStyle(JSONHelper.createJSONObject(style));
+        userLayer.setFields(parseFields(ft));
+        userLayer.setWkt(getWGS84ExtentAsWKT(fc));
+        return userLayer;
+    }
+    public static UserLayer createUserLayer(SimpleFeatureCollection fc, String uuid, JSONObject locale, JSONObject style) {
+        final SimpleFeatureType ft = fc.getSchema();
+        final UserLayer userLayer = new UserLayer();
+        userLayer.setUuid(uuid);
+        userLayer.setLayer_name(ft.getTypeName());
+        userLayer.setLocale(locale);
+        WFSLayerOptions wfsOptions = userLayer.getWFSLayerOptions();
+        wfsOptions.setDefaultFeatureStyle(style);
         userLayer.setFields(parseFields(ft));
         userLayer.setWkt(getWGS84ExtentAsWKT(fc));
         return userLayer;

--- a/service-userlayer/src/main/java/org/oskari/map/userlayer/service/UserLayerDbServiceMybatisImpl.java
+++ b/service-userlayer/src/main/java/org/oskari/map/userlayer/service/UserLayerDbServiceMybatisImpl.java
@@ -58,6 +58,7 @@ public class UserLayerDbServiceMybatisImpl extends UserLayerDbService {
     }
 
     public int insertUserLayerAndData(final UserLayer userLayer, final List<UserLayerData> userLayerDataList) throws UserLayerException {
+        validateUserLayer(userLayer);
         try (SqlSession session = factory.openSession(ExecutorType.BATCH)) {
             int count = 0;
             final UserLayerMapper mapper = getMapper(session);
@@ -96,6 +97,7 @@ public class UserLayerDbServiceMybatisImpl extends UserLayerDbService {
      * @param userLayer
      */
     public int updateUserLayer(final UserLayer userLayer) throws UserLayerException {
+        validateUserLayer(userLayer);
         try (SqlSession session = factory.openSession()) {
             final UserLayerMapper mapper = getMapper(session);
             int result = mapper.updateUserLayer(userLayer);
@@ -119,7 +121,11 @@ public class UserLayerDbServiceMybatisImpl extends UserLayerDbService {
         }
         return layer;
     }
-
+    private void validateUserLayer (UserLayer layer) throws UserLayerException {
+        if (layer.getNames().isEmpty()) {
+            throw new UserLayerException("Couldn't find name for userlayer", UserLayerException.ErrorType.NO_NAME);
+        }
+    }
     /**
      * Get UserLayer row  by id
      *

--- a/service-userlayer/src/main/java/org/oskari/map/userlayer/service/UserLayerException.java
+++ b/service-userlayer/src/main/java/org/oskari/map/userlayer/service/UserLayerException.java
@@ -12,7 +12,7 @@ import fi.nls.oskari.util.JSONHelper;
 public class UserLayerException extends ServiceException {
     private JSONObject options;
     private static final long serialVersionUID = 1L;
-    private static final String ERROR_KEY = "error";
+    private static final String ERROR_KEY = "errorKey";
     private static final String CAUSE_KEY = "cause";
 
     public UserLayerException(final String message, final Exception e) {

--- a/service-userlayer/src/main/java/org/oskari/map/userlayer/service/UserLayerException.java
+++ b/service-userlayer/src/main/java/org/oskari/map/userlayer/service/UserLayerException.java
@@ -79,6 +79,7 @@ public class UserLayerException extends ServiceException {
         // Error codes for frontEnd localization (error or cause)
         PARSER("parser_error"),
         NO_FILE("no_main_file"),
+        NO_NAME("no_name"),
         NO_FEATURES("no_features"),
         NO_SOURCE_EPSG("unknown_projection"),
         MULTI_MAIN("multiple_main_file"),

--- a/service-userlayer/src/main/java/org/oskari/map/userlayer/service/UserLayerException.java
+++ b/service-userlayer/src/main/java/org/oskari/map/userlayer/service/UserLayerException.java
@@ -12,7 +12,7 @@ import fi.nls.oskari.util.JSONHelper;
 public class UserLayerException extends ServiceException {
     private JSONObject options;
     private static final long serialVersionUID = 1L;
-    private static final String ERROR_KEY = "errorKey";
+    private static final String ERROR_KEY = "error";
     private static final String CAUSE_KEY = "cause";
 
     public UserLayerException(final String message, final Exception e) {


### PR DESCRIPTION
Migrage desc and source to locale with default language (name was migrated in https://github.com/oskariorg/oskari-server/pull/701).

Use locale to store values and return locale in maplayer json. Name is also returned as common to userdatalayer. Maybe return locale could be moved to common userdatalayer (and name removed) and override layer.getname in frontend.

Changed UserDataLayer to extend JSONLocalizedName because subtitle isn't used.