### PR TITLE
Jetty 9.4.44.v20210927 -> 9.4.48.v20220622

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
 
         <fi.mml.nameregister.version>1.0</fi.mml.nameregister.version>
 
-        <jetty.version>9.4.44.v20210927</jetty.version>
+        <jetty.version>9.4.48.v20220622</jetty.version>
         <mybatis.version>3.5.7</mybatis.version>
         <flyway.version>6.5.7</flyway.version>
         <postgresql.version>42.5.0</postgresql.version>


### PR DESCRIPTION
Jetty has been upgraded in sample-configs repository: https://github.com/oskariorg/sample-configs/pull/21. The new bundled version will be 9.4.48.