### PR TITLE
Make CSW query type and fields configurable

### DIFF
--- a/service-csw/pom.xml
+++ b/service-csw/pom.xml
@@ -27,14 +27,14 @@
             <groupId>org.mybatis</groupId>
             <artifactId>mybatis</artifactId>
         </dependency>
-		<dependency>
+        <dependency>
             <groupId>org.oskari</groupId>
-			<artifactId>service-control</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>javax.vecmath</groupId>
-			<artifactId>vecmath</artifactId>
-		</dependency>
+            <artifactId>service-control</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.vecmath</groupId>
+            <artifactId>vecmath</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>junit</groupId>
@@ -51,16 +51,16 @@
             <artifactId>postgresql</artifactId>
             <scope>test</scope>
         </dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-core</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.oskari</groupId>
             <artifactId>shared-test-resources</artifactId>
             <scope>test</scope>
         </dependency>
-	</dependencies>
+    </dependencies>
 
 </project>

--- a/service-csw/src/main/java/fi/nls/oskari/search/channel/MetadataCatalogueChannelSearchService.java
+++ b/service-csw/src/main/java/fi/nls/oskari/search/channel/MetadataCatalogueChannelSearchService.java
@@ -176,19 +176,10 @@ public class MetadataCatalogueChannelSearchService extends SearchChannel {
             getResults(root).forEach(metadata -> {
                 try {
                     final SearchResultItem item = RESULT_PARSER.parseResult(metadata);
-/*
-// done in frontend now?
-                    final List<OskariLayer> oskariLayers = getOskariLayerWithUuid(item);
-                    for(OskariLayer oskariLayer : oskariLayers){
-                        log.debug("METAID: " + oskariLayer.getMetadataId());
-                        item.addUuId(oskariLayer.getMetadataId());
-                    }
- */
-
                     item.addValue("geom", getWKT(item, WKTHelper.PROJ_EPSG_4326, srs));
                     channelSearchResult.addItem(item);
                 } catch (Exception e) {
-                    log.warn(e);
+                    log.info("Error parsing metadata search result item", e);
                 }
             });
 

--- a/service-csw/src/main/java/fi/nls/oskari/search/channel/MetadataCatalogueQueryHelper.java
+++ b/service-csw/src/main/java/fi/nls/oskari/search/channel/MetadataCatalogueQueryHelper.java
@@ -24,6 +24,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.oskari.csw.request.GetRecords.DEFAULT_QUERY_TYPE;
+
 /**
  * Helper class for creating search queries for MetadataCatalogue
  */
@@ -35,6 +37,7 @@ public class MetadataCatalogueQueryHelper {
     public final static String WILDCARD_CHARACTER = "*";
     public final static String SINGLE_WILDCARD_CHARACTER = "?";
     public final static String ESCAPE_CHARACTER = "/";
+    private static final String[] DEFAULT_QUERY_FIELDS = new String[] { "csw:anyText" };
 
     private static final Logger log = LogFactory.getLogger(MetadataCatalogueQueryHelper.class);
     private FilterFactory2 filterFactory;
@@ -45,7 +48,10 @@ public class MetadataCatalogueQueryHelper {
     }
 
     public String getQueryPayload(SearchCriteria searchCriteria) {
-        final List<Filter> filters = getFiltersForQuery(searchCriteria);
+        return getQueryPayload(searchCriteria, DEFAULT_QUERY_TYPE, DEFAULT_QUERY_FIELDS);
+    }
+    public String getQueryPayload(SearchCriteria searchCriteria, String queryType, String... queryFields) {
+        final List<Filter> filters = getFiltersForQuery(searchCriteria, queryFields);
         if (filters.isEmpty()) {
             // no point in making the query without GetRecords, but throw exception instead?
             //throw new ServiceRuntimeException("Can't create GetRecords request without filters");
@@ -58,19 +64,27 @@ public class MetadataCatalogueQueryHelper {
             filter = filterFactory.and(filters);
         }
 
-        return GetRecords.createRequest(filter);
+        return GetRecords.createRequest(filter, queryType);
     }
 
-    private List<Filter> getFiltersForQuery(SearchCriteria searchCriteria) {
+    private List<Filter> getFiltersForQuery(SearchCriteria searchCriteria, String... queryFields) {
         final List<Filter> list = new ArrayList<>();
         final List<Filter> theOrList = new ArrayList<>();
 
         // user input
-        Filter userInput = createLikeFilter(searchCriteria.getSearchString(), "csw:anyText");
-        if (userInput != null) {
-            list.add(userInput);
+        if (queryFields == null || queryFields.length == 0) {
+            queryFields = DEFAULT_QUERY_FIELDS;
         }
-
+        List<Filter> queryFilters = new ArrayList<>();
+        for (String field: queryFields) {
+            queryFilters.add(createLikeFilter(searchCriteria.getSearchString(), field));
+        }
+        if (queryFilters.size() == 1) {
+            list.add(queryFilters.get(0));
+        } else if (queryFilters.size() > 1) {
+            list.add(filterFactory.or(queryFilters));
+        }
+        // "advanced fields"
         for (MetadataField field : MetadataCatalogueChannelSearchService.getFields()) {
             final Filter operation = getFilterForField(searchCriteria, field);
             if (operation == null) {

--- a/service-csw/src/main/java/fi/nls/oskari/search/channel/MetadataCatalogueResultParser.java
+++ b/service-csw/src/main/java/fi/nls/oskari/search/channel/MetadataCatalogueResultParser.java
@@ -16,8 +16,6 @@ import java.util.*;
  */
 public class MetadataCatalogueResultParser {
 
-    private static final Logger log = LogFactory.getLogger(MetadataCatalogueResultParser.class);
-
     public static final String KEY_IDENTIFICATION = "identification";
     public static final String KEY_IDENTIFICATION_DATE = "date";
     public static final String KEY_IDENTIFICATION_CODELIST = "code";

--- a/service-csw/src/main/java/fi/nls/oskari/search/channel/MetadataCatalogueResultParser.java
+++ b/service-csw/src/main/java/fi/nls/oskari/search/channel/MetadataCatalogueResultParser.java
@@ -42,7 +42,6 @@ public class MetadataCatalogueResultParser {
                 XmlHelper.getFirstChild(elem, "fileIdentifier"),
                 "CharacterString");
         item.setResourceId(uuid);
-        //item.addUuId(uuid);
         // lang
         Element languageCode = XmlHelper.getFirstChild(
                 XmlHelper.getFirstChild(elem, "language"),

--- a/service-csw/src/main/java/org/oskari/csw/request/GetRecords.java
+++ b/service-csw/src/main/java/org/oskari/csw/request/GetRecords.java
@@ -96,8 +96,11 @@ public class GetRecords {
             // changes from full to summary for performance reasons. "brief" would be even faster but doesn't include dates
             String type = queryType;
             // these are the valid values
-            if (!"summary".equals(type) || !"brief".equals(type) || !"full".equals(type)) {
+            if (type == null) {
                 type = "summary";
+            }
+            if (!("summary".equals(type) || "brief".equals(type) || "full".equals(type))) {
+                throw new IllegalArgumentException("Type needs to be one of: summary, brief, full. Was: " + type);
             }
             xsw.writeCharacters(type);
             xsw.writeEndElement(); // ElementSetName

--- a/service-csw/src/main/java/org/oskari/csw/request/GetRecords.java
+++ b/service-csw/src/main/java/org/oskari/csw/request/GetRecords.java
@@ -18,21 +18,25 @@ public class GetRecords {
 
     private static final String CSW_VERSION = "2.0.2";
     private static final String CONSTRAINT_VERSION = "1.0.0";
+    public static final String DEFAULT_QUERY_TYPE = "summary";
 
     private GetRecords() {}
 
+    public static String createRequest(Filter filter) {
+        return createRequest(filter, DEFAULT_QUERY_TYPE);
+    }
     /**
      * Builds a GetRecords request payload for CSW-service with the given filters.
      * @param filter required
      * @return
      */
-    public static String createRequest(Filter filter) {
+    public static String createRequest(Filter filter, String queryType) {
         if (filter == null) {
             throw new ServiceRuntimeException("Filter is required");
         }
         final StringWriter writer = new StringWriter();
         XMLStreamWriter xsw = getXMLWriter(writer);
-        startDocument(xsw);
+        startDocument(xsw, queryType);
         writeRawXMLUnsafe(xsw, writer, getFilterAsString(filter));
         endDocument(xsw);
         return writer.toString();
@@ -59,7 +63,7 @@ public class GetRecords {
      <csw:Constraint version="1.1.0">
      ...
      */
-    private static void startDocument(XMLStreamWriter xsw) {
+    private static void startDocument(XMLStreamWriter xsw, String queryType) {
         try {
             xsw.writeStartDocument();
             xsw.writeStartElement("csw", "GetRecords", CSW_URI);
@@ -72,7 +76,7 @@ public class GetRecords {
             xsw.writeAttribute("service", "CSW");
             xsw.writeAttribute("version", CSW_VERSION);
 
-            xsw.writeAttribute("maxRecords", "10000");
+            xsw.writeAttribute("maxRecords", "100");
             xsw.writeAttribute("startPosition", "1");
 
             xsw.writeAttribute("resultType", "results"); // or "validate" or "hits"
@@ -90,7 +94,12 @@ public class GetRecords {
             // parse but it's safe.
             xsw.writeStartElement(CSW_URI, "ElementSetName");
             // changes from full to summary for performance reasons. "brief" would be even faster but doesn't include dates
-            xsw.writeCharacters("summary");
+            String type = queryType;
+            // these are the valid values
+            if (!"summary".equals(type) || !"brief".equals(type) || !"full".equals(type)) {
+                type = "summary";
+            }
+            xsw.writeCharacters(type);
             xsw.writeEndElement(); // ElementSetName
 
 

--- a/service-csw/src/test/java/org/oskari/csw/request/GetRecordsTest.java
+++ b/service-csw/src/test/java/org/oskari/csw/request/GetRecordsTest.java
@@ -49,6 +49,28 @@ public class GetRecordsTest {
     }
 
     @Test
+    public void testRequestType() {
+        // build filter
+        Filter filter = createEqualsFilter("csw:Any", "testing");
+        String request = org.oskari.csw.request.GetRecords.createRequest(filter);
+
+        assertTrue("Should get 'summary' as request type", request.contains("<csw:ElementSetName>summary</csw:ElementSetName>"));
+
+        request = org.oskari.csw.request.GetRecords.createRequest(filter, "brief");
+        assertTrue("Should get 'brief' as request type", request.contains("<csw:ElementSetName>brief</csw:ElementSetName>"));
+
+        request = org.oskari.csw.request.GetRecords.createRequest(filter, "full");
+        assertTrue("Should get 'full' as request type", request.contains("<csw:ElementSetName>full</csw:ElementSetName>"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRequestTypeInvalid() {
+        // build filter
+        Filter filter = createEqualsFilter("csw:Any", "testing");
+        org.oskari.csw.request.GetRecords.createRequest(filter, "dummy");
+    }
+
+    @Test
     public void testSimpleFilter() throws IOException, SAXException {
         // build filter
         Filter filter = createEqualsFilter("my value", "myprop");

--- a/service-csw/src/test/resources/org/oskari/csw/request/GetRecords-coverage.xml
+++ b/service-csw/src/test/resources/org/oskari/csw/request/GetRecords-coverage.xml
@@ -2,7 +2,7 @@
 <csw:GetRecords xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:gmd="http://www.isotc211.org/2005/gmd"
                 xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows"
                 xmlns:ogc="http://www.opengis.net/ogc"
-                service="CSW" version="2.0.2" maxRecords="10000" startPosition="1" resultType="results"
+                service="CSW" version="2.0.2" maxRecords="100" startPosition="1" resultType="results"
                 outputFormat="application/xml" outputSchema="http://www.isotc211.org/2005/gmd">
     <csw:Query typeNames="gmd:MD_Metadata">
         <csw:ElementSetName>summary</csw:ElementSetName>

--- a/service-csw/src/test/resources/org/oskari/csw/request/GetRecords-multi.xml
+++ b/service-csw/src/test/resources/org/oskari/csw/request/GetRecords-multi.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <csw:GetRecords xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:gmd="http://www.isotc211.org/2005/gmd"
-                xmlns:ogc="http://www.opengis.net/ogc" service="CSW" version="2.0.2" maxRecords="10000"
+                xmlns:ogc="http://www.opengis.net/ogc" service="CSW" version="2.0.2" maxRecords="100"
                 startPosition="1" resultType="results" outputFormat="application/xml"
                 outputSchema="http://www.isotc211.org/2005/gmd">
     <csw:Query typeNames="gmd:MD_Metadata">

--- a/service-csw/src/test/resources/org/oskari/csw/request/GetRecords-simple.xml
+++ b/service-csw/src/test/resources/org/oskari/csw/request/GetRecords-simple.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <csw:GetRecords xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:gmd="http://www.isotc211.org/2005/gmd"
-                xmlns:ogc="http://www.opengis.net/ogc" service="CSW" version="2.0.2" maxRecords="10000"
+                xmlns:ogc="http://www.opengis.net/ogc" service="CSW" version="2.0.2" maxRecords="100"
                 startPosition="1" resultType="results" outputFormat="application/xml"
                 outputSchema="http://www.isotc211.org/2005/gmd">
     <csw:Query typeNames="gmd:MD_Metadata">


### PR DESCRIPTION
So it's easier to test between "full", "summary", "brief" responses and try optimizing anyText -> Title, Abstract etc for slower services.

Adds configuration options to `oskari-ext.properties`:
```
# Valid values: summary, brief, full (defaults to "summary")
search.channel.METADATA_CATALOGUE_CHANNEL.queryType=summary
# comma-separated list - defaults to csw:anyText
search.channel.METADATA_CATALOGUE_CHANNEL.queryFields=Title, Abstract
```
Also reduces max results from 10000 (that we never use) to 100 (that geonetwork can more probably handle)