### PR TITLE
Parse metadata UUID from capabilities

### DIFF
--- a/service-capabilities/src/main/java/org/oskari/capabilities/ogc/LayerCapabilitiesOGC.java
+++ b/service-capabilities/src/main/java/org/oskari/capabilities/ogc/LayerCapabilitiesOGC.java
@@ -1,11 +1,15 @@
 package org.oskari.capabilities.ogc;
 
+import org.oskari.capabilities.CapabilitiesService;
 import org.oskari.capabilities.LayerCapabilities;
 import java.util.Set;
 
 import static org.oskari.capabilities.ogc.CapabilitiesConstants.*;
 
 public class LayerCapabilitiesOGC extends LayerCapabilities {
+
+    public static final String METADATA_URL = "metadataUrl";
+    public static final String METADATA_UUID = "metadataId";
 
     public LayerCapabilitiesOGC(String name, String title) {
         super(name, title);
@@ -22,4 +26,10 @@ public class LayerCapabilitiesOGC extends LayerCapabilities {
         addCapabilityData(IS_QUERYABLE, !infoFormats.isEmpty());
     }
 
+    public void setMetadataUrl(String url) {
+        if (url != null) {
+            addCapabilityData(METADATA_URL, url);
+            addCapabilityData(METADATA_UUID, CapabilitiesService.getIdFromMetadataUrl(url));
+        }
+    }
 }

--- a/service-capabilities/src/main/java/org/oskari/capabilities/ogc/LayerCapabilitiesWMS.java
+++ b/service-capabilities/src/main/java/org/oskari/capabilities/ogc/LayerCapabilitiesWMS.java
@@ -16,7 +16,6 @@ public class LayerCapabilitiesWMS extends LayerCapabilitiesOGC {
     public static final String PARENT = "parent";
     public static final String MIN_SCALE = "minScale";
     public static final String MAX_SCALE = "maxScale";
-    public static final String METADATA_URL = "metadataUrl";
     public static final String TIMES = "times";
 
     public LayerCapabilitiesWMS(String name, String title) {
@@ -46,11 +45,6 @@ public class LayerCapabilitiesWMS extends LayerCapabilitiesOGC {
     public void setParent(String parent) {
         if (parent != null) {
             addCapabilityData(PARENT, parent);
-        }
-    }
-    public void setMetadataUrl(String url) {
-        if (url != null) {
-            addCapabilityData(METADATA_URL, url);
         }
     }
     public void setMinScale(String scale) {

--- a/service-capabilities/src/test/java/org/oskari/capabilities/CapabilitiesServiceTest.java
+++ b/service-capabilities/src/test/java/org/oskari/capabilities/CapabilitiesServiceTest.java
@@ -1,0 +1,29 @@
+package org.oskari.capabilities;
+
+import junit.framework.TestCase;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class CapabilitiesServiceTest extends TestCase {
+
+    @Test
+    public void testGetIdFromMetadataUrl() {
+        assertNull("Null metadata returns null id", CapabilitiesService.getIdFromMetadataUrl(null));
+        assertNull("Empty metadata returns null id", CapabilitiesService.getIdFromMetadataUrl(""));
+        assertEquals("Non http-starting metadata returns as is", "testing", CapabilitiesService.getIdFromMetadataUrl("testing"));
+        assertNull("Url without querystring returns null id", CapabilitiesService.getIdFromMetadataUrl("http://mydomain.org"));
+        assertNull("Url without id|uuid returns null id", CapabilitiesService.getIdFromMetadataUrl("http://mydomain.org?my=key"));
+        assertEquals("Url with id returns id value simple", "key", CapabilitiesService.getIdFromMetadataUrl("http://mydomain.org?uuid=key"));
+        Map<String, String> expected = new HashMap<>();
+        expected.put("http://mydomain.org?test=test&id=key&post=test", "key");
+        expected.put("http://mydomain.org?test=test&uuid=key2&post=test", "key2");
+        expected.put("http://mydomain.org?test=test&Id=key&post=test", "key");
+        expected.put("http://mydomain.org?test=test&uuId=Key&post=test", "Key");
+        for (String url : expected.keySet()) {
+            assertEquals("Url with id returns id value", expected.get(url), CapabilitiesService.getIdFromMetadataUrl(url));
+        }
+    }
+}

--- a/service-capabilities/src/test/java/org/oskari/capabilities/ogc/WMSCapabilitiesParserTest.java
+++ b/service-capabilities/src/test/java/org/oskari/capabilities/ogc/WMSCapabilitiesParserTest.java
@@ -38,7 +38,8 @@ public class WMSCapabilitiesParserTest {
         // Check and remove version as it is different on expected between 1.1.1 and 1.3.0 input
         assertEquals("Check version", WMSCapsParser1_1_1.VERSION, json.optJSONObject("typeSpecific").remove("version"));
         // Note! 1.1.1 doesn't have the metadata url
-        expectedJSON.optJSONObject("typeSpecific").remove("metadataUrl");
+        expectedJSON.optJSONObject("typeSpecific").remove(LayerCapabilitiesOGC.METADATA_URL);
+        expectedJSON.optJSONObject("typeSpecific").remove(LayerCapabilitiesOGC.METADATA_UUID);
         // System.out.println(json);
         assertTrue("JSON should match", JSONHelper.isEqual(json, expectedJSON));
 

--- a/service-capabilities/src/test/resources/org/oskari/capabilities/ogc/WMSCapabilitiesParserTest-capabilities-with-duplicated-layername-expected.json
+++ b/service-capabilities/src/test/resources/org/oskari/capabilities/ogc/WMSCapabilitiesParserTest-capabilities-with-duplicated-layername-expected.json
@@ -14,6 +14,7 @@
   "url":null,
   "typeSpecific": {
     "parent": "muinaismuistot",
+    "metadataId":"93a384df-31da-40fa-a001-2b3bb79c955c",
     "metadataUrl": "http://www.paikkatietohakemisto.fi/geonetwork/srv/fi/metadata.show.portti.metaMultiLingual?uuid=93a384df-31da-40fa-a001-2b3bb79c955c",
     "infoFormats": [
       "text/html",

--- a/service-capabilities/src/test/resources/org/oskari/capabilities/ogc/WMSCapabilitiesParserTest-cp-expected.json
+++ b/service-capabilities/src/test/resources/org/oskari/capabilities/ogc/WMSCapabilitiesParserTest-cp-expected.json
@@ -15,6 +15,7 @@
   "title": "Cadastral Boundary",
   "url":null,
   "typeSpecific": {
+    "metadataId": "34af5151-8372-495c-a423-4f8de4bde152",
     "metadataUrl": "http://www.paikkatietohakemisto.fi/geonetwork/srv/en/csw?request=GetRecordById&service=CSW&id=34af5151-8372-495c-a423-4f8de4bde152&elementSetName=full&outputSchema=http://www.isotc211.org/2005/gmd&version=2.0.2",
     "keywords": [
       "Cadastral Boundary"

--- a/service-capabilities/src/test/resources/org/oskari/capabilities/ogc/WMSCapabilitiesParserTest-dummy-expected.json
+++ b/service-capabilities/src/test/resources/org/oskari/capabilities/ogc/WMSCapabilitiesParserTest-dummy-expected.json
@@ -21,6 +21,7 @@
       "1933-12-31T00:00:00.000Z",
       "1934-12-31T00:00:00.000Z"
     ],
+    "metadataId": "AAAAA1234-1234-1234-1AAA-1A1A1A111A1",
     "metadataUrl": "http://www.test.domain//csw?request=GetRecordById&service=CSW&id=AAAAA1234-1234-1234-1AAA-1A1A1A111A1&elementSetName=full&outputSchema=http%3A%2F%2Fwww.isotc211.org%2F2005%2Fgmd",
     "infoFormats": [
       "application/vnd.esri.wms_raw_xml",

--- a/service-map/src/main/java/fi/nls/oskari/service/capabilities/CapabilitiesConstants.java
+++ b/service-map/src/main/java/fi/nls/oskari/service/capabilities/CapabilitiesConstants.java
@@ -1,6 +1,7 @@
 package fi.nls.oskari.service.capabilities;
 
 import fi.nls.oskari.domain.map.wfs.WFSLayerCapabilities;
+import org.oskari.capabilities.ogc.LayerCapabilitiesWMS;
 
 public class CapabilitiesConstants {
     public static final String WFS3_VERSION = "3.0.0";

--- a/service-map/src/main/java/org/oskari/maplayer/admin/LayerAdminJSONHelper.java
+++ b/service-map/src/main/java/org/oskari/maplayer/admin/LayerAdminJSONHelper.java
@@ -7,14 +7,19 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import fi.nls.oskari.domain.map.DataProvider;
 import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.map.layer.DataProviderService;
+import fi.nls.oskari.map.layer.formatters.LayerJSONFormatter;
 import fi.nls.oskari.service.OskariComponentManager;
 import fi.nls.oskari.service.ServiceRuntimeException;
 import fi.nls.oskari.util.JSONHelper;
 import org.json.JSONObject;
+import org.oskari.capabilities.ogc.LayerCapabilitiesWMS;
 import org.oskari.maplayer.model.MapLayer;
 import org.oskari.maplayer.model.MapLayerAdminOutput;
 
 import java.util.*;
+
+import static fi.nls.oskari.service.capabilities.CapabilitiesConstants.KEY_METADATA;
+import static fi.nls.oskari.service.capabilities.CapabilitiesConstants.KEY_TYPE_SPECIFIC;
 
 public class LayerAdminJSONHelper {
 

--- a/service-map/src/test/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterTest.java
+++ b/service-map/src/test/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterTest.java
@@ -57,23 +57,6 @@ public class LayerJSONFormatterTest {
     }
 
     @Test
-    public void getFixedDataUrl() {
-        assertNull("Null metadata returns null id", LayerJSONFormatter.getFixedDataUrl(null));
-        assertNull("Empty metadata returns null id", LayerJSONFormatter.getFixedDataUrl(""));
-        assertEquals("Non http-starting metadata returns as is", "testing", LayerJSONFormatter.getFixedDataUrl("testing"));
-        assertNull("Url without querystring returns null id", LayerJSONFormatter.getFixedDataUrl("http://mydomain.org"));
-        assertNull("Url without id|uuid returns null id", LayerJSONFormatter.getFixedDataUrl("http://mydomain.org?my=key"));
-        assertEquals("Url with id returns id value simple", "key", LayerJSONFormatter.getFixedDataUrl("http://mydomain.org?uuid=key"));
-        Map<String, String> expected = new HashMap<>();
-        expected.put("http://mydomain.org?test=test&id=key&post=test", "key");
-        expected.put("http://mydomain.org?test=test&uuid=key2&post=test", "key2");
-        expected.put("http://mydomain.org?test=test&Id=key&post=test", "key");
-        expected.put("http://mydomain.org?test=test&uuId=Key&post=test", "Key");
-        for (String url : expected.keySet()) {
-            assertEquals("Url with id returns id value", expected.get(url), LayerJSONFormatter.getFixedDataUrl(url));
-        }
-    }
-    @Test
     public void legendWMS() throws Exception {
         OskariLayer layer = initLayer(OskariLayer.TYPE_WMS);
         JSONObject layerJSON = FORMATTER.getJSON(layer, LANG, false, CRS);


### PR DESCRIPTION
Previously only metadata url was parsed to layer capabiltiies json. Now also `metadataId` is generated while parsing capabilities next to `capabilities.typeSpecific.metadataUrl`

Moved and renamed helper function for getting metadata uuid from metadata url:
`fi.nls.oskari.map.layer.formatters.LayerJSONFormatter.getFixedDataUrl()` -> `org.oskari.capabilities.CapabilitiesService.getIdFromMetadataUrl()`
