### PR TITLE
Fix migrations using service code

### DIFF
--- a/content-resources/src/main/java/flyway/oskari/V2_7_10__update_capabilities_WMS.java
+++ b/content-resources/src/main/java/flyway/oskari/V2_7_10__update_capabilities_WMS.java
@@ -1,14 +1,14 @@
 package flyway.oskari;
 
 import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.domain.map.view.Bundle;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
-import fi.nls.oskari.map.view.ViewService;
-import fi.nls.oskari.map.view.util.ViewHelper;
-import fi.nls.oskari.service.OskariComponentManager;
 import org.flywaydb.core.api.migration.Context;
+import org.json.JSONObject;
 import org.oskari.capabilities.CapabilitiesService;
 import org.oskari.capabilities.CapabilitiesUpdateResult;
+import org.oskari.helpers.AppSetupHelper;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * This updates the oskari_maplayer.capabilities column in the db
@@ -26,7 +27,7 @@ public class V2_7_10__update_capabilities_WMS extends V2_7_0__update_WMTS_capabi
         Logger log = LogFactory.getLogger(V2_7_1__update_WMS_capabilities.class);
         Connection connection = context.getConnection();
         List<OskariLayer> layers = getLayers(connection, OskariLayer.TYPE_WMS);
-        Set<String> systemCRS = ViewHelper.getSystemCRSs(OskariComponentManager.getComponentOfType(ViewService.class));
+        Set<String> systemCRS = getSystemCRS(connection);
         List<CapabilitiesUpdateResult> results = CapabilitiesService.updateCapabilities(layers, systemCRS);
 
         Map<String, OskariLayer> layersById = new HashMap<>(layers.size());
@@ -49,5 +50,36 @@ public class V2_7_10__update_capabilities_WMS extends V2_7_0__update_WMTS_capabi
                     });
         }
     }
+
+    protected Set<String> getSystemCRS(Connection conn) throws SQLException {
+        List<Long> appsetups = AppSetupHelper.getSetupsForUserAndDefaultType(conn);
+
+        return appsetups.stream()
+                .map(appId -> getMapfullBundle(conn, appId))
+                .filter(i -> i != null)
+                .map(bundle -> getSRSFromMapfullConfig(bundle.getConfigJSON()))
+                .filter(i -> i != null)
+                .collect(Collectors.toSet());
+    }
+
+    private Bundle getMapfullBundle(Connection conn, long appId) {
+        try {
+            return AppSetupHelper.getAppBundle(conn, appId, "mapfull");
+        } catch (SQLException e) {
+            return null;
+        }
+    }
+
+    private String getSRSFromMapfullConfig(JSONObject conf) {
+        if (conf == null) {
+            return null;
+        }
+        JSONObject opts = conf.optJSONObject("mapOptions");
+        if (opts == null) {
+            return null;
+        }
+        return opts.optString("srsName", null);
+    }
+
 
 }

--- a/content-resources/src/main/java/flyway/oskari/V2_7_11__update_capabilities_WFS.java
+++ b/content-resources/src/main/java/flyway/oskari/V2_7_11__update_capabilities_WFS.java
@@ -3,9 +3,6 @@ package flyway.oskari;
 import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
-import fi.nls.oskari.map.view.ViewService;
-import fi.nls.oskari.map.view.util.ViewHelper;
-import fi.nls.oskari.service.OskariComponentManager;
 import org.flywaydb.core.api.migration.Context;
 import org.oskari.capabilities.CapabilitiesService;
 import org.oskari.capabilities.CapabilitiesUpdateResult;
@@ -20,13 +17,13 @@ import java.util.Set;
 /**
  * This updates the oskari_maplayer.capabilities column in the db
  */
-public class V2_7_11__update_capabilities_WFS extends V2_7_0__update_WMTS_capabilities {
+public class V2_7_11__update_capabilities_WFS extends V2_7_10__update_capabilities_WMS {
     @Override
     public void migrate(Context context) throws Exception {
         Logger log = LogFactory.getLogger(V2_7_1__update_WMS_capabilities.class);
         Connection connection = context.getConnection();
         List<OskariLayer> layers = getLayers(connection, OskariLayer.TYPE_WFS);
-        Set<String> systemCRS = ViewHelper.getSystemCRSs(OskariComponentManager.getComponentOfType(ViewService.class));
+        Set<String> systemCRS = getSystemCRS(connection);
         List<CapabilitiesUpdateResult> results = CapabilitiesService.updateCapabilities(layers, systemCRS);
 
         Map<String, OskariLayer> layersById = new HashMap<>(layers.size());

--- a/content-resources/src/main/java/flyway/oskari/V2_7_12__update_capabilities_WMTS.java
+++ b/content-resources/src/main/java/flyway/oskari/V2_7_12__update_capabilities_WMTS.java
@@ -3,9 +3,6 @@ package flyway.oskari;
 import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
-import fi.nls.oskari.map.view.ViewService;
-import fi.nls.oskari.map.view.util.ViewHelper;
-import fi.nls.oskari.service.OskariComponentManager;
 import org.flywaydb.core.api.migration.Context;
 import org.oskari.capabilities.CapabilitiesService;
 import org.oskari.capabilities.CapabilitiesUpdateResult;
@@ -20,13 +17,13 @@ import java.util.Set;
 /**
  * This updates the oskari_maplayer.capabilities column in the db
  */
-public class V2_7_12__update_capabilities_WMTS extends V2_7_0__update_WMTS_capabilities {
+public class V2_7_12__update_capabilities_WMTS extends V2_7_10__update_capabilities_WMS {
     @Override
     public void migrate(Context context) throws Exception {
         Logger log = LogFactory.getLogger(V2_7_0__update_WMTS_capabilities.class);
         Connection connection = context.getConnection();
         List<OskariLayer> layers = getLayers(connection, OskariLayer.TYPE_WMTS);
-        Set<String> systemCRS = ViewHelper.getSystemCRSs(OskariComponentManager.getComponentOfType(ViewService.class));
+        Set<String> systemCRS = getSystemCRS(connection);
         List<CapabilitiesUpdateResult> results = CapabilitiesService.updateCapabilities(layers, systemCRS);
 
         Map<String, OskariLayer> layersById = new HashMap<>(layers.size());


### PR DESCRIPTION
Don't use existing `ViewService` for migrations to get a list of projections used in the instance. The problem is that some of the migrations are run before the database changes and the service classes expect the database to be fully migrated before they are used. This fixes the issue by using migration helpers to detect projections that are used by the system for capabilities updated instead of the actual service classes.