### PR TITLE
Metadata search cleanup

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/data/GetCSWDataHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/data/GetCSWDataHandler.java
@@ -20,9 +20,10 @@ import fi.nls.oskari.util.ResponseHelper;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.geotools.referencing.CRS;
 import org.json.JSONArray;
 import org.json.JSONObject;
+
+import static fi.nls.oskari.csw.Constants.PROP_SERVICE_URL;
 
 
 /**
@@ -34,7 +35,7 @@ public class GetCSWDataHandler extends ActionHandler {
     
     private static final String LANG_PARAM = "lang";
     private static final String UUID_PARAM = "uuid";
-    private final String baseUrl = PropertyUtil.getOptional("service.metadata.url");
+    private final String baseUrl = PropertyUtil.getOptional(PROP_SERVICE_URL);
     private final String imgUrl = PropertyUtil.getOptional("service.metadata.imgurl");
     private final String metadataRatingType = PropertyUtil.getOptional("service.metadata.rating");
     private final String licenseUrlPrefix = PropertyUtil.getOptional("search.channel.METADATA_CATALOGUE_CHANNEL.licenseUrlPrefix");

--- a/control-base/src/main/java/fi/nls/oskari/control/data/GetCSWDataHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/data/GetCSWDataHandler.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-import static fi.nls.oskari.csw.Constants.PROP_SERVICE_URL;
+import static fi.nls.oskari.csw.service.CSWService.PROP_SERVICE_URL;
 
 
 /**
@@ -36,7 +36,6 @@ public class GetCSWDataHandler extends ActionHandler {
     private static final String LANG_PARAM = "lang";
     private static final String UUID_PARAM = "uuid";
     private final String baseUrl = PropertyUtil.getOptional(PROP_SERVICE_URL);
-    private final String imgUrl = PropertyUtil.getOptional("service.metadata.imgurl");
     private final String metadataRatingType = PropertyUtil.getOptional("service.metadata.rating");
     private final String licenseUrlPrefix = PropertyUtil.getOptional("search.channel.METADATA_CATALOGUE_CHANNEL.licenseUrlPrefix");
     public static final String KEY_LICENSE = "license";

--- a/service-csw/src/main/java/fi/nls/oskari/control/metadata/GetMetadataSearchHandler.java
+++ b/service-csw/src/main/java/fi/nls/oskari/control/metadata/GetMetadataSearchHandler.java
@@ -64,7 +64,7 @@ public class GetMetadataSearchHandler extends RestActionHandler {
 
         log.debug("done search... now creating json objects");
 
-        for(SearchResultItem item : searchResult.getSearchResultItems()) {
+        for (SearchResultItem item : searchResult.getSearchResultItems()) {
             results.put(item.toJSON());
         }
 

--- a/service-csw/src/main/java/fi/nls/oskari/control/metadata/MetadataFieldHandler.java
+++ b/service-csw/src/main/java/fi/nls/oskari/control/metadata/MetadataFieldHandler.java
@@ -32,11 +32,8 @@ public class MetadataFieldHandler {
 
     private static final Logger log = LogFactory.getLogger(MetadataFieldHandler.class);
 
-    private final static NodeList EMPTY_NODELIST = new EmptyNodeList();
-
     private MetadataField field = null;
     private String serverURL = MetadataCatalogueChannelSearchService.getServerURL();
-    private String queryParams = "?" + PropertyUtil.get("search.channel.METADATA_CATALOGUE_CHANNEL.metadata.catalogue.queryParams", "SERVICE=CSW&VERSION=2.0.2&request=GetDomain&PropertyName=");
     private Cache<Set<SelectItem>> cache = CacheManager.getCache(MetadataFieldHandler.class.getCanonicalName());
 
     public String getPropertyName() {
@@ -51,8 +48,8 @@ public class MetadataFieldHandler {
         return field;
     }
 
-    public String getSearchURL() {
-        return serverURL + queryParams;
+    public String getSearchURL(String propertyName) {
+        return IOHelper.addQueryString(serverURL, "SERVICE=CSW&VERSION=2.0.2&request=GetDomain&PropertyName=" + propertyName);
     }
 
     public JSONArray getOptions(final String language) {
@@ -114,7 +111,7 @@ public class MetadataFieldHandler {
             return response;
         }
 
-        final String url = getSearchURL() + propertyName;
+        final String url = getSearchURL(propertyName);
         final List<String> valueList = getTags(url);
         List<String> blacklist = field.getBlacklist();
         response = valueList.stream()

--- a/service-csw/src/main/java/fi/nls/oskari/control/metadata/MetadataFieldHandler.java
+++ b/service-csw/src/main/java/fi/nls/oskari/control/metadata/MetadataFieldHandler.java
@@ -36,7 +36,6 @@ public class MetadataFieldHandler {
 
     private MetadataField field = null;
     private String serverURL = MetadataCatalogueChannelSearchService.getServerURL();
-    private String serverPath = MetadataCatalogueChannelSearchService.getServerPath();
     private String queryParams = "?" + PropertyUtil.get("search.channel.METADATA_CATALOGUE_CHANNEL.metadata.catalogue.queryParams", "SERVICE=CSW&VERSION=2.0.2&request=GetDomain&PropertyName=");
     private Cache<Set<SelectItem>> cache = CacheManager.getCache(MetadataFieldHandler.class.getCanonicalName());
 
@@ -53,7 +52,7 @@ public class MetadataFieldHandler {
     }
 
     public String getSearchURL() {
-        return serverURL + serverPath + queryParams;
+        return serverURL + queryParams;
     }
 
     public JSONArray getOptions(final String language) {

--- a/service-csw/src/main/java/fi/nls/oskari/csw/Constants.java
+++ b/service-csw/src/main/java/fi/nls/oskari/csw/Constants.java
@@ -1,6 +1,0 @@
-package fi.nls.oskari.csw;
-
-public class Constants {
-
-    public static final String PROP_SERVICE_URL = "service.metadata.url";
-}

--- a/service-csw/src/main/java/fi/nls/oskari/csw/Constants.java
+++ b/service-csw/src/main/java/fi/nls/oskari/csw/Constants.java
@@ -1,0 +1,6 @@
+package fi.nls.oskari.csw;
+
+public class Constants {
+
+    public static final String PROP_SERVICE_URL = "service.metadata.url";
+}

--- a/service-csw/src/main/java/fi/nls/oskari/csw/service/CSWService.java
+++ b/service-csw/src/main/java/fi/nls/oskari/csw/service/CSWService.java
@@ -39,6 +39,7 @@ import java.util.Locale;
  */
 public class CSWService {
 
+    public static final String PROP_SERVICE_URL = "service.metadata.url";
     private static final Logger log = LogFactory
             .getLogger(CSWService.class);
 

--- a/service-csw/src/main/java/fi/nls/oskari/search/channel/MetadataCatalogueChannelSearchService.java
+++ b/service-csw/src/main/java/fi/nls/oskari/search/channel/MetadataCatalogueChannelSearchService.java
@@ -31,7 +31,7 @@ import org.apache.axiom.om.OMElement;
 import java.net.HttpURLConnection;
 import java.util.*;
 
-import static fi.nls.oskari.csw.Constants.PROP_SERVICE_URL;
+import static fi.nls.oskari.csw.service.CSWService.PROP_SERVICE_URL;
 
 /**
  * Search channel for making CSW queries.

--- a/service-csw/src/main/java/fi/nls/oskari/search/channel/MetadataCatalogueResultParser.java
+++ b/service-csw/src/main/java/fi/nls/oskari/search/channel/MetadataCatalogueResultParser.java
@@ -147,12 +147,11 @@ setResourceNameSpace(serverURL)
         identification.put(KEY_MAINTENANCE_AND_UPDATE_FREQUENCY_CODELIST, getAttributeValue(maintenanceAndUpdateFrequencyNode, QName.valueOf("codeListValue")));
         item.addValue(KEY_IDENTIFICATION, identification);
 
-
-        log.debug("==1");
         final OMElement codeListValue = (OMElement) XPATH_CODELISTVALUE.selectSingleNode(elem);
-        log.debug("====: " + codeListValue.getAttributeValue(QNAME_CODELISTVALUE));
-        item.setNatureOfTarget(codeListValue.getAttributeValue(QNAME_CODELISTVALUE));
-        item.addValue(KEY_NATUREOFTHETARGET, item.getNatureOfTarget());
+        if (codeListValue != null) {
+            item.setNatureOfTarget(codeListValue.getAttributeValue(QNAME_CODELISTVALUE));
+            item.addValue(KEY_NATUREOFTHETARGET, item.getNatureOfTarget());
+        }
 
         for(OMElement operatesOnNode  : operatesOnNodes){
             if(operatesOnNode != null){

--- a/service-csw/src/main/java/fi/nls/oskari/search/channel/MetadataCatalogueResultParser.java
+++ b/service-csw/src/main/java/fi/nls/oskari/search/channel/MetadataCatalogueResultParser.java
@@ -51,7 +51,7 @@ public class MetadataCatalogueResultParser {
     public static final String KEY_MAINTENANCE_AND_UPDATE_FREQUENCY_CODELIST = "updateFrequency";
     public static final String KEY_NATUREOFTHETARGET = "natureofthetarget";
     // we need to map languages from 3-letter codes to 2-letter codes so initialize a global codeMapping property
-    private final static Map<String, String> ISO3letterOskariLangMapping = new HashMap<String, String>();
+    private final static Map<String, String> ISO3letterOskariLangMapping = new HashMap<>();
 
     public MetadataCatalogueResultParser() {
         NAMESPACE_CTX = new SimpleNamespaceContext();
@@ -240,7 +240,7 @@ setResourceNameSpace(serverURL)
   </gmd:locale>
      */
     private Map<String, String> getLocaleMap(final OMElement elem) {
-        final Map<String, String> locales = new HashMap<String, String>();
+        final Map<String, String> locales = new HashMap<>();
         try {
             final List<OMElement> localeNodes = (List<OMElement>) XPATH_LOCALE_MAP.selectNodes(elem);
             for(OMElement loc : localeNodes) {

--- a/service-csw/src/main/java/org/oskari/csw/request/GetRecords.java
+++ b/service-csw/src/main/java/org/oskari/csw/request/GetRecords.java
@@ -89,7 +89,8 @@ public class GetRecords {
             // this might lead to complications. Just using "full" for now, it's more XML to transfer and
             // parse but it's safe.
             xsw.writeStartElement(CSW_URI, "ElementSetName");
-            xsw.writeCharacters("full");
+            // changes from full to summary for performance reasons. "brief" would be even faster but doesn't include dates
+            xsw.writeCharacters("summary");
             xsw.writeEndElement(); // ElementSetName
 
 

--- a/service-csw/src/test/resources/org/oskari/csw/request/GetRecords-coverage.xml
+++ b/service-csw/src/test/resources/org/oskari/csw/request/GetRecords-coverage.xml
@@ -5,7 +5,7 @@
                 service="CSW" version="2.0.2" maxRecords="10000" startPosition="1" resultType="results"
                 outputFormat="application/xml" outputSchema="http://www.isotc211.org/2005/gmd">
     <csw:Query typeNames="gmd:MD_Metadata">
-        <csw:ElementSetName>full</csw:ElementSetName>
+        <csw:ElementSetName>summary</csw:ElementSetName>
         <csw:Constraint version="1.0.0">
             <ogc:Filter
                     xmlns:gml="http://www.opengis.net/gml" xmlns:ogc="http://www.opengis.net/ogc">

--- a/service-csw/src/test/resources/org/oskari/csw/request/GetRecords-multi.xml
+++ b/service-csw/src/test/resources/org/oskari/csw/request/GetRecords-multi.xml
@@ -4,7 +4,7 @@
                 startPosition="1" resultType="results" outputFormat="application/xml"
                 outputSchema="http://www.isotc211.org/2005/gmd">
     <csw:Query typeNames="gmd:MD_Metadata">
-        <csw:ElementSetName>full</csw:ElementSetName>
+        <csw:ElementSetName>summary</csw:ElementSetName>
         <csw:Constraint version="1.0.0">
             <ogc:Filter
                     xmlns:ogc="http://www.opengis.net/ogc">

--- a/service-csw/src/test/resources/org/oskari/csw/request/GetRecords-simple.xml
+++ b/service-csw/src/test/resources/org/oskari/csw/request/GetRecords-simple.xml
@@ -4,7 +4,7 @@
                 startPosition="1" resultType="results" outputFormat="application/xml"
                 outputSchema="http://www.isotc211.org/2005/gmd">
     <csw:Query typeNames="gmd:MD_Metadata">
-        <csw:ElementSetName>full</csw:ElementSetName>
+        <csw:ElementSetName>summary</csw:ElementSetName>
         <csw:Constraint version="1.0.0">
             <ogc:Filter
                     xmlns:ogc="http://www.opengis.net/ogc">


### PR DESCRIPTION
This makes metadata searches a bit faster by requesting "summary" dataset instead of "full". There's a more efficient "brief" option, but it doesn't include dates or organization in the response so we can't use it as a direct replacement.

Also removes unnecessary/duplicated configuration for metadata service integration on Oskari. The only required property in `oskari-ext.properties` for metadata functionality is now `service.metadata.url`:
```
# Used by metadata search/flyout/CSW coverage scheduled task
service.metadata.url=https://www.paikkatietohakemisto.fi/geonetwork/srv/fin/csw
```

These properties are no longer used and can be removed from `oskari-ext.properties`:
- `search.channel.METADATA_CATALOGUE_CHANNEL.query.url`
- `search.channel.METADATA_CATALOGUE_CHANNEL.server.url`
- `search.channel.METADATA_CATALOGUE_CHANNEL.metadata.catalogue.server`
- `search.channel.METADATA_CATALOGUE_CHANNEL.metadata.catalogue.path`
- `search.channel.METADATA_CATALOGUE_CHANNEL.metadata.catalogue.queryParams`
- `search.channel.METADATA_CATALOGUE_CHANNEL.fetchpage.url.[lang code]`
- `search.channel.METADATA_CATALOGUE_CHANNEL.image.url.[lang code]`

