### PR TITLE
Pass metadata id from new capabilities structure to frontend for layer listing

### DIFF
--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
@@ -253,15 +253,15 @@ public class LayerJSONFormatter {
         if (fixed != null) {
             return fixed;
         }
-        String olderMetadataCaps = layer.getCapabilities().optString(KEY_METADATA);
-        if (olderMetadataCaps != null) {
+        String olderMetadataCaps = layer.getCapabilities().optString(KEY_METADATA, null);
+        if (olderMetadataCaps != null && !olderMetadataCaps.trim().isEmpty()) {
             return olderMetadataCaps;
         }
         JSONObject typeSpecific = layer.getCapabilities().optJSONObject(KEY_TYPE_SPECIFIC);
         if (typeSpecific == null) {
             return null;
         }
-        return typeSpecific.optString(LayerCapabilitiesOGC.METADATA_UUID);
+        return typeSpecific.optString(LayerCapabilitiesOGC.METADATA_UUID, null);
     }
 
     /**


### PR DESCRIPTION
Currently metadata id isn't passed correctly to frontend from the new capabilities structure. This fixes the issue by handling empty string from old capabilities properly so code proceeds to searching for it from the new structure if old one doesn't have a value.