### PR TITLE
WFSSearchChannel: get region from a property

### DIFF
--- a/service-search-wfs/src/main/java/fi/nls/oskari/search/channel/WFSChannelHandler.java
+++ b/service-search-wfs/src/main/java/fi/nls/oskari/search/channel/WFSChannelHandler.java
@@ -15,6 +15,7 @@ import java.io.ByteArrayOutputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Default handler for WFS Search channel filter and title
@@ -89,12 +90,8 @@ public class WFSChannelHandler extends OskariComponent {
     }
 
     public String getTitle(List<SelectItem> list, String separator) {
-        StringBuilder buf = new StringBuilder();
-        for(SelectItem item : list) {
-            buf.append(item.getValue());
-            buf.append(separator);
-        }
-        // drop last separator (', ')
-        return buf.substring(0, buf.length()-separator.length());
+        return list.stream()
+                .map(SelectItem::getValue)
+                .collect(Collectors.joining(separator));
     }
 }

--- a/service-search-wfs/src/test/java/fi/nls/oskari/search/channel/WFSSearchChannelTest.java
+++ b/service-search-wfs/src/test/java/fi/nls/oskari/search/channel/WFSSearchChannelTest.java
@@ -1,0 +1,93 @@
+package fi.nls.oskari.search.channel;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.json.JSONObject;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import fi.mml.portti.service.search.SearchResultItem;
+import fi.nls.oskari.util.JSONHelper;
+import fi.nls.oskari.wfs.WFSSearchChannelsConfiguration;
+
+public class WFSSearchChannelTest {
+
+    private static JSONObject dinagatIslands;
+    private static JSONObject pointFeature;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        String dinagat = ""
+                + "{"
+                + "  'type': 'Feature',"
+                + "  'geometry': {"
+                + "    'type': 'Point',"
+                + "    'coordinates': [125.6, 10.1]"
+                + "  },"
+                + "  'properties': {"
+                + "    'name': 'Dinagat Islands',"
+                + "    'region': 'Caraga'"
+                + "  }"
+                + "}";
+        dinagat.replace('\'', '"');
+        dinagatIslands = new JSONObject(dinagat);
+
+        String point = ""
+                + "{"
+                + "  'type': 'Feature',"
+                + "  'geometry': {"
+                + "    'type': 'Point',"
+                + "    'coordinates': [102.0, 0.5]"
+                + "  },"
+                + "  'properties': {"
+                + "    'prop0': 'value0'"
+                + "  }"
+                + "}";
+        point.replace('\'', '"');
+        pointFeature = new JSONObject(point);
+    }
+
+    @Test
+    public void whenConfigNotSetRegionIsNotReadFromProperty() throws Exception {
+        WFSSearchChannelsConfiguration cfg = new WFSSearchChannelsConfiguration();
+
+        WFSSearchChannel ch = new WFSSearchChannel(cfg);
+
+        assertNull(ch.getRegion(dinagatIslands));
+        assertNull(ch.getRegion(pointFeature));
+    }
+
+    @Test
+    public void whenConfigIsSetRegionIsReadFromProperty() throws Exception {
+        WFSSearchChannelsConfiguration cfg = new WFSSearchChannelsConfiguration();
+
+        cfg.setConfig(JSONHelper.createJSONObject(WFSSearchChannel.CONFIG_REGION_PROPERTY, "region"));
+
+        WFSSearchChannel ch = new WFSSearchChannel(cfg);
+
+        assertEquals("Caraga", ch.getRegion(dinagatIslands));
+        assertNull(ch.getRegion(pointFeature));
+    }
+
+    @Test
+    public void whenDefaultIsSetRegionIsOverriddenFromProperty() throws Exception {
+        WFSSearchChannelsConfiguration cfg = new WFSSearchChannelsConfiguration();
+
+        JSONObject config = new JSONObject();
+        config.put(WFSSearchChannel.CONFIG_REGION_PROPERTY, "region");
+        config.put("defaults", JSONHelper.createJSONObject("region", "My Default Region"));
+        cfg.setConfig(config);
+
+        WFSSearchChannel ch = new WFSSearchChannel(cfg);
+
+        SearchResultItem item;
+
+        item = ch.parseResultItem(dinagatIslands);
+        assertEquals("Caraga", item.getRegion());
+
+        item = ch.parseResultItem(pointFeature);
+        assertEquals("My Default Region", item.getRegion());
+    }
+
+}


### PR DESCRIPTION
Allow feature property to be used for the value of `SearchResultItem.region` as discussed in https://github.com/oskariorg/oskari-docs/issues/280.

Stored in database table `oskari_wfs_search_channels` inside column `config`:
```
{
   ... rest of the config ...,
  "region-property": "foobar",
}
```

Example SQL for adding the value to existing config value (there's no UI for this yet)
`UPDATE oskari_wfs_search_channels SET config = (config::jsonb || '{"region-property": "my_prop"}'::jsonb) where id = :id`
