### PR TITLE
Hotfix/2.7.1

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,7 +2,13 @@
 
 ## 2.7.1
 
-For a full list of changes see: https://github.com/oskariorg/oskari-server/milestone/39?closed=1
+For a full list of changes see: https://github.com/oskariorg/oskari-server/milestone/41?closed=1
+
+Bumped dependencies:
+- Spring 5.3.14 -> 5.3.18
+- Spring Security 5.6.1 -> 5.6.2
+- Spring Session 2021.1.1 -> 2021.1.2
+- Jackson 2.12.1 -> 2.13.2 (databind to 2.13.2.2)
 
 ## 2.7.0
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 2.7.1
+
+For a full list of changes see: https://github.com/oskariorg/oskari-server/milestone/39?closed=1
+
 ## 2.7.0
 
 For a full list of changes see: https://github.com/oskariorg/oskari-server/milestone/39?closed=1

--- a/content-resources/pom.xml
+++ b/content-resources/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
 		<artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
 	</parent>
     <artifactId>content-resources</artifactId>
     <packaging>jar</packaging>

--- a/content-resources/pom.xml
+++ b/content-resources/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
 		<artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
 	</parent>
     <artifactId>content-resources</artifactId>
     <packaging>jar</packaging>

--- a/control-admin/pom.xml
+++ b/control-admin/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
 	</parent>
 
     <artifactId>control-admin</artifactId>

--- a/control-admin/pom.xml
+++ b/control-admin/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
 	</parent>
 
     <artifactId>control-admin</artifactId>

--- a/control-announcements/pom.xml
+++ b/control-announcements/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
     </parent>
 
     <artifactId>control-announcements</artifactId>

--- a/control-announcements/pom.xml
+++ b/control-announcements/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>control-announcements</artifactId>

--- a/control-base/pom.xml
+++ b/control-base/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
 	</parent>
 
     <artifactId>control-base</artifactId>

--- a/control-base/pom.xml
+++ b/control-base/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
 	</parent>
 
     <artifactId>control-base</artifactId>

--- a/control-example/pom.xml
+++ b/control-example/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
 	</parent>
 
     <artifactId>control-example</artifactId>

--- a/control-example/pom.xml
+++ b/control-example/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
 	</parent>
 
     <artifactId>control-example</artifactId>

--- a/control-mvt/pom.xml
+++ b/control-mvt/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>control-mvt</artifactId>

--- a/control-mvt/pom.xml
+++ b/control-mvt/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
     </parent>
 
     <artifactId>control-mvt</artifactId>

--- a/control-myplaces/pom.xml
+++ b/control-myplaces/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
 	</parent>
 
     <artifactId>control-myplaces</artifactId>

--- a/control-myplaces/pom.xml
+++ b/control-myplaces/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
 	</parent>
 
     <artifactId>control-myplaces</artifactId>

--- a/control-rating/pom.xml
+++ b/control-rating/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/control-rating/pom.xml
+++ b/control-rating/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/control-routing/pom.xml
+++ b/control-routing/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
 	</parent>
 
     <artifactId>control-routing</artifactId>

--- a/control-routing/pom.xml
+++ b/control-routing/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
 	</parent>
 
     <artifactId>control-routing</artifactId>

--- a/control-statistics/pom.xml
+++ b/control-statistics/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
 	</parent>
 
     <artifactId>control-statistics</artifactId>

--- a/control-statistics/pom.xml
+++ b/control-statistics/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
 	</parent>
 
     <artifactId>control-statistics</artifactId>

--- a/control-userlayer/pom.xml
+++ b/control-userlayer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
     </parent>
     <artifactId>control-userlayer</artifactId>
 

--- a/control-userlayer/pom.xml
+++ b/control-userlayer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
     <artifactId>control-userlayer</artifactId>
 

--- a/control-users/pom.xml
+++ b/control-users/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
 	</parent>
 
     <artifactId>control-users</artifactId>

--- a/control-users/pom.xml
+++ b/control-users/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
 	</parent>
 
     <artifactId>control-users</artifactId>

--- a/download-basket/pom.xml
+++ b/download-basket/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.oskari</groupId>
 		<artifactId>oskari-server</artifactId>
-		<version>2.8.0-SNAPSHOT</version>
+		<version>2.7.1</version>
 	</parent>
 	<artifactId>download-basket</artifactId>
 	<name>Download Basket</name>

--- a/download-basket/pom.xml
+++ b/download-basket/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.oskari</groupId>
 		<artifactId>oskari-server</artifactId>
-		<version>2.7.0</version>
+		<version>2.8.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>download-basket</artifactId>
 	<name>Download Basket</name>

--- a/geoserver-ext/geoserver-rest-client/pom.xml
+++ b/geoserver-ext/geoserver-rest-client/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>geoserver-rest-client</artifactId>

--- a/geoserver-ext/geoserver-rest-client/pom.xml
+++ b/geoserver-ext/geoserver-rest-client/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>geoserver-rest-client</artifactId>

--- a/geotools-ext/gt-geojson/pom.xml
+++ b/geotools-ext/gt-geojson/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>gt-geojson</artifactId>

--- a/geotools-ext/gt-geojson/pom.xml
+++ b/geotools-ext/gt-geojson/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>gt-geojson</artifactId>

--- a/geotools-ext/gt-mif/pom.xml
+++ b/geotools-ext/gt-mif/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>gt-mif</artifactId>

--- a/geotools-ext/gt-mif/pom.xml
+++ b/geotools-ext/gt-mif/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>gt-mif</artifactId>

--- a/geotools-ext/gt-xsd-gpx/pom.xml
+++ b/geotools-ext/gt-xsd-gpx/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/geotools-ext/gt-xsd-gpx/pom.xml
+++ b/geotools-ext/gt-xsd-gpx/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/oskari-utils/pom.xml
+++ b/oskari-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>oskari-utils</artifactId>

--- a/oskari-utils/pom.xml
+++ b/oskari-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
     </parent>
 
     <artifactId>oskari-utils</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,14 +49,15 @@
         <!-- Value comes from profile when needed -->
         <module.build.config></module.build.config>
 
-        <spring.version>5.3.14</spring.version>
-        <spring-security.version>5.6.1</spring-security.version>
+        <spring.version>5.3.18</spring.version>
+        <spring-security.version>5.6.2</spring-security.version>
         <!--
-        session-bom 2021.1.1 uses 2.6.1 from session
-        which is aligned with core 5.3.14 and security 5.6.1 versions
-        https://github.com/spring-projects/spring-session/releases/tag/2.6.1
-        https://search.maven.org/artifact/org.springframework.session/spring-session-bom/2021.1.1/pom -->
-        <spring.session.version>2021.1.1</spring.session.version>
+        session-bom 2021.1.2 uses 2.6.2 from session
+        which is aligned with core 5.3.16 and security 5.6.2 versions
+        Note! Bumped core to unaligned version 5.3.18 for CVE fix
+        https://github.com/spring-projects/spring-session/releases/tag/2.6.2
+        https://search.maven.org/artifact/org.springframework.session/spring-session-bom/2021.1.2/pom -->
+        <spring.session.version>2021.1.2</spring.session.version>
 
         <javax.servlet.version>3.1.0</javax.servlet.version>
         <javax.servlet.jsp.version>2.3.3</javax.servlet.jsp.version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.oskari</groupId>
     <artifactId>oskari-server</artifactId>
-    <version>2.8.0-SNAPSHOT</version>
+    <version>2.7.1</version>
     <packaging>pom</packaging>
 
     <name>Oskari server</name>
@@ -80,7 +80,8 @@
         <woodstox.version>5.1.0</woodstox.version>
         <xmlbeans.version>3.1.0</xmlbeans.version>
 
-        <jackson.version>2.12.1</jackson.version>
+        <jackson.version>2.13.2</jackson.version>
+        <jackson-databind.version>2.13.2.2</jackson-databind.version>
 
         <fi.mml.capabilities.version>1.3.0</fi.mml.capabilities.version>
         <fi.mml.wms.version>1.1.1</fi.mml.wms.version>
@@ -682,7 +683,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
+                <version>${jackson-databind.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.oskari</groupId>
     <artifactId>oskari-server</artifactId>
-    <version>2.7.0</version>
+    <version>2.8.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Oskari server</name>

--- a/service-admin/pom.xml
+++ b/service-admin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
     </parent>
 
     <artifactId>service-admin</artifactId>

--- a/service-admin/pom.xml
+++ b/service-admin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-admin</artifactId>

--- a/service-base/pom.xml
+++ b/service-base/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
 	</parent>
 
     <artifactId>service-base</artifactId>

--- a/service-base/pom.xml
+++ b/service-base/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
 	</parent>
 
     <artifactId>service-base</artifactId>

--- a/service-capabilities-update/pom.xml
+++ b/service-capabilities-update/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-capabilities-update</artifactId>

--- a/service-capabilities-update/pom.xml
+++ b/service-capabilities-update/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
     </parent>
 
     <artifactId>service-capabilities-update</artifactId>

--- a/service-capabilities/pom.xml
+++ b/service-capabilities/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
     </parent>
 
     <artifactId>service-capabilities</artifactId>

--- a/service-capabilities/pom.xml
+++ b/service-capabilities/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-capabilities</artifactId>

--- a/service-control/pom.xml
+++ b/service-control/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
     </parent>
 
     <artifactId>service-control</artifactId>

--- a/service-control/pom.xml
+++ b/service-control/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-control</artifactId>

--- a/service-csw/pom.xml
+++ b/service-csw/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-csw</artifactId>

--- a/service-csw/pom.xml
+++ b/service-csw/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
     </parent>
 
     <artifactId>service-csw</artifactId>

--- a/service-feedback-open311/pom.xml
+++ b/service-feedback-open311/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>service-feedback-open311</artifactId>

--- a/service-feedback-open311/pom.xml
+++ b/service-feedback-open311/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>service-feedback-open311</artifactId>

--- a/service-feedback/pom.xml
+++ b/service-feedback/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
     </parent>
     <artifactId>service-feedback</artifactId>
     <packaging>jar</packaging>

--- a/service-feedback/pom.xml
+++ b/service-feedback/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
     <artifactId>service-feedback</artifactId>
     <packaging>jar</packaging>

--- a/service-logging/pom.xml
+++ b/service-logging/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service-logging/pom.xml
+++ b/service-logging/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service-map/pom.xml
+++ b/service-map/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
     </parent>
 
     <artifactId>service-map</artifactId>

--- a/service-map/pom.xml
+++ b/service-map/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-map</artifactId>

--- a/service-mvt/pom.xml
+++ b/service-mvt/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-mvt</artifactId>

--- a/service-mvt/pom.xml
+++ b/service-mvt/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
     </parent>
 
     <artifactId>service-mvt</artifactId>

--- a/service-mybatis/pom.xml
+++ b/service-mybatis/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.oskari</groupId>
 		<artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
 	</parent>
 
 	<artifactId>service-mybatis</artifactId>

--- a/service-mybatis/pom.xml
+++ b/service-mybatis/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.oskari</groupId>
 		<artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>service-mybatis</artifactId>

--- a/service-myplaces/pom.xml
+++ b/service-myplaces/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-myplaces</artifactId>

--- a/service-myplaces/pom.xml
+++ b/service-myplaces/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
     </parent>
 
     <artifactId>service-myplaces</artifactId>

--- a/service-permissions/pom.xml
+++ b/service-permissions/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
     </parent>
 
     <artifactId>service-permissions</artifactId>

--- a/service-permissions/pom.xml
+++ b/service-permissions/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-permissions</artifactId>

--- a/service-print/pom.xml
+++ b/service-print/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
     </parent>
     <artifactId>service-print</artifactId>
 

--- a/service-print/pom.xml
+++ b/service-print/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
     <artifactId>service-print</artifactId>
 

--- a/service-rating/pom.xml
+++ b/service-rating/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service-rating/pom.xml
+++ b/service-rating/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service-routing/pom.xml
+++ b/service-routing/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
     </parent>
 
     <artifactId>service-routing</artifactId>

--- a/service-routing/pom.xml
+++ b/service-routing/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-routing</artifactId>

--- a/service-scheduler/pom.xml
+++ b/service-scheduler/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-scheduler</artifactId>

--- a/service-scheduler/pom.xml
+++ b/service-scheduler/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
     </parent>
 
     <artifactId>service-scheduler</artifactId>

--- a/service-search-opendata/pom.xml
+++ b/service-search-opendata/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.oskari</groupId>
 		<artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>service-search-opendata</artifactId>
 	<packaging>jar</packaging>

--- a/service-search-opendata/pom.xml
+++ b/service-search-opendata/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.oskari</groupId>
 		<artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
 	</parent>
 	<artifactId>service-search-opendata</artifactId>
 	<packaging>jar</packaging>

--- a/service-search-wfs/pom.xml
+++ b/service-search-wfs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.oskari</groupId>
 		<artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
 	</parent>
 
 	<artifactId>service-search-wfs</artifactId>

--- a/service-search-wfs/pom.xml
+++ b/service-search-wfs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.oskari</groupId>
 		<artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>service-search-wfs</artifactId>

--- a/service-search/pom.xml
+++ b/service-search/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.oskari</groupId>
 		<artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>service-search</artifactId>

--- a/service-search/pom.xml
+++ b/service-search/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.oskari</groupId>
 		<artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
 	</parent>
 
 	<artifactId>service-search</artifactId>

--- a/service-spatineo-monitor/pom.xml
+++ b/service-spatineo-monitor/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
     </parent>
 
     <artifactId>service-spatineo-monitor</artifactId>

--- a/service-spatineo-monitor/pom.xml
+++ b/service-spatineo-monitor/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-spatineo-monitor</artifactId>

--- a/service-statistics-common/pom.xml
+++ b/service-statistics-common/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
 	</parent>
 
     <artifactId>service-statistics-common</artifactId>

--- a/service-statistics-common/pom.xml
+++ b/service-statistics-common/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
 	</parent>
 
     <artifactId>service-statistics-common</artifactId>

--- a/service-statistics-eurostat/pom.xml
+++ b/service-statistics-eurostat/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
 	</parent>
 
     <artifactId>service-statistics-eurostat</artifactId>

--- a/service-statistics-eurostat/pom.xml
+++ b/service-statistics-eurostat/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
 	</parent>
 
     <artifactId>service-statistics-eurostat</artifactId>

--- a/service-statistics-kapa/pom.xml
+++ b/service-statistics-kapa/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
 	</parent>
 
     <artifactId>service-statistics-kapa</artifactId>

--- a/service-statistics-kapa/pom.xml
+++ b/service-statistics-kapa/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
 	</parent>
 
     <artifactId>service-statistics-kapa</artifactId>

--- a/service-statistics-pxweb/pom.xml
+++ b/service-statistics-pxweb/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
     </parent>
 
     <artifactId>service-statistics-pxweb</artifactId>

--- a/service-statistics-pxweb/pom.xml
+++ b/service-statistics-pxweb/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-statistics-pxweb</artifactId>

--- a/service-statistics-sotka/pom.xml
+++ b/service-statistics-sotka/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
 	</parent>
 
     <artifactId>service-statistics-sotka</artifactId>

--- a/service-statistics-sotka/pom.xml
+++ b/service-statistics-sotka/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
 	</parent>
 
     <artifactId>service-statistics-sotka</artifactId>

--- a/service-statistics-unsd/pom.xml
+++ b/service-statistics-unsd/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
 	</parent>
 
     <artifactId>service-statistics-unsd</artifactId>

--- a/service-statistics-unsd/pom.xml
+++ b/service-statistics-unsd/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
 	</parent>
 
     <artifactId>service-statistics-unsd</artifactId>

--- a/service-statistics/pom.xml
+++ b/service-statistics/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
 	</parent>
 
     <artifactId>service-statistics</artifactId>

--- a/service-statistics/pom.xml
+++ b/service-statistics/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
 	</parent>
 
     <artifactId>service-statistics</artifactId>

--- a/service-userlayer/pom.xml
+++ b/service-userlayer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
     <artifactId>service-userlayer</artifactId>
     <description>Everything related to UserLayers</description>

--- a/service-userlayer/pom.xml
+++ b/service-userlayer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
     </parent>
     <artifactId>service-userlayer</artifactId>
     <description>Everything related to UserLayers</description>

--- a/service-users/pom.xml
+++ b/service-users/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-users</artifactId>

--- a/service-users/pom.xml
+++ b/service-users/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
     </parent>
 
     <artifactId>service-users</artifactId>

--- a/service-wcs/pom.xml
+++ b/service-wcs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-wcs</artifactId>

--- a/service-wcs/pom.xml
+++ b/service-wcs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
     </parent>
 
     <artifactId>service-wcs</artifactId>

--- a/service-webapp/pom.xml
+++ b/service-webapp/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-webapp</artifactId>

--- a/service-webapp/pom.xml
+++ b/service-webapp/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
     </parent>
 
     <artifactId>service-webapp</artifactId>

--- a/service-wfs-client/pom.xml
+++ b/service-wfs-client/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
     </parent>
     <artifactId>service-wfs-client</artifactId>
     <description>Utilities for accessing WFS 1.1.0 services</description>

--- a/service-wfs-client/pom.xml
+++ b/service-wfs-client/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
     <artifactId>service-wfs-client</artifactId>
     <description>Utilities for accessing WFS 1.1.0 services</description>

--- a/service-wfs3/pom.xml
+++ b/service-wfs3/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
     </parent>
     <artifactId>service-wfs3</artifactId>
     <description>When working with WFS 3 services</description>

--- a/service-wfs3/pom.xml
+++ b/service-wfs3/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
     <artifactId>service-wfs3</artifactId>
     <description>When working with WFS 3 services</description>

--- a/servlet-map/pom.xml
+++ b/servlet-map/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
     <artifactId>servlet-map</artifactId>
     <packaging>jar</packaging>

--- a/servlet-map/pom.xml
+++ b/servlet-map/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
     </parent>
     <artifactId>servlet-map</artifactId>
     <packaging>jar</packaging>

--- a/shared-test-resources/pom.xml
+++ b/shared-test-resources/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
 	</parent>
 
     <artifactId>shared-test-resources</artifactId>

--- a/shared-test-resources/pom.xml
+++ b/shared-test-resources/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
 	</parent>
 
     <artifactId>shared-test-resources</artifactId>

--- a/webapp-setup/pom.xml
+++ b/webapp-setup/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.7.1</version>
     </parent>
 
     <artifactId>webapp-setup</artifactId>

--- a/webapp-setup/pom.xml
+++ b/webapp-setup/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>webapp-setup</artifactId>


### PR DESCRIPTION
Bump dependencies:
- spring 5.3.14 -> 5.3.18
- spring-security 5.6.1 -> 5.6.2
- spring session 2021.1.1 -> 2021.1.2
- Jackson 2.12.1 -> 2.13.2 (databind to 2.13.2.2)