### PR TITLE
Fix null value handling in JSONHelper.getObjectAsMap()

### DIFF
--- a/service-base/src/main/java/fi/nls/oskari/util/JSONHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/JSONHelper.java
@@ -114,14 +114,18 @@ public class JSONHelper {
         while(it.hasNext()) {
             String key = (String)it.next();
             try {
-                if (obj.opt(key) instanceof JSONObject){
-                    map.put(key, (T) getObjectAsMap((JSONObject) obj.opt(key)));
+                Object value = obj.opt(key);
+                if (JSONObject.NULL.equals(value)){
+                    map.put(key, null);
                 }
-                else if (obj.opt(key) instanceof JSONArray){
-                    map.put(key, (T) getArrayAsList( (JSONArray) obj.opt(key)));
+                else if (value instanceof JSONObject){
+                    map.put(key, (T) getObjectAsMap((JSONObject) value));
+                }
+                else if (value instanceof JSONArray){
+                    map.put(key, (T) getArrayAsList( (JSONArray) value));
                 }
                 else {
-                    map.put(key, (T) obj.opt(key));
+                    map.put(key, (T) value);
                 }
             }
             catch (Exception e) {

--- a/service-base/src/test/java/fi/nls/oskari/util/JSONHelperTest.java
+++ b/service-base/src/test/java/fi/nls/oskari/util/JSONHelperTest.java
@@ -1,7 +1,11 @@
 package fi.nls.oskari.util;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import org.json.JSONObject;
 import org.junit.Test;
+
+import java.util.Map;
 
 import static org.junit.Assert.*;
 
@@ -71,65 +75,21 @@ public class JSONHelperTest {
         assertTrue("Inserting inner object should be successful", JSONHelper.putValue(obj, "inner", innerObj));
         assertEquals("JSONObject 'inner' should return innerObj", JSONHelper.getJSONObject(obj, "inner"), innerObj);
     }
-
     @Test
-    public void testGetJSONArray() throws Exception {
+    public void testNullValueForGetObjectAsMap() throws Exception {
+        String input = "{'first':'a','second':null}".replace('\'', '"');
+        JSONObject obj = JSONHelper.createJSONObject(input);
 
-    }
+        Map<String, Object> map = JSONHelper.getObjectAsMap(obj);
+        assertNull("Should have null value", map.get("second"));
 
-    @Test
-    public void testGetEmptyIfNull() throws Exception {
+        String fromJSONObject = obj.toString();
+        assertEquals("toString() should match", input, fromJSONObject);
 
-    }
-
-    @Test
-    public void testGetStringFromJSON() throws Exception {
-
-    }
-/*
-    @Test
-    public void testPutValue() throws Exception {
-
-    }
-
-    @Test
-    public void testPutValue() throws Exception {
-
-    }
-
-    @Test
-    public void testPutValue() throws Exception {
-
-    }
-
-    @Test
-    public void testPutValue() throws Exception {
-
-    }
-
-    @Test
-    public void testPutValue() throws Exception {
-
-    }
-
-    @Test
-    public void testPutValue() throws Exception {
-
-    }
-
-    @Test
-    public void testPutValue() throws Exception {
-
-    }
-*/
-    @Test
-    public void testCreateJSONArray() throws Exception {
-
-    }
-
-    @Test
-    public void testIsEqual() throws Exception {
-
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+        String fromMapByJackson = mapper.writeValueAsString(map);
+        assertEquals("Jackson output should match", input, fromMapByJackson);
     }
 
     @Test


### PR DESCRIPTION
Fixes an issue where writing the Map to JSON string through Jackson mistakenly output `null` values as empty objects because JSONObject null value is a constant Object JSONObject.NULL and not a `null` value.

Problem was that running `new ObjectMapper().writeValueAsString(JSONHelper.getObjectAsMap(JSONObject))` changed `null` values to `{}` in the output.