### PR TITLE
Remove dummy regionset for user indicator before it is sent to frontend

### DIFF
--- a/control-statistics/src/main/java/fi/nls/oskari/control/statistics/GetIndicatorListHandler.java
+++ b/control-statistics/src/main/java/fi/nls/oskari/control/statistics/GetIndicatorListHandler.java
@@ -88,11 +88,7 @@ public class GetIndicatorListHandler extends ActionHandler {
             JSONHelper.putValue(json, KEY_CREATED, indicator.getCreated());
             JSONHelper.putValue(json, KEY_UPDATED, indicator.getUpdated());
             // add layer ids as available regionsets for the indicator
-            JSONHelper.putValue(json, KEY_REGIONSETS, new JSONArray(indicator
-                    .getLayers()
-                    .stream()
-                    .map(StatisticalIndicatorLayer::getOskariLayerId)
-                    .collect(Collectors.toSet())));
+            JSONHelper.putValue(json, KEY_REGIONSETS, StatisticsHelper.toJSON(indicator.getLayers()));
             return Optional.of(json);
         } catch (NoSuchElementException e) {
             return Optional.empty();

--- a/control-statistics/src/main/java/fi/nls/oskari/control/statistics/StatisticsHelper.java
+++ b/control-statistics/src/main/java/fi/nls/oskari/control/statistics/StatisticsHelper.java
@@ -4,9 +4,11 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import fi.nls.oskari.cache.JedisManager;
 import fi.nls.oskari.control.statistics.data.*;
+import fi.nls.oskari.util.JSONHelper;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -120,12 +122,14 @@ public class StatisticsHelper {
         return stringArray;
     }
 
-    public static JSONArray toJSON(List<StatisticalIndicatorLayer> layers) throws JSONException {
-        JSONArray layersJSON = new JSONArray();
-        for (StatisticalIndicatorLayer layer: layers) {
-            layersJSON.put(layer.getOskariLayerId());
-        }
-        return layersJSON;
+    public static JSONArray toJSON(List<StatisticalIndicatorLayer> layers) {
+        return new JSONArray(layers
+                .stream()
+                .map(StatisticalIndicatorLayer::getOskariLayerId)
+                // user indicators use a dummy -1 regionset to allow the indicator to pass to frontend.
+                // remove the dummy regionset here before we pass it to frontend
+                .filter(id -> id != -1)
+                .collect(Collectors.toSet()));
     }
 
 


### PR DESCRIPTION
Instead of handling in the frontend https://github.com/oskariorg/oskari-frontend/pull/1957

Also use the same code to get regionsets for list and indicator metadata.