### PR TITLE
Cache clustered flush

### DIFF
--- a/service-base/src/main/java/fi/nls/oskari/cache/Cache.java
+++ b/service-base/src/main/java/fi/nls/oskari/cache/Cache.java
@@ -168,6 +168,11 @@ public class Cache<T> {
     }
 
     public boolean flush(final boolean force) {
+        notifyFlush();
+        return flushSilent(force);
+    }
+
+    protected boolean flushSilent(final boolean force) {
         final long now = currentTime();
         if(force || isTimeToFlush(now)) {
             // flushCache
@@ -203,7 +208,7 @@ public class Cache<T> {
             return;
         }
         if (CLUSTER_CMD_FLUSH.equals(data)) {
-            flush(true);
+            flushSilent(true);
             return;
         }
         if (data.startsWith(CLUSTER_CMD_REMOVE_PREFIX)) {
@@ -216,6 +221,9 @@ public class Cache<T> {
 
     private void notifyRemoval(String key) {
         notifyCluster(CLUSTER_CMD_REMOVE_PREFIX + key);
+    }
+    private void notifyFlush() {
+        notifyCluster(CLUSTER_CMD_FLUSH);
     }
 
     private void notifyCluster(String msg) {

--- a/service-base/src/test/java/fi/nls/oskari/cache/CacheClusterTest.java
+++ b/service-base/src/test/java/fi/nls/oskari/cache/CacheClusterTest.java
@@ -28,7 +28,9 @@ public class CacheClusterTest {
         // another cache instance
         cache.handleClusterMsg(Cache.CLUSTER_CMD_FLUSH);
         // message from OTHER should trigger call
-        Mockito.verify(cache).flush(true);
+        Mockito.verify(cache).flushSilent(true);
+        // but not trigger another notify for cluster
+        Mockito.verify(cache, never()).flush(true);
     }
 
     @Test


### PR DESCRIPTION
Notify clusters to flush. Fixes issue where other clusters doesn't flush cache when requested and user may get outdated cached data in clustered env.

Not sure if force should be added to message `FLUSH: true` and boolean parsed from message. handleClusterMsg had already listener for flush and changed only it to flushSilent to avoid triggering notify on received msg.