### PR TITLE
Fix config for CreateUserLayer

### DIFF
--- a/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java
+++ b/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java
@@ -378,8 +378,10 @@ public class CreateUserLayerHandler extends RestActionHandler {
                 }
             }
             return mainFile;
+        } catch (EOFException e) {
+            throw new ServiceException("File too large. " + e.getMessage());
         } catch (IOException e) {
-            throw new ServiceException("Failed to unzip file: " + zipFile.getName() + ": " + e.getMessage());
+            throw new ServiceException("Failed to unzip file: " + zipFile.getName());
         }
     }
 

--- a/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
@@ -270,7 +270,7 @@ public class IOHelper {
         int read = 0;
         while ((read = in.read(buffer, 0, BUFFER_SIZE)) != -1) {
             if (sizeLimit > -1 && total + read > sizeLimit) {
-                throw new IOException("Size limit reached: " + humanReadableByteCount(sizeLimit));
+                throw new EOFException("Size limit reached: " + humanReadableByteCount(sizeLimit));
             }
             out.write(buffer, 0, read);
             total += read;


### PR DESCRIPTION
Initialize props when the route is called so we can be sure the oskari-ext.properties file has been read before we get the values. To workaround the properties file timing issue we can use `OSKARI_USERLAYER_MAX_FILESIZE_MB=15` env variable, but this should work with the values configured in the file as well.

Also make unzipped file size limit exception more informative.