### PR TITLE
Fix indicator name logic to return any name for missing locales

### DIFF
--- a/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/data/StatisticalIndicator.java
+++ b/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/data/StatisticalIndicator.java
@@ -94,7 +94,7 @@ public class StatisticalIndicator {
         if(value == null || value.trim().isEmpty()) {
             // try any language
             value = map.values().stream()
-                    .filter(val -> val.trim().isEmpty())
+                    .filter(val -> !val.trim().isEmpty())
                     .findFirst()
                     .orElse(null);
         }

--- a/service-statistics-common/src/test/java/fi/nls/oskari/control/statistics/data/StatisticalIndicatorTest.java
+++ b/service-statistics-common/src/test/java/fi/nls/oskari/control/statistics/data/StatisticalIndicatorTest.java
@@ -1,0 +1,32 @@
+package fi.nls.oskari.control.statistics.data;
+
+import fi.nls.oskari.util.PropertyUtil;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class StatisticalIndicatorTest {
+
+    @BeforeClass
+    public static void init() throws Exception {
+        PropertyUtil.addProperty("oskari.locales", "fi_FI,en_US,sv_SE", true);
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception {
+        PropertyUtil.clearProperties();
+    }
+
+    @Test
+    public void testSetValueInvalid() {
+        StatisticalIndicator ind = new StatisticalIndicator();
+        ind.addName("sv", "testing");
+        assertEquals("Should return sv as only value with en request", "testing", ind.getName("en"));
+        ind.addName("fi", "testing fi");
+        assertEquals("Should return fi (default locale) with en request", "testing fi", ind.getName("en"));
+        ind.addName("en", "testing en");
+        assertEquals("Should return direct match", "testing en", ind.getName("en"));
+    }
+}


### PR DESCRIPTION
Fix for `getLocalizedValue()`.