### PR TITLE
Ignore timeseries value when there is no resolution present

### DIFF
--- a/service-capabilities/src/main/java/org/oskari/capabilities/ogc/wms/WMSCapsParser1_1_1.java
+++ b/service-capabilities/src/main/java/org/oskari/capabilities/ogc/wms/WMSCapsParser1_1_1.java
@@ -90,7 +90,8 @@ public class WMSCapsParser1_1_1 extends WMSCapsParser {
         if (dimension == null || extent == null) {
             return null;
         }
-        if (!"time".equals(XmlHelper.getAttributeValue(extent, "name"))) {
+        // All parameter names are case-insensitive
+        if (!"time".equalsIgnoreCase(XmlHelper.getAttributeValue(extent, "name"))) {
             return null;
         }
         if (!"ISO8601".equals(XmlHelper.getAttributeValue(dimension, "units"))) {
@@ -100,6 +101,10 @@ public class WMSCapsParser1_1_1 extends WMSCapsParser {
         if (content.trim().isEmpty()) {
             return null;
         }
+        /* For the TIME parameter, the special keyword 'current' may be used if advertised by the server as in Annex C.3,
+        Specifying Dimensional Extents. The expression "TIME=current" means "send the most current data available."
+        The expression "TIME=start_time/current" means "send data from start_time up to the most current data available."
+         */
         return content.split("\\s*,\\s*");
     }
 }

--- a/service-capabilities/src/main/java/org/oskari/capabilities/ogc/wms/WMSCapsParser1_3_0.java
+++ b/service-capabilities/src/main/java/org/oskari/capabilities/ogc/wms/WMSCapsParser1_3_0.java
@@ -85,7 +85,8 @@ public class WMSCapsParser1_3_0 extends WMSCapsParser {
         if (dimension == null) {
             return null;
         }
-        if (!"time".equals(XmlHelper.getAttributeValue(dimension, "name"))) {
+        // All parameter names are case-insensitive
+        if (!"time".equalsIgnoreCase(XmlHelper.getAttributeValue(dimension, "name"))) {
             return null;
         }
         if (!"ISO8601".equals(XmlHelper.getAttributeValue(dimension, "units"))) {

--- a/service-map/src/test/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWMSTest.java
+++ b/service-map/src/test/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWMSTest.java
@@ -1,0 +1,54 @@
+package fi.nls.oskari.map.layer.formatters;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class LayerJSONFormatterWMSTest {
+
+    private JSONObject generateCaps(String... values)  throws JSONException{
+        JSONObject caps = new JSONObject();
+        if (values != null) {
+            JSONArray times = new JSONArray();
+            for(String value: values) {
+                times.put(value);
+            }
+            caps.put("times", times);
+        }
+        return caps;
+    }
+
+    @Test
+    public void getTimesFromCapabilitiesNone() throws JSONException {
+        JSONObject caps = generateCaps();
+        JSONArray parsed = LayerJSONFormatterWMS.getTimesFromCapabilities(caps);
+        assertNull("No times should be parsed as 'no timeseries'", parsed);
+    }
+    @Test
+    public void getTimesFromCapabilitiesSingle() throws JSONException {
+        JSONObject caps = generateCaps("2021");
+        JSONArray parsed = LayerJSONFormatterWMS.getTimesFromCapabilities(caps);
+        assertNull("Single year should be parsed as 'no timeseries'", parsed);
+    }
+    @Test
+    public void getTimesFromCapabilitiesMultiple() throws JSONException {
+        JSONObject caps = generateCaps("2021", "2022");
+        JSONArray parsed = LayerJSONFormatterWMS.getTimesFromCapabilities(caps);
+        assertEquals("Two years should be parsed as having timeseries", 2, parsed.length());
+    }
+    @Test
+    public void getTimesFromCapabilitiesRangeWithoutResolution() throws JSONException {
+        JSONObject caps = generateCaps("1970-01-01/2022-12-1");
+        JSONArray parsed = LayerJSONFormatterWMS.getTimesFromCapabilities(caps);
+        assertNull("Only start/end without resolution should be parsed as 'no timeseries'", parsed);
+    }
+    @Test
+    public void getTimesFromCapabilitiesRangeWithResolution() throws JSONException {
+        JSONObject caps = generateCaps("1970-01-01/2022-12-1/P1Y");
+        JSONArray parsed = LayerJSONFormatterWMS.getTimesFromCapabilities(caps);
+        assertEquals("Returned as is when there is start/end/resolution", 1, parsed.length());
+    }
+}


### PR DESCRIPTION
Some services have timeseries described like this:
```
<Extent name="time" default="9999-99" nearestValue="0">1978-11/2015-12</Extent> 
```
If we added code to detect a resolution we might be able to make an educated guess that the above could be P1Y or P1M. But for now lets skip the timeseries when we need to do guessing. If there is only single value in the times array the frontend breaks visually so filtering them out.