### PR TITLE
Add response code in log message for PXWeb

### DIFF
--- a/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/PxwebStatisticalDatasourcePlugin.java
+++ b/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/PxwebStatisticalDatasourcePlugin.java
@@ -175,8 +175,9 @@ public class PxwebStatisticalDatasourcePlugin extends StatisticalDatasourcePlugi
             final HttpURLConnection con = IOHelper.getConnection(url);
             IOHelper.writeHeader(con, IOHelper.HEADER_CONTENTTYPE, IOHelper.CONTENT_TYPE_JSON + ";  charset=utf-8");
             IOHelper.writeToConnection(con, payload.toString().getBytes(IOHelper.CHARSET_UTF8));
-            if (con.getResponseCode() != HttpURLConnection.HTTP_OK) {
-                throw new APIException("Couldn't connect to API at " + url);
+            int respCode = con.getResponseCode();
+            if (respCode != HttpURLConnection.HTTP_OK) {
+                throw new APIException("Couldn't connect to API. Got code '" + respCode + "' from " + url);
             }
             final String data = IOHelper.readString(con);
             JSONObject json = JSONHelper.createJSONObject(data);


### PR DESCRIPTION
If the API responds with non-ok answer -> attach the code in error so it's shown on the log/make debugging easier.