### PR TITLE
Refactor GetLayerCapabilities and fetching raw capabilities response

### DIFF
--- a/control-base/src/main/java/org/oskari/capabilities/RawCapabilitiesHelper.java
+++ b/control-base/src/main/java/org/oskari/capabilities/RawCapabilitiesHelper.java
@@ -1,0 +1,28 @@
+package org.oskari.capabilities;
+
+import fi.nls.oskari.control.ActionException;
+import fi.nls.oskari.control.ActionParamsException;
+import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.service.ServiceException;
+import org.oskari.capabilities.ogc.OGCCapabilitiesParser;
+
+import java.io.IOException;
+
+public class RawCapabilitiesHelper {
+    public static RawCapabilitiesResponse getCapabilities(OskariLayer layer) throws ActionException {
+        CapabilitiesParser parser = CapabilitiesService.getParser(layer.getType());
+        if (parser == null) {
+            throw new ActionParamsException("Unsupported layer type: " + layer.getType());
+        }
+        if (!(parser instanceof OGCCapabilitiesParser)) {
+            throw new ActionParamsException("Only OGC layers support capabilities");
+        }
+        OGCCapabilitiesParser ogcParser = (OGCCapabilitiesParser) parser;
+        String url = ogcParser.contructCapabilitiesUrl(layer.getUrl(), layer.getVersion());
+        try {
+            return ogcParser.fetchCapabilities(url, layer.getUsername(), layer.getPassword(), ogcParser.getExpectedContentType(layer.getVersion()));
+        } catch (IOException | ServiceException  ex) {
+            throw new ActionException("Error fetching capabilities", ex);
+        }
+    }
+}

--- a/control-base/src/test/java/fi/nls/oskari/control/layer/GetLayerCapabilitiesHandlerTest.java
+++ b/control-base/src/test/java/fi/nls/oskari/control/layer/GetLayerCapabilitiesHandlerTest.java
@@ -7,8 +7,6 @@ import fi.nls.oskari.control.ActionParameters;
 import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.map.layer.OskariLayerService;
 import fi.nls.oskari.map.layer.OskariLayerServiceMybatisImpl;
-import fi.nls.oskari.service.OskariComponentManager;
-import fi.nls.oskari.service.capabilities.CapabilitiesCacheService;
 import fi.nls.oskari.util.PropertyUtil;
 import fi.nls.test.control.JSONActionRouteTest;
 import fi.nls.test.util.TestHelper;
@@ -30,9 +28,6 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
-/**
- * Created by SMAKINEN on 28.8.2015.
- */
 @RunWith(PowerMockRunner.class)
 public class GetLayerCapabilitiesHandlerTest extends JSONActionRouteTest {
 
@@ -44,10 +39,6 @@ public class GetLayerCapabilitiesHandlerTest extends JSONActionRouteTest {
         assumeTrue(TestHelper.dbAvailable());
         OskariLayerService layerService = getOskariLayerService();
         PermissionService permissionsService = getPermissionsService();
-        // replace the cache service with a test service
-        OskariComponentManager.removeComponentsOfType(CapabilitiesCacheService.class);
-        OskariComponentManager.addComponent(new CapabilitiesCacheServiceMock(TEST_DATA));
-        //CapabilitiesCacheService service = OskariComponentManager.getComponentOfType(CapabilitiesCacheService.class);
         handler = new GetLayerCapabilitiesHandler();
 
         PermissionHelper helper = new PermissionHelper(layerService, permissionsService);

--- a/service-capabilities/src/main/java/org/oskari/capabilities/CapabilitiesParser.java
+++ b/service-capabilities/src/main/java/org/oskari/capabilities/CapabilitiesParser.java
@@ -49,6 +49,7 @@ public abstract class CapabilitiesParser extends OskariComponent {
             throw new ServiceException("Unexpected Content-Type: " + contentType + " from: " + capabilitiesUrl);
         }
         RawCapabilitiesResponse response = new RawCapabilitiesResponse(conn.getURL().toString());
+        response.setContentType(contentType);
         String encoding = IOHelper.getCharset(conn);
         response.setResponse(IOHelper.readBytes(conn), encoding);
         return response;

--- a/service-capabilities/src/main/java/org/oskari/capabilities/CapabilitiesService.java
+++ b/service-capabilities/src/main/java/org/oskari/capabilities/CapabilitiesService.java
@@ -110,7 +110,7 @@ public class CapabilitiesService {
         }
     }
 
-    private static CapabilitiesParser getParser(String layerType) {
+    protected static CapabilitiesParser getParser(String layerType) {
         return (CapabilitiesParser) OskariComponentManager
                 .getComponentsOfType(CapabilitiesParser.class)
                 .get(layerType);

--- a/service-capabilities/src/main/java/org/oskari/capabilities/RawCapabilitiesResponse.java
+++ b/service-capabilities/src/main/java/org/oskari/capabilities/RawCapabilitiesResponse.java
@@ -5,6 +5,7 @@ public class RawCapabilitiesResponse {
     private final String url;
     private byte[] response;
     private String encoding;
+    private String contentType;
 
     public RawCapabilitiesResponse(String url) {
         this.url = url;
@@ -18,8 +19,17 @@ public class RawCapabilitiesResponse {
     public String getEncoding() {
         return encoding;
     }
+
     public byte[] getResponse() {
         return response;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
     }
 
     public void setResponse(byte[] resp, String encoding) {
@@ -32,7 +42,7 @@ public class RawCapabilitiesResponse {
         StringBuilder sb = new StringBuilder();
         sb.append('{');
         sb.append(",url=").append(url);
-        sb.append(",bytes=").append(response != null ? response.length: -1);
+        sb.append(",bytes=").append(response != null ? response.length : -1);
         sb.append('}');
         return sb.toString();
     }

--- a/service-capabilities/src/main/java/org/oskari/capabilities/ogc/OGCCapabilitiesParser.java
+++ b/service-capabilities/src/main/java/org/oskari/capabilities/ogc/OGCCapabilitiesParser.java
@@ -21,7 +21,7 @@ public abstract class OGCCapabilitiesParser extends CapabilitiesParser {
         return "xml";
     }
     // allow overriding for OGC API services etc
-    protected String getExpectedContentType(String version) {
+    public String getExpectedContentType(String version) {
         return getExpectedContentType();
     }
     protected abstract String getDefaultVersion();
@@ -60,7 +60,7 @@ public abstract class OGCCapabilitiesParser extends CapabilitiesParser {
         return parseLayers(capabilities, version);
     }
 
-    protected String contructCapabilitiesUrl(String url, String version) {
+    public String contructCapabilitiesUrl(String url, String version) {
         String urlLC = url.toLowerCase();
 
         final Map<String, String> params = new HashMap<>();

--- a/service-capabilities/src/main/java/org/oskari/capabilities/ogc/WFSCapabilitiesParser.java
+++ b/service-capabilities/src/main/java/org/oskari/capabilities/ogc/WFSCapabilitiesParser.java
@@ -37,7 +37,7 @@ public class WFSCapabilitiesParser extends OGCCapabilitiesParser {
         return "acceptVersions";
     }
     protected String getDefaultVersion() { return "1.1.0"; }
-    protected String getExpectedContentType(String version) {
+    public String getExpectedContentType(String version) {
         if (OGC_API_VERSION.equals(version)) {
             return "json";
         }
@@ -110,6 +110,13 @@ public class WFSCapabilitiesParser extends OGCCapabilitiesParser {
         } catch (Exception e) {
             throw new ServiceException("Unable to parse layers for WFS capabilities", e);
         }
+    }
+
+    public String contructCapabilitiesUrl(String url, String version) {
+        if (OGC_API_VERSION.equals(version)) {
+            return OGCAPIFeaturesService.constructUrl(url);
+        }
+        return super.contructCapabilitiesUrl(url, version);
     }
 
     protected void enhanceCapabilitiesData(LayerCapabilitiesWFS layer, ServiceConnectInfo src) {

--- a/service-capabilities/src/main/java/org/oskari/capabilities/ogc/api/OGCAPIFeaturesService.java
+++ b/service-capabilities/src/main/java/org/oskari/capabilities/ogc/api/OGCAPIFeaturesService.java
@@ -63,10 +63,17 @@ public class OGCAPIFeaturesService {
         String conformanceUrl = url + "/conformance";
         OGCAPIReqClasses reqClasses = load(conformanceUrl, user, pass, OGCAPIReqClasses.class);
 
-        String collectionsUrl = url + "/collections";
+        String collectionsUrl = constructUrl(url);
         FeaturesContent collections = load(collectionsUrl, user, pass, FeaturesContent.class);
 
         return new OGCAPIFeaturesService(reqClasses, collections);
+    }
+
+    public static String constructUrl(String baseUrl) {
+        while (baseUrl.endsWith("/")) {
+            baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+        }
+        return baseUrl + "/collections";
     }
 
     public String toJSON() throws JsonProcessingException {


### PR DESCRIPTION
The action route now uses the same urls/logic to fetch raw capabilities response as CapabilitiesService (skipping the parsing).