### PR TITLE
Always return a set from combined srs list to prevent npe

### DIFF
--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
@@ -164,7 +164,7 @@ public class LayerJSONFormatter {
 
         // setup supported projections
         Set<String> srs = getSRSs(layer.getAttributes(), layer.getCapabilities());
-        if (srs != null) {
+        if (srs != null && !srs.isEmpty()) {
             JSONHelper.putValue(layerJson, KEY_SRS, new JSONArray(srs));
         }
 
@@ -277,7 +277,7 @@ public class LayerJSONFormatter {
         JSONArray jsonCapabilitiesSRS = capabilities != null ? capabilities.optJSONArray(KEY_SRS): null;
         if (jsonForcedSRS == null && jsonCapabilitiesSRS == null) {
             LOG.debug("No SRS information found from either attributes or capabilities");
-            return null;
+            return Collections.emptySet();
         }
         Set<String> srs = new HashSet<>();
         srs.addAll(JSONHelper.getArrayAsList(jsonForcedSRS));

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWMTS.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWMTS.java
@@ -36,7 +36,7 @@ public class LayerJSONFormatterWMTS extends LayerJSONFormatter {
         }
 
         Set<String> srs = getSRSs(layer.getAttributes(), layer.getCapabilities());
-        if (srs != null) {
+        if (srs != null && !srs.isEmpty()) {
             JSONHelper.putValue(layerJson, KEY_SRS, new JSONArray(srs));
         }
 


### PR DESCRIPTION
Previously returned null which breaks this https://github.com/oskariorg/oskari-server/pull/831/commits/e35eef579f9044f9e91d65a0b42aa8fa708e028d change. Fixes an issue where sample-app initial db content couldn't be constructed.