### PR TITLE
Update Flyway 6.5.7 -> 9.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
 
         <jetty.version>9.4.48.v20220622</jetty.version>
         <mybatis.version>3.5.11</mybatis.version>
-        <flyway.version>6.5.7</flyway.version>
+        <flyway.version>9.12.0</flyway.version>
         <postgresql.version>42.5.1</postgresql.version>
         <!-- https://github.com/spring-projects/spring-data-redis/blob/2.7.x/pom.xml#L28 -->
         <jedis.version>3.8.0</jedis.version>


### PR DESCRIPTION
This makes Postgres 11+ the new requirement (https://documentation.red-gate.com/fd/supported-database-versions-143754067.html) and needs some more testing before merging.