### PR TITLE
Small tweaks for capabilities updates

### DIFF
--- a/service-capabilities-update/src/main/java/org/oskari/capabilities/CapabilitiesUpdateService.java
+++ b/service-capabilities-update/src/main/java/org/oskari/capabilities/CapabilitiesUpdateService.java
@@ -62,6 +62,7 @@ public class CapabilitiesUpdateService {
         switch (type) {
         case OskariLayer.TYPE_WMS:
         case OskariLayer.TYPE_WMTS:
+        case OskariLayer.TYPE_WFS:
             return true;
         default:
             return false;

--- a/service-capabilities-update/src/test/java/org/oskari/capabilities/CapabilitiesUpdateServiceTest.java
+++ b/service-capabilities-update/src/test/java/org/oskari/capabilities/CapabilitiesUpdateServiceTest.java
@@ -13,7 +13,7 @@ public class CapabilitiesUpdateServiceTest {
     public void testCanUpdate() {
         assertTrue("Should allow WMTS", CapabilitiesUpdateService.canUpdate(OskariLayer.TYPE_WMTS));
         assertTrue("Should allow WMS", CapabilitiesUpdateService.canUpdate(OskariLayer.TYPE_WMS));
-        assertFalse("Should NOT allow WFS", CapabilitiesUpdateService.canUpdate(OskariLayer.TYPE_WFS));
+        assertTrue("Should allow WFS", CapabilitiesUpdateService.canUpdate(OskariLayer.TYPE_WFS));
         assertFalse("Should NOT allow analysis", CapabilitiesUpdateService.canUpdate(OskariLayer.TYPE_ANALYSIS));
         assertFalse("Should NOT allow argcis93", CapabilitiesUpdateService.canUpdate(OskariLayer.TYPE_ARCGIS93));
         assertFalse("Should NOT allow stats", CapabilitiesUpdateService.canUpdate(OskariLayer.TYPE_STATS));

--- a/service-capabilities/src/main/java/org/oskari/capabilities/CapabilitiesService.java
+++ b/service-capabilities/src/main/java/org/oskari/capabilities/CapabilitiesService.java
@@ -94,6 +94,9 @@ public class CapabilitiesService {
     }
 
     public static JSONObject toJSON(LayerCapabilities caps, Set<String> systemCRSs) {
+        if (caps == null) {
+            throw new ServiceRuntimeException("Tried serializing <null> capabilities as JSON");
+        }
         try {
             String raw = MAPPER.writeValueAsString(caps);
             JSONObject json = new JSONObject(raw);


### PR DESCRIPTION
- Adds nicer log message if layer was not found in capabilities doc. 
- Add WFS layers for schedules capabilities updates

Thoughts: Should we return null/empty capabilities instead when the assumed layer name isn't directly found from the capabilitiies? The usual cause is that the layer is not found in capabilities doc. It might be under namespace or we are searching with namespace and it's with just the local name in capabilities. The namespace issue we could solve by trying harder to find it, but it would require the admin user-interface to tell the admin that the layer name was changed to match capabilities doc as well.