### PR TITLE
Enable more config options to link client code

### DIFF
--- a/servlet-map/src/main/java/fi/nls/oskari/MapController.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/MapController.java
@@ -37,6 +37,8 @@ public class MapController {
     private final static Logger log = LogFactory.getLogger(MapController.class);
 
     private final static String PROPERTY_VERSION = "oskari.client.version";
+    private final static String PROPERTY_VERSION_REQUEST = "oskari.client.version.request";
+    private final static String PROPERTY_CLIENT_DOMAIN = "oskari.client.domain";
     private final static String KEY_PRELOADED = "preloaded";
     private final static String KEY_PATH = "path";
 
@@ -46,7 +48,9 @@ public class MapController {
     private final static String KEY_RESPONSE_HEADER_PREFIX = "oskari.page.header.";
 
     private final ViewService viewService = new AppSetupServiceMybatisImpl();
+    private String clientDomain = "";
     private String version = null;
+    private boolean allowVersionRequest = false;
     private final Set<String> paramHandlers = new HashSet<>();
 
     @Autowired
@@ -55,6 +59,8 @@ public class MapController {
     public MapController() {
         // Get version from properties
         version = PropertyUtil.get(PROPERTY_VERSION);
+        allowVersionRequest = PropertyUtil.getOptional(PROPERTY_VERSION_REQUEST, false);
+        clientDomain = PropertyUtil.get(PROPERTY_CLIENT_DOMAIN, "");
     }
 
     @RequestMapping("/")
@@ -204,8 +210,13 @@ public class MapController {
         model.addAttribute(KEY_PRELOADED, true);
 
         // for figuring out paths for frontend files
-        model.addAttribute("version", version);
-        model.addAttribute(KEY_PATH, "/" + version + "/" + view.getApplication());
+        model.addAttribute("clientDomain", clientDomain);
+        String clientVersion = version;
+        if (allowVersionRequest) {
+            clientVersion = params.getHttpParam("v", version);
+        }
+        model.addAttribute("version", clientVersion);
+        model.addAttribute(KEY_PATH, "/" + clientVersion + "/" + view.getApplication());
         model.addAttribute("application", view.getApplication());
 
         // title of the page

--- a/servlet-map/src/main/resources/META-INF/resources/spring-map-jsp/index.jsp
+++ b/servlet-map/src/main/resources/META-INF/resources/spring-map-jsp/index.jsp
@@ -6,18 +6,18 @@
 <html>
 <head>
     <title>Oskari - ${viewName}</title>
-    <link rel="shortcut icon" href="/Oskari${path}/logo.png" type="image/png" />
+    <link rel="shortcut icon" href="${clientDomain}/Oskari${path}/logo.png" type="image/png" />
 
     <!-- ############# css ################# -->
     <link
             rel="stylesheet"
             type="text/css"
-            href="/Oskari${path}/icons.css"/>
+            href="${clientDomain}/Oskari${path}/icons.css"/>
 
     <link
             rel="stylesheet"
             type="text/css"
-            href="/Oskari${path}/oskari.min.css"/>
+            href="${clientDomain}/Oskari${path}/oskari.min.css"/>
 
     <link href="https://fonts.googleapis.com/css?family=Noto+Sans" rel="stylesheet">
     <style type="text/css">
@@ -52,7 +52,7 @@
             #login input[type="text"], #login input[type="password"] {
                 width: 90%;
                 margin-bottom: 5px;
-                background-image: url("/Oskari/${version}/resources/images/forms/input_shadow.png");
+                background-image: url("${clientDomain}/Oskari/${version}/resources/images/forms/input_shadow.png");
                 background-repeat: no-repeat;
                 padding-left: 5px;
                 padding-right: 5px;
@@ -168,15 +168,15 @@
 </script>
 <%-- Pre-compiled application JS, empty unless created by build job --%>
 <script type="text/javascript"
-        src="/Oskari${path}/oskari.min.js">
+        src="${clientDomain}/Oskari${path}/oskari.min.js">
 </script>
 <%--language files --%>
 <script type="text/javascript"
-        src="/Oskari${path}/oskari_lang_${language}.js">
+        src="${clientDomain}/Oskari${path}/oskari_lang_${language}.js">
 </script>
 
 <script type="text/javascript"
-        src="/Oskari${path}/index.js">
+        src="${clientDomain}/Oskari${path}/index.js">
 </script>
 
 

--- a/servlet-map/src/main/resources/META-INF/resources/spring-map-jsp/published.jsp
+++ b/servlet-map/src/main/resources/META-INF/resources/spring-map-jsp/published.jsp
@@ -3,21 +3,19 @@
 <html>
 <head>
     <title>${viewName}</title>
-    <link rel="shortcut icon" href="/Oskari${path}/logo.png" type="image/png" />
+    <link rel="shortcut icon" href="${clientDomain}/Oskari${path}/logo.png" type="image/png" />
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
-    <!-- IE 9 polyfill for openlayers 3 - https://github.com/openlayers/ol3/issues/4865 -->
-    <!--[if lte IE 9]> <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=fetch,requestAnimationFrame,Element.prototype.classList"></script> <![endif]-->
 
     <!-- ############# css ################# -->
     <link
             rel="stylesheet"
             type="text/css"
-            href="/Oskari${path}/icons.css"/>
+            href="${clientDomain}/Oskari${path}/icons.css"/>
 
     <link
             rel="stylesheet"
             type="text/css"
-            href="/Oskari${path}/oskari.min.css"/>
+            href="${clientDomain}/Oskari${path}/oskari.min.css"/>
 
     <link href="https://fonts.googleapis.com/css?family=Noto+Sans" rel="stylesheet">
     <style type="text/css">
@@ -60,16 +58,16 @@
 </script>
 <%-- Pre-compiled application JS, empty unless created by build job --%>
 <script type="text/javascript"
-        src="/Oskari${path}/oskari.min.js">
+        src="${clientDomain}/Oskari${path}/oskari.min.js">
 </script>
 
 <%-- language files --%>
 <script type="text/javascript"
-        src="/Oskari${path}/oskari_lang_${language}.js">
+        src="${clientDomain}/Oskari${path}/oskari_lang_${language}.js">
 </script>
 
 <script type="text/javascript"
-        src="/Oskari${path}/index.js">
+        src="${clientDomain}/Oskari${path}/index.js">
 </script>
 
 


### PR DESCRIPTION
Adds more configuration options:
- Enable browser to request specific version of frontend with URL-parameter `v=[version]`. This is disabled by default but can be enabled in oskari-ext.properties:
```
# Enables client to request specific version of frontend - defaults to false
oskari.client.version.request=true
```
- Allow frontend code to be linked from another domain:
```
# For example "https://cdn.domain.com" if frontend files are served from another domain than the server - defaults to same domain
oskari.client.domain=
```

Customized/application specific JSP-files can use `${clientDomain}` to enable the domain config. See the JSP changes here for details on how to use it.