### PR TITLE
Bump JDBC to match zip version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <jetty.version>9.4.44.v20210927</jetty.version>
         <mybatis.version>3.5.7</mybatis.version>
         <flyway.version>6.5.7</flyway.version>
-        <postgresql.version>42.2.16</postgresql.version>
+        <postgresql.version>42.3.1</postgresql.version>
         <jedis.version>3.8.0</jedis.version>
         <quartz-scheduler.version>2.3.2</quartz-scheduler.version>
 


### PR DESCRIPTION
In https://github.com/oskariorg/sample-configs/tree/master/jetty-9/oskari-server/lib/ext

- PostgreSQL 42.2.16 -> 42.3.1