### PR TITLE
Add initial parsing for DescribeFeatureType calls on WFS

### DIFF
--- a/content-resources/src/main/java/org/oskari/helpers/AppSetupHelper.java
+++ b/content-resources/src/main/java/org/oskari/helpers/AppSetupHelper.java
@@ -37,9 +37,8 @@ public class AppSetupHelper {
 
             final long viewId = viewService.addView(view);
             log.info("Added view from file:", viewfile, "/viewId is:", viewId, "/uuid is:", view.getUuid());
-            // TODO: only call refreshLayerCapabilities() if we added an appsetup with NEW projection
             // update supported SRS for layers after possibly new projection on appsetup/view
-            LayerHelper.refreshLayerCapabilities();
+            LayerHelper.refreshLayerCapabilities(view.getSrsName());
             return viewId;
         } catch (Exception ex) {
             log.error( "Unable to insert appsetup! Msg: ", ex.getMessage());

--- a/content-resources/src/main/java/org/oskari/helpers/LayerHelper.java
+++ b/content-resources/src/main/java/org/oskari/helpers/LayerHelper.java
@@ -6,18 +6,22 @@ import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.map.layer.OskariLayerService;
 import fi.nls.oskari.map.layer.OskariLayerServiceMybatisImpl;
+import fi.nls.oskari.map.layer.formatters.LayerJSONFormatter;
 import fi.nls.oskari.service.ServiceException;
 import fi.nls.oskari.util.IOHelper;
 import fi.nls.oskari.util.OskariRuntimeException;
 import org.oskari.admin.LayerCapabilitiesHelper;
 import org.oskari.admin.MapLayerGroupsHelper;
 import org.oskari.admin.MapLayerPermissionsHelper;
+import org.oskari.capabilities.CapabilitiesService;
+import org.oskari.capabilities.CapabilitiesUpdateResult;
 import org.oskari.maplayer.model.MapLayer;
 import org.oskari.maplayer.admin.LayerAdminJSONHelper;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 // Service-admin provides helpers for inserting layers BUT this helper has been used in multiple migrations for setting
@@ -74,14 +78,23 @@ public class LayerHelper {
      * So we can get updated "supported SRS" for layers after inserting a new appsetup with possibly new projection
      * @throws ServiceException
      */
-    protected static void refreshLayerCapabilities() {
-        for (OskariLayer layer : layerService.findAll()) {
-            if (layer.getUrl().startsWith("http://localhost:")) {
+    protected static void refreshLayerCapabilities(String srsForNewAppsetup) {
+        Set<String> systemSRSlist;
+        try {
+            systemSRSlist = LayerCapabilitiesHelper.getSystemCRSs();
+        } catch (Exception e) {
+            throw new OskariRuntimeException("Couldn't get system crs list");
+        }
+        List<OskariLayer> layers = layerService.findAll().stream()
                 // skip localhost servers as the service is starting when this is called and geoserver will not answer
-                continue;
-            }
+                .filter(l -> !l.getUrl().startsWith("http://localhost:"))
+                // only update layers when new projection is added
+                .filter(layer -> !LayerJSONFormatter.getSRSs(layer.getAttributes(), layer.getCapabilities()).contains(srsForNewAppsetup))
+                .collect(Collectors.toList());
+        CapabilitiesService.updateCapabilities(layers, systemSRSlist);
+        // Save updated capabilities to db
+        for (OskariLayer layer : layers) {
             try {
-                LayerCapabilitiesHelper.updateCapabilities(layer);
                 layerService.update(layer);
             } catch (Exception e) {
                 log.warn(e,"Couldn't update capabilities for layer:", layer.getUrl(), layer.getName());

--- a/service-admin/src/main/java/org/oskari/admin/LayerCapabilitiesHelper.java
+++ b/service-admin/src/main/java/org/oskari/admin/LayerCapabilitiesHelper.java
@@ -138,7 +138,7 @@ public class LayerCapabilitiesHelper {
         CapabilitiesService.updateCapabilities(ml, getSystemCRSs());
     }
 
-    private static Set<String> getSystemCRSs() throws ServiceException {
+    public static Set<String> getSystemCRSs() throws ServiceException {
         return ViewHelper.getSystemCRSs(getViewService());
     }
 

--- a/service-capabilities/src/main/java/org/oskari/capabilities/CapabilitiesParser.java
+++ b/service-capabilities/src/main/java/org/oskari/capabilities/CapabilitiesParser.java
@@ -16,6 +16,18 @@ public abstract class CapabilitiesParser extends OskariComponent {
     private static final int TIMEOUT_MS = PropertyUtil.getOptional("capabilities.timeout", 30) * 1000;
 
     public abstract Map<String, LayerCapabilities> getLayersFromService(ServiceConnectInfo src) throws IOException, ServiceException;
+    /*
+     For optimization purposes to get single layer (this method can be overridden to optimize single layer, the base method is not optimized).
+     For example wfs-layers require multiple requests/layer and this can be used to update single layer.
+     Can be used to speed up update when service has multiple layers.
+     */
+    public LayerCapabilities getLayerFromService(ServiceConnectInfo src, String layer) throws IOException, ServiceException {
+        if (layer == null || layer.isEmpty()) {
+            throw new ServiceException("No layer specified");
+        }
+        Map<String, LayerCapabilities> layers = getLayersFromService(src);
+        return layers.get(layer);
+    }
 
     public RawCapabilitiesResponse fetchCapabilities(String capabilitiesUrl, String user, String pass, String expectedContentType) throws IOException, ServiceException {
         HttpURLConnection conn = IOHelper.getConnection(capabilitiesUrl, user, pass);

--- a/service-capabilities/src/main/java/org/oskari/capabilities/ogc/LayerCapabilitiesWFS.java
+++ b/service-capabilities/src/main/java/org/oskari/capabilities/ogc/LayerCapabilitiesWFS.java
@@ -2,20 +2,25 @@ package org.oskari.capabilities.ogc;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import fi.nls.oskari.domain.map.OskariLayer;
+import org.oskari.capabilities.ogc.wfs.FeaturePropertyType;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 public class LayerCapabilitiesWFS extends LayerCapabilitiesOGC {
 
     public static final String OGC_API_CRS_URI = "crs-uri";
     public static final String MAX_FEATURES = CapabilitiesConstants.KEY_MAX_FEATURES;
-    public static final String NAMESPACE_URI = "nsUri";
+    public static final String NAMESPACE_URI = "nsUri"; // previously KEY_NAMESPACE_URL = "namespaceURL";
+    public static final String FEATURE_PROPERTIES = "featureProperties";
+    public static final String GEOMETRY_FIELD = "geomName";
 
     public LayerCapabilitiesWFS(String name, String title) {
         super(name, title);
         setType(OskariLayer.TYPE_WFS);
     }
+
 
     public void setSupportedCrsURIs(Set<String> uris) {
         addCapabilityData(OGC_API_CRS_URI, uris);
@@ -26,6 +31,32 @@ public class LayerCapabilitiesWFS extends LayerCapabilitiesOGC {
         return (Set<String>) getTypeSpecific().getOrDefault(OGC_API_CRS_URI, Collections.emptySet());
     }
 
+    public void setFeatureProperties(List<FeaturePropertyType> props) {
+        if (props != null) {
+            addCapabilityData(FEATURE_PROPERTIES, props);
+            setGeometryField(props.stream()
+                    .filter(p -> p.isGeometry())
+                    .map(p -> p.name)
+                    .findFirst()
+                    .orElse(null));
+        }
+    }
+
+    @JsonIgnore
+    public List<FeaturePropertyType> getFeatureProperties() {
+        return (List<FeaturePropertyType>) getTypeSpecific().getOrDefault(FEATURE_PROPERTIES, Collections.emptyList());
+    }
+
+    public void setGeometryField(String geomName) {
+        if (geomName != null) {
+            addCapabilityData(GEOMETRY_FIELD, geomName);
+        }
+    }
+
+    @JsonIgnore
+    public String getGeometryField() {
+        return (String) getTypeSpecific().get(GEOMETRY_FIELD);
+    }
     @JsonIgnore
     public String getNamespaceUri() {
         return (String) getTypeSpecific().getOrDefault(NAMESPACE_URI, null);

--- a/service-capabilities/src/main/java/org/oskari/capabilities/ogc/OGCCapabilitiesParser.java
+++ b/service-capabilities/src/main/java/org/oskari/capabilities/ogc/OGCCapabilitiesParser.java
@@ -42,7 +42,7 @@ public abstract class OGCCapabilitiesParser extends CapabilitiesParser {
         String capabilitiesUrl = contructCapabilitiesUrl(src.getUrl(), src.getVersion());
         RawCapabilitiesResponse response = fetchCapabilities(capabilitiesUrl, src.getUser(), src.getPass(), getExpectedContentType(src.getVersion()));
         String validResponse = validateResponse(response, src.getVersion());
-        Map<String, LayerCapabilities> layers = parseLayers(validResponse, src.getVersion());
+        Map<String, LayerCapabilities> layers = parseLayers(validResponse, src.getVersion(), src);
         layers.values().stream().forEach(l -> {
             l.setUrl(response.getUrl());
             // parser name == layer type
@@ -56,6 +56,11 @@ public abstract class OGCCapabilitiesParser extends CapabilitiesParser {
     // allow overriding for OGC API services etc
     protected Map<String, LayerCapabilities> parseLayers(String capabilities, String version) throws ServiceException {
         return parseLayers(capabilities);
+    }
+
+    // allow overriding/connect info for additional requests
+    protected Map<String, LayerCapabilities> parseLayers(String capabilities, String version, ServiceConnectInfo src) throws ServiceException {
+        return parseLayers(capabilities, version);
     }
 
     protected String contructCapabilitiesUrl(String url, String version) {

--- a/service-capabilities/src/main/java/org/oskari/capabilities/ogc/WFSCapabilitiesParser.java
+++ b/service-capabilities/src/main/java/org/oskari/capabilities/ogc/WFSCapabilitiesParser.java
@@ -87,7 +87,7 @@ public class WFSCapabilitiesParser extends OGCCapabilitiesParser {
                 LOG.info("DescribeFeatureType response not available:", src.getUrl());
                 return;
             }
-            layer.setFeatureProperties(DescribeFeatureTypeParser.parseFeatureType(xml));
+            layer.setFeatureProperties(DescribeFeatureTypeParser.parseFeatureType(xml, layer.getName()));
         } catch (IOException e) {
             LOG.error("Unable to access wfs describe feature type: " + e.getMessage());
         } catch (Exception e) {

--- a/service-capabilities/src/main/java/org/oskari/capabilities/ogc/WFSCapabilitiesParser.java
+++ b/service-capabilities/src/main/java/org/oskari/capabilities/ogc/WFSCapabilitiesParser.java
@@ -80,9 +80,9 @@ public class WFSCapabilitiesParser extends OGCCapabilitiesParser {
 
     protected void enhanceCapabilitiesData(LayerCapabilitiesWFS layer, ServiceConnectInfo src) {
         try {
-            String xml = featureTypeProvider.getDescribeContent(layer.getUrl(), src.getUser(), src.getPass());
+            String xml = featureTypeProvider.getDescribeContent(src.getUrl(), src.getUser(), src.getPass());
             if (xml == null) {
-                LOG.info("DescribeFeatureType response not available:", layer.getUrl());
+                LOG.info("DescribeFeatureType response not available:", src.getUrl());
                 return;
             }
             layer.setFeatureProperties(DescribeFeatureTypeParser.parseFeatureType(xml));

--- a/service-capabilities/src/main/java/org/oskari/capabilities/ogc/wfs/DescribeFeatureTypeParser.java
+++ b/service-capabilities/src/main/java/org/oskari/capabilities/ogc/wfs/DescribeFeatureTypeParser.java
@@ -1,0 +1,73 @@
+package org.oskari.capabilities.ogc.wfs;
+
+import org.oskari.xml.XmlHelper;
+import org.w3c.dom.Element;
+
+import javax.xml.stream.XMLStreamException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class DescribeFeatureTypeParser {
+
+    public static List<FeaturePropertyType> parseFeatureType(String xml)
+            throws IllegalArgumentException, XMLStreamException {
+        Element doc = XmlHelper.parseXML(xml);
+        if (doc == null) {
+            throw new XMLStreamException("Failed to parse DescribeFeatureType XML");
+        }
+        return parseFeatureType(doc);
+    }
+
+    public static List<FeaturePropertyType> parseFeatureType(Element doc)
+            throws IllegalArgumentException, XMLStreamException {
+        String rootEl = XmlHelper.getLocalName(doc);
+        if (!"schema".equals(rootEl)) {
+            throw new IllegalArgumentException(XmlHelper.generateUnexpectedElementMessage(doc));
+        }
+        Element element = XmlHelper.getFirstChild(doc, "element");
+        if (element == null) {
+            throw new IllegalArgumentException("No 'element' tag");
+        }
+        String type = getSimpleType(XmlHelper.getAttributeValue(element, "type"));
+
+        Element typeElement = XmlHelper.getChildElements(doc, "complexType")
+                .filter(e -> type.equals(getSimpleType(XmlHelper.getAttributeValue(e, "name"))))
+                .findFirst().orElse(null);
+
+        if (typeElement == null) {
+            throw new IllegalArgumentException("No 'complexType' element");
+        }
+        Element complexContent = XmlHelper.getFirstChild(typeElement, "complexContent");
+        if (complexContent == null) {
+            throw new IllegalArgumentException("No 'complexContent' tag");
+        }
+        Element extension = XmlHelper.getFirstChild(complexContent, "extension");
+        if (extension == null) {
+            throw new IllegalArgumentException("No 'extension' tag");
+        }
+        Element sequence = XmlHelper.getFirstChild(extension, "sequence");
+        if (sequence == null) {
+            throw new IllegalArgumentException("No 'sequence' tag");
+        }
+
+        return XmlHelper.getChildElements(sequence, "element")
+                .map(e -> {
+                    FeaturePropertyType prop = new FeaturePropertyType();
+                    Map<String, String> properties = XmlHelper.getAttributesAsMap(e);
+                    prop.name = properties.get("name");
+                    prop.type = getSimpleType(properties.get("type"));
+                    return prop;
+                }).collect(Collectors.toList());
+    }
+
+    private static String getSimpleType(String ns) {
+        if (ns == null || ns.isEmpty()) {
+            return "";
+        }
+        String[] parts = ns.split("\\:");
+        if (parts.length < 2) {
+            return ns;
+        }
+        return parts[1];
+    }
+}

--- a/service-capabilities/src/main/java/org/oskari/capabilities/ogc/wfs/DescribeFeatureTypeParser.java
+++ b/service-capabilities/src/main/java/org/oskari/capabilities/ogc/wfs/DescribeFeatureTypeParser.java
@@ -9,22 +9,28 @@ import java.util.stream.Collectors;
 
 public class DescribeFeatureTypeParser {
 
-    public static List<FeaturePropertyType> parseFeatureType(String xml)
+    public static List<FeaturePropertyType> parseFeatureType(String xml, String featureType)
             throws IllegalArgumentException, XMLStreamException {
         Element doc = XmlHelper.parseXML(xml);
         if (doc == null) {
             throw new XMLStreamException("Failed to parse DescribeFeatureType XML");
         }
-        return parseFeatureType(doc);
+        return parseFeatureType(doc, featureType);
     }
 
-    public static List<FeaturePropertyType> parseFeatureType(Element doc)
+    public static List<FeaturePropertyType> parseFeatureType(Element doc, String featureType)
             throws IllegalArgumentException, XMLStreamException {
+        if (featureType == null) {
+            throw new IllegalArgumentException("FeatureType param missing");
+        }
         String rootEl = XmlHelper.getLocalName(doc);
         if (!"schema".equals(rootEl)) {
             throw new IllegalArgumentException(XmlHelper.generateUnexpectedElementMessage(doc));
         }
-        Element element = XmlHelper.getFirstChild(doc, "element");
+        String simpleType = getSimpleType(featureType);
+        Element element = XmlHelper.getChildElements(doc, "element")
+                .filter(e -> simpleType.equals(getSimpleType(XmlHelper.getAttributeValue(e, "name"))))
+                .findFirst().orElse(null);
         if (element == null) {
             throw new IllegalArgumentException("No 'element' tag");
         }

--- a/service-capabilities/src/main/java/org/oskari/capabilities/ogc/wfs/DescribeFeatureTypeProvider.java
+++ b/service-capabilities/src/main/java/org/oskari/capabilities/ogc/wfs/DescribeFeatureTypeProvider.java
@@ -1,0 +1,13 @@
+package org.oskari.capabilities.ogc.wfs;
+
+import fi.nls.oskari.util.IOHelper;
+
+import java.io.IOException;
+
+// separated provider to help mocking in JUnit test
+public class DescribeFeatureTypeProvider {
+    public String getDescribeContent(String url, String user, String pass) throws IOException {
+        // TODO: follow redirects
+        return IOHelper.getURL(url, user, pass);
+    }
+}

--- a/service-capabilities/src/main/java/org/oskari/capabilities/ogc/wfs/DescribeFeatureTypeProvider.java
+++ b/service-capabilities/src/main/java/org/oskari/capabilities/ogc/wfs/DescribeFeatureTypeProvider.java
@@ -3,11 +3,19 @@ package org.oskari.capabilities.ogc.wfs;
 import fi.nls.oskari.util.IOHelper;
 
 import java.io.IOException;
+import java.net.HttpURLConnection;
 
 // separated provider to help mocking in JUnit test
 public class DescribeFeatureTypeProvider {
     public String getDescribeContent(String url, String user, String pass) throws IOException {
-        // TODO: follow redirects
-        return IOHelper.getURL(url, user, pass);
+        HttpURLConnection con = IOHelper.getConnection(url, user, pass);
+        con = IOHelper.followRedirect(con, user, pass, 5);
+        int sc = con.getResponseCode();
+        if (sc != HttpURLConnection.HTTP_OK) {
+            String msg = "Unexpected status code: " + sc  + " from: " + url;
+            throw new IOException(msg);
+        }
+
+        return IOHelper.readString(con);
     }
 }

--- a/service-capabilities/src/main/java/org/oskari/capabilities/ogc/wfs/FeaturePropertyType.java
+++ b/service-capabilities/src/main/java/org/oskari/capabilities/ogc/wfs/FeaturePropertyType.java
@@ -1,6 +1,7 @@
 package org.oskari.capabilities.ogc.wfs;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import fi.nls.oskari.util.WFSConversionHelper;
 
 public class FeaturePropertyType {
     public String name;
@@ -8,6 +9,6 @@ public class FeaturePropertyType {
 
     @JsonIgnore
     public boolean isGeometry() {
-        return "GeometryPropertyType".equals(type);
+        return WFSConversionHelper.isGeometryType(type);
     }
 }

--- a/service-capabilities/src/main/java/org/oskari/capabilities/ogc/wfs/FeaturePropertyType.java
+++ b/service-capabilities/src/main/java/org/oskari/capabilities/ogc/wfs/FeaturePropertyType.java
@@ -1,9 +1,12 @@
 package org.oskari.capabilities.ogc.wfs;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 public class FeaturePropertyType {
     public String name;
     public String type;
 
+    @JsonIgnore
     public boolean isGeometry() {
         return "GeometryPropertyType".equals(type);
     }

--- a/service-capabilities/src/main/java/org/oskari/capabilities/ogc/wfs/FeaturePropertyType.java
+++ b/service-capabilities/src/main/java/org/oskari/capabilities/ogc/wfs/FeaturePropertyType.java
@@ -1,0 +1,10 @@
+package org.oskari.capabilities.ogc.wfs;
+
+public class FeaturePropertyType {
+    public String name;
+    public String type;
+
+    public boolean isGeometry() {
+        return "GeometryPropertyType".equals(type);
+    }
+}

--- a/service-capabilities/src/test/java/org/oskari/capabilities/ogc/WFSCapabilitiesParserTest.java
+++ b/service-capabilities/src/test/java/org/oskari/capabilities/ogc/WFSCapabilitiesParserTest.java
@@ -86,12 +86,12 @@ public class WFSCapabilitiesParserTest {
 
     @Test
     public void parseStatFi3_0_0() throws Exception {
+        String version = "3.0.0";
         String serviceJSON = ResourceHelper.readStringResource("WFSCapabilitiesParserTest-statfi-3_0_0-input.json", this);
         String expected = ResourceHelper.readStringResource("WFSCapabilitiesParserTest-statfi-3_0_0-expected.json", this);
 
-        OGCAPIFeaturesService se = OGCAPIFeaturesService.fromJSON(serviceJSON);
         WFSCapabilitiesParser parser = getParser();
-        Map<String, LayerCapabilities> layers = parser.listToMap(parser.getOGCAPIFeatures(se));
+        Map<String, LayerCapabilities> layers = parser.parseLayers(serviceJSON, version, getConnectInfo(version));
         assertEquals("Should find 19 layers", 19, layers.size());
         LayerCapabilitiesWFS layerCaps = (LayerCapabilitiesWFS) layers.get("AreaStatisticalUnit_4500k_EPSG_4326_2020");
 

--- a/service-capabilities/src/test/java/org/oskari/capabilities/ogc/WFSCapabilitiesParserTest.java
+++ b/service-capabilities/src/test/java/org/oskari/capabilities/ogc/WFSCapabilitiesParserTest.java
@@ -9,7 +9,6 @@ import org.junit.Test;
 import org.oskari.capabilities.CapabilitiesService;
 import org.oskari.capabilities.LayerCapabilities;
 import org.oskari.capabilities.ServiceConnectInfo;
-import org.oskari.capabilities.ogc.api.OGCAPIFeaturesService;
 import org.oskari.capabilities.ogc.wfs.DescribeFeatureTypeProvider;
 
 import java.io.IOException;
@@ -103,8 +102,7 @@ public class WFSCapabilitiesParserTest {
 
     class DescribeFeatureTypeProviderMock extends DescribeFeatureTypeProvider {
         private String content;
-        public DescribeFeatureTypeProviderMock() {
-        }
+
         public DescribeFeatureTypeProviderMock(String content) {
             this.content = content;
         }

--- a/service-capabilities/src/test/java/org/oskari/capabilities/ogc/WFSCapabilitiesParserTest.java
+++ b/service-capabilities/src/test/java/org/oskari/capabilities/ogc/WFSCapabilitiesParserTest.java
@@ -1,5 +1,6 @@
 package org.oskari.capabilities.ogc;
 
+import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.util.JSONHelper;
 import fi.nls.test.util.ResourceHelper;
 import org.json.JSONObject;
@@ -7,19 +8,25 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.oskari.capabilities.CapabilitiesService;
 import org.oskari.capabilities.LayerCapabilities;
+import org.oskari.capabilities.ServiceConnectInfo;
 import org.oskari.capabilities.ogc.api.OGCAPIFeaturesService;
+import org.oskari.capabilities.ogc.wfs.DescribeFeatureTypeProvider;
 
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class WFSCapabilitiesParserTest {
 
     private static final Set<String> SYSTEM_CRS = new HashSet<>(5);
-    private WFSCapabilitiesParser parser = new WFSCapabilitiesParser();
 
+    private ServiceConnectInfo getConnectInfo(String version) {
+        return new ServiceConnectInfo("https://mydomain.org", OskariLayer.TYPE_WFS, version);
+    }
     @BeforeClass
     public static void init() {
         SYSTEM_CRS.add("EPSG:3857");
@@ -27,18 +34,29 @@ public class WFSCapabilitiesParserTest {
         SYSTEM_CRS.add("EPSG:4326");
     }
 
+    private WFSCapabilitiesParser getParser() {
+        return getParser(null);
+    }
+    private WFSCapabilitiesParser getParser(String describeResponse) {
+        // spy to just override the single method
+        WFSCapabilitiesParser parser = new WFSCapabilitiesParser();
+        parser.setDescribeFeatureTypeProvider(new DescribeFeatureTypeProviderMock(describeResponse));
+        return parser;
+    }
+
     @Test
     public void parseStatFi1_1_0() throws Exception {
+        String version = "1.1.0";
         String xml = ResourceHelper.readStringResource("WFSCapabilitiesParserTest-statfi-1_1_0-input.xml", this);
         String expected = ResourceHelper.readStringResource("WFSCapabilitiesParserTest-statfi-expected.json", this);
 
-        Map<String, LayerCapabilities> layers = parser.parseLayers(xml);
+        Map<String, LayerCapabilities> layers = getParser().parseLayers(xml, version, getConnectInfo(version));
         assertEquals("Should find 297 layers", 297, layers.size());
         LayerCapabilitiesWFS layerCaps = (LayerCapabilitiesWFS) layers.get("tilastointialueet:avi4500k");
         JSONObject json = CapabilitiesService.toJSON(layerCaps, SYSTEM_CRS);
         JSONObject expectedJSON = JSONHelper.createJSONObject(expected);
         // Check and remove version as it is different on expected between 1.1.0 and 2.0.0 input
-        assertEquals("Check version", "1.1.0", json.optJSONObject("typeSpecific").remove("version"));
+        assertEquals("Check version", version, json.optJSONObject("typeSpecific").remove("version"));
         // System.out.println(json);
         assertTrue("JSON should match", JSONHelper.isEqual(json, expectedJSON));
 
@@ -48,16 +66,17 @@ public class WFSCapabilitiesParserTest {
 
     @Test
     public void parseStatFi2_0_0() throws Exception {
+        String version = "2.0.0";
         String xml = ResourceHelper.readStringResource("WFSCapabilitiesParserTest-statfi-2_0_0-input.xml", this);
         String expected = ResourceHelper.readStringResource("WFSCapabilitiesParserTest-statfi-expected.json", this);
 
-        Map<String, LayerCapabilities> layers = parser.parseLayers(xml);
+        Map<String, LayerCapabilities> layers = getParser().parseLayers(xml, version, getConnectInfo(version));
         assertEquals("Should find 297 layers", 297, layers.size());
         LayerCapabilitiesWFS layerCaps = (LayerCapabilitiesWFS) layers.get("tilastointialueet:avi4500k");
         JSONObject json = CapabilitiesService.toJSON(layerCaps, SYSTEM_CRS);
         JSONObject expectedJSON = JSONHelper.createJSONObject(expected);
         // Check and remove version as it is different on expected between 1.1.0 and 2.0.0 input
-        assertEquals("Check version", "2.0.0", json.optJSONObject("typeSpecific").remove("version"));
+        assertEquals("Check version", version, json.optJSONObject("typeSpecific").remove("version"));
         // System.out.println(json);
         assertTrue("JSON should match", JSONHelper.isEqual(json, expectedJSON));
 
@@ -71,7 +90,7 @@ public class WFSCapabilitiesParserTest {
         String expected = ResourceHelper.readStringResource("WFSCapabilitiesParserTest-statfi-3_0_0-expected.json", this);
 
         OGCAPIFeaturesService se = OGCAPIFeaturesService.fromJSON(serviceJSON);
-
+        WFSCapabilitiesParser parser = getParser();
         Map<String, LayerCapabilities> layers = parser.listToMap(parser.getOGCAPIFeatures(se));
         assertEquals("Should find 19 layers", 19, layers.size());
         LayerCapabilitiesWFS layerCaps = (LayerCapabilitiesWFS) layers.get("AreaStatisticalUnit_4500k_EPSG_4326_2020");
@@ -80,5 +99,18 @@ public class WFSCapabilitiesParserTest {
         // System.out.println(json);
         JSONObject expectedJSON = JSONHelper.createJSONObject(expected);
         assertTrue("JSON should match", JSONHelper.isEqual(json, expectedJSON));
+    }
+
+    class DescribeFeatureTypeProviderMock extends DescribeFeatureTypeProvider {
+        private String content;
+        public DescribeFeatureTypeProviderMock() {
+        }
+        public DescribeFeatureTypeProviderMock(String content) {
+            this.content = content;
+        }
+        @Override
+        public String getDescribeContent(String url, String user, String pass) throws IOException {
+            return content;
+        }
     }
 }

--- a/service-capabilities/src/test/java/org/oskari/capabilities/ogc/wfs/DescribeFeatureTypeParserTest.java
+++ b/service-capabilities/src/test/java/org/oskari/capabilities/ogc/wfs/DescribeFeatureTypeParserTest.java
@@ -25,13 +25,13 @@ public class DescribeFeatureTypeParserTest {
     @Test
     public void parseFeatureType() throws Exception {
         String xml = ResourceHelper.readStringResource("WFSDescribeFeatureTypeParserTest-statfi-1_1_0-input.xml", this);
-        List<FeaturePropertyType> props = DescribeFeatureTypeParser.parseFeatureType(xml);
+        List<FeaturePropertyType> props = DescribeFeatureTypeParser.parseFeatureType(xml, "tilastointialueet:avi4500k");
         verify(props);
     }
     @Test
     public void parseFeatureType2_0_0() throws Exception {
         String xml = ResourceHelper.readStringResource("WFSDescribeFeatureTypeParserTest-statfi-2_0_0-input.xml", this);
-        List<FeaturePropertyType> props = DescribeFeatureTypeParser.parseFeatureType(xml);
+        List<FeaturePropertyType> props = DescribeFeatureTypeParser.parseFeatureType(xml, "tilastointialueet:avi4500k");
         verify(props);
     }
 
@@ -43,4 +43,5 @@ public class DescribeFeatureTypeParserTest {
             assertEquals("Prop " + p.name + " should be " + p.type, expected.get(p.name), p.type);
         });
     }
+
 }

--- a/service-capabilities/src/test/java/org/oskari/capabilities/ogc/wfs/DescribeFeatureTypeParserTest.java
+++ b/service-capabilities/src/test/java/org/oskari/capabilities/ogc/wfs/DescribeFeatureTypeParserTest.java
@@ -1,0 +1,46 @@
+package org.oskari.capabilities.ogc.wfs;
+
+import fi.nls.test.util.ResourceHelper;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class DescribeFeatureTypeParserTest {
+
+    private Map<String, String> getExpected() {
+        Map<String, String> expected = new HashMap<>();
+        expected.put("avi", "string");
+        expected.put("vuosi", "int");
+        expected.put("nimi", "string");
+        expected.put("namn", "string");
+        expected.put("name", "string");
+        expected.put("geom", "GeometryPropertyType");
+        return expected;
+    }
+
+    @Test
+    public void parseFeatureType() throws Exception {
+        String xml = ResourceHelper.readStringResource("WFSDescribeFeatureTypeParserTest-statfi-1_1_0-input.xml", this);
+        List<FeaturePropertyType> props = DescribeFeatureTypeParser.parseFeatureType(xml);
+        verify(props);
+    }
+    @Test
+    public void parseFeatureType2_0_0() throws Exception {
+        String xml = ResourceHelper.readStringResource("WFSDescribeFeatureTypeParserTest-statfi-2_0_0-input.xml", this);
+        List<FeaturePropertyType> props = DescribeFeatureTypeParser.parseFeatureType(xml);
+        verify(props);
+    }
+
+    private void verify(List<FeaturePropertyType> props) {
+        Map<String, String> expected = getExpected();
+        assertEquals("Should get expected amount of props", expected.size(), props.size());
+
+        props.stream().forEach(p -> {
+            assertEquals("Prop " + p.name + " should be " + p.type, expected.get(p.name), p.type);
+        });
+    }
+}

--- a/service-capabilities/src/test/resources/org/oskari/capabilities/ogc/wfs/WFSDescribeFeatureTypeParserTest-statfi-1_1_0-input.xml
+++ b/service-capabilities/src/test/resources/org/oskari/capabilities/ogc/wfs/WFSDescribeFeatureTypeParserTest-statfi-1_1_0-input.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" xmlns:tilastointialueet="http://www.tilastointialueet.fi" elementFormDefault="qualified" targetNamespace="http://www.tilastointialueet.fi">
+    <xsd:import namespace="http://www.opengis.net/gml" schemaLocation="https://geo.stat.fi/geoserver/schemas/gml/3.1.1/base/gml.xsd"/>
+    <xsd:complexType name="avi4500kType">
+        <xsd:complexContent>
+            <xsd:extension base="gml:AbstractFeatureType">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="avi" nillable="true" type="xsd:string"/>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="vuosi" nillable="true" type="xsd:int"/>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="nimi" nillable="true" type="xsd:string"/>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="namn" nillable="true" type="xsd:string"/>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="name" nillable="true" type="xsd:string"/>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="geom" nillable="true" type="gml:GeometryPropertyType"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:element name="avi4500k" substitutionGroup="gml:_Feature" type="tilastointialueet:avi4500kType"/>
+</xsd:schema>

--- a/service-capabilities/src/test/resources/org/oskari/capabilities/ogc/wfs/WFSDescribeFeatureTypeParserTest-statfi-2_0_0-input.xml
+++ b/service-capabilities/src/test/resources/org/oskari/capabilities/ogc/wfs/WFSDescribeFeatureTypeParserTest-statfi-2_0_0-input.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:tilastointialueet="http://www.tilastointialueet.fi" xmlns:wfs="http://www.opengis.net/wfs/2.0" elementFormDefault="qualified" targetNamespace="http://www.tilastointialueet.fi">
+    <xsd:import namespace="http://www.opengis.net/gml/3.2" schemaLocation="https://geo.stat.fi/geoserver/schemas/gml/3.2.1/gml.xsd"/>
+    <xsd:complexType name="avi4500kType">
+        <xsd:complexContent>
+            <xsd:extension base="gml:AbstractFeatureType">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="avi" nillable="true" type="xsd:string"/>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="vuosi" nillable="true" type="xsd:int"/>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="nimi" nillable="true" type="xsd:string"/>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="namn" nillable="true" type="xsd:string"/>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="name" nillable="true" type="xsd:string"/>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="geom" nillable="true" type="gml:GeometryPropertyType"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:element name="avi4500k" substitutionGroup="gml:AbstractFeature" type="tilastointialueet:avi4500kType"/>
+</xsd:schema>

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
@@ -272,7 +272,7 @@ public class LayerJSONFormatter {
      * @return null iff attributes.forcedSRS and capabilities.srs are both null
      *         otherwise a Set containing both (can be empty)
      */
-    protected static Set<String> getSRSs(JSONObject attributes, JSONObject capabilities) {
+    public static Set<String> getSRSs(JSONObject attributes, JSONObject capabilities) {
         JSONArray jsonForcedSRS = attributes != null ? attributes.optJSONArray(KEY_ATTRIBUTE_FORCED_SRS): null;
         JSONArray jsonCapabilitiesSRS = capabilities != null ? capabilities.optJSONArray(KEY_SRS): null;
         if (jsonForcedSRS == null && jsonCapabilitiesSRS == null) {


### PR DESCRIPTION
So we can get the geometryfield and properties in capabilities as well.

Previous parsing code that we can get rid of after this parsing is finalized:
- https://github.com/oskariorg/oskari-server/blob/develop/control-base/src/main/java/fi/nls/oskari/util/WFSDescribeFeatureHelper.java
- https://github.com/oskariorg/oskari-server/blob/develop/control-base/src/main/java/fi/nls/oskari/util/WFSGetLayerFields.java
