### PR TITLE
Fix main maplayer group creation

### DIFF
--- a/service-base/src/main/java/fi/nls/oskari/domain/map/MaplayerGroup.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/MaplayerGroup.java
@@ -6,7 +6,7 @@ import org.json.JSONObject;
 
 public class MaplayerGroup extends JSONLocalizedName {
     private int id;
-    private int parentId;
+    private int parentId = -1;
     private boolean selectable;
     private int orderNumber = -1;
 


### PR DESCRIPTION
Now when saving new parent theme group the parentId is saved incorrectly saved as 0 (and for this reason the group is visible in the front only during the session).

The bug can be reproduced at [demo.oskari.org](https://demo.oskari.org/):
* [ ] login admin/oskari user
* [ ] add and save a new main theme group in the layerlist
* [ ] now the newly created group is shown in the layrlist
* [ ] refresh page and group is now visible anymore because new group gets parentId as 0


This PR fixes at main group parentId is -1.