### PR TITLE
Fix NPE when getting charset from request

### DIFF
--- a/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
@@ -466,6 +466,9 @@ public class IOHelper {
 
     public static String getCharset(final HttpURLConnection con, final String defaultCharset) {
         final String contentType = con.getContentType();
+        if (contentType == null) {
+            return defaultCharset;
+        }
         final String[] values = contentType.split(";");
 
         for (String value : values) {


### PR DESCRIPTION
Some servers omit the content-type which results in null pointer exception.