### PR TITLE
WMTS layer null legend fix

### DIFF
--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
@@ -213,9 +213,9 @@ public class LayerJSONFormatter {
         }
         for(int i = 0; i < styleList.length(); i++) {
             JSONObject style = styleList.optJSONObject(i);
-            String legend = style.optString(KEY_LEGEND);
-            String name = style.optString(KEY_STYLE_NAME);
-            String title = style.optString(KEY_STYLE_TITLE);
+            String legend = JSONHelper.optString(style, KEY_LEGEND);
+            String name = JSONHelper.optString(style, KEY_STYLE_NAME);
+            String title = JSONHelper.optString(style, KEY_STYLE_TITLE);
             if (legends.containsKey(name)) {
                 legend = legends.get(name);
             } else if (!globalLegend.isEmpty()) {

--- a/service-map/src/test/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterTest.java
+++ b/service-map/src/test/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterTest.java
@@ -76,6 +76,21 @@ public class LayerJSONFormatterTest {
 
     }
     @Test
+    public void legendWMTS() throws Exception {
+        OskariLayer layer = new OskariLayer();
+        layer.setType(OskariLayer.TYPE_WMTS);
+        JSONArray styles = new JSONArray("[{\"default\": true, \"legend\": null, \"name\": \"default\", \"title\": \"default\"}]");
+        JSONHelper.putValue(layer.getCapabilities(), CapabilitiesConstants.KEY_STYLES, styles);
+
+        JSONObject layerJSON = FORMATTER.getJSON(layer, LANG, true, CRS);
+        JSONArray stylesJSON = layerJSON.getJSONArray("styles");
+        Assert.assertEquals(1, stylesJSON.length());
+        JSONObject styleJSON = stylesJSON.getJSONObject(0);
+        Assert.assertEquals("Style should have name",  "default", styleJSON.getString("name"));
+        Assert.assertEquals("Style should have title",  "default", styleJSON.getString("title"));
+        Assert.assertTrue("Style shouldn't have legend url", styleJSON.getString("legend").isEmpty());
+    }
+    @Test
     public void proxyLegend() throws Exception {
         String proxyLegend = "action?action_route=GetLayerTile&legend=true&style=%s&id=-1";
 


### PR DESCRIPTION
If style doesn't have legend, capabilities styles for wmts layer is parsed as:
`"styles": [{
        "default": true,
        "legend": null,
        "name": "default",
        "title": "default"
 }]`
String for JSONObject.null is 'null'. Changed to use JSONHelper which handles null more properly. This fixes issue where wmts layer could have 'null' or proxyUrl in frontend and layer is handled as it has legend url and tried to get legend image for layer.