### PR TITLE
Send Accept header for OGC API Features services

### DIFF
--- a/service-wfs3/src/main/java/org/oskari/service/wfs3/WFS3Service.java
+++ b/service-wfs3/src/main/java/org/oskari/service/wfs3/WFS3Service.java
@@ -81,11 +81,10 @@ public class WFS3Service {
 
     private static <T> T load(String url, String user, String pass, Class<T> clazz)
             throws WFS3Exception, IOException {
-        HttpURLConnection conn = IOHelper.getConnection(url, user, pass);
         Map<String, String> headers = new HashMap<>();
         headers.put("Accept", "application/json");
-        conn = IOHelper.followRedirect(conn, user, pass, headers, 3);
-
+        HttpURLConnection conn = IOHelper.getConnection(url, user, pass, null, headers);
+        conn = IOHelper.followRedirect(conn, user, pass, null, headers, 3);
         int sc = conn.getResponseCode();
         if (sc == 200) {
             try (InputStream in = conn.getInputStream()) {


### PR DESCRIPTION
Fixes an issue with OGC API Features client not sending the intended headers for the service:
- if request was not redirected, header was not written at all
- if the request was redirected the header was changed to query params (now sends null as params and headers as the next param as that is the order IOHelper handles them)

This fixes an issue where the OGC API Features service doesn't natively respond with JSON, but can handle the format negotiation by HTTP-header.