### PR TITLE
Default publish domain to empty string on server

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/view/AppSetupHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/view/AppSetupHandler.java
@@ -304,7 +304,7 @@ public class AppSetupHandler extends RestActionHandler {
         }
 
         // setup basic info about view
-        final String domain = JSONHelper.getStringFromJSON(view.getMetadata(), KEY_DOMAIN, null);
+        final String domain = JSONHelper.getStringFromJSON(view.getMetadata(), KEY_DOMAIN, "");
         final String name = JSONHelper.getStringFromJSON(view.getMetadata(), KEY_NAME, "Published map " + System.currentTimeMillis());
         final String language = JSONHelper.getStringFromJSON(view.getMetadata(), KEY_LANGUAGE, PropertyUtil.getDefaultLanguage());
 


### PR DESCRIPTION
Fixes an issue that happens after https://github.com/oskariorg/oskari-frontend/pull/1895. If user doesn't touch the "domain" field the React-UI doesn't initialize the field value and as such it's not sent to the server. Having a null value results in a NPE a couple of lines after when trim() is called for the value. There might be other parts in the code that doesn't check for null as this has always been sent previously so just defaulting it to empty string to prevent other issues. There has been discussions whether this should be a list instead of a single value so a simple change that makes the field work like before for other parts of the server.