### PR TITLE
update geotools, jts and mvt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,9 +92,9 @@
         <jedis.version>3.8.0</jedis.version>
         <quartz-scheduler.version>2.3.2</quartz-scheduler.version>
 
-        <geotools.version>25.1</geotools.version>
-        <jts.version>1.18.1</jts.version>
-        <mvt.version>1.3.15</mvt.version>
+        <geotools.version>27.1</geotools.version>
+        <jts.version>1.18.2</jts.version>
+        <mvt.version>1.3.16</mvt.version>
         <flexjson.version>2.0</flexjson.version>
 
         <pdfbox.version>2.0.24</pdfbox.version>


### PR DESCRIPTION
Update:
GeoTools: 25.1 => 27.1
jts: 1.18.1 => 1.18.2
mvt (no.ecc.vectortile): 1.3.15 => 1.3.16

There is also mvt 1.3.17 and jts 1.19.0 available but GeoTools 27.1 uses jts 1.18.2 (as mvt 1.3.16). 
GeoTools 28-SNAPSHOT uses jts 1.9.0.

