### PR TITLE
Remove JNDI requirement

### DIFF
--- a/content-resources/src/main/java/org/oskari/helpers/AppSetupHelper.java
+++ b/content-resources/src/main/java/org/oskari/helpers/AppSetupHelper.java
@@ -7,6 +7,7 @@ import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.map.view.ViewService;
 import fi.nls.oskari.map.view.AppSetupServiceMybatisImpl;
+import fi.nls.oskari.service.OskariComponentManager;
 import fi.nls.oskari.service.ServiceRuntimeException;
 import fi.nls.oskari.util.*;
 import org.json.JSONArray;
@@ -22,8 +23,11 @@ import java.util.*;
  */
 public class AppSetupHelper {
 
-    private static final ViewService viewService = new AppSetupServiceMybatisImpl();
     private static Logger log = LogFactory.getLogger(AppSetupHelper.class);
+
+    private static ViewService getViewService() {
+        return OskariComponentManager.getComponentOfType(ViewService.class);
+    }
 
     public static long create(Connection conn, final String viewfile)
             throws IOException, SQLException {
@@ -35,7 +39,7 @@ public class AppSetupHelper {
             Bundle bundle = view.getBundleByName("mapfull");
             replaceSelectedLayers(bundle, selectedLayerIds);
 
-            final long viewId = viewService.addView(view);
+            final long viewId = getViewService().addView(view);
             log.info("Added view from file:", viewfile, "/viewId is:", viewId, "/uuid is:", view.getUuid());
             // update supported SRS for layers after possibly new projection on appsetup/view
             LayerHelper.refreshLayerCapabilities(view.getSrsName());

--- a/content-resources/src/main/java/org/oskari/helpers/LayerHelper.java
+++ b/content-resources/src/main/java/org/oskari/helpers/LayerHelper.java
@@ -7,6 +7,7 @@ import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.map.layer.OskariLayerService;
 import fi.nls.oskari.map.layer.OskariLayerServiceMybatisImpl;
 import fi.nls.oskari.map.layer.formatters.LayerJSONFormatter;
+import fi.nls.oskari.service.OskariComponentManager;
 import fi.nls.oskari.service.ServiceException;
 import fi.nls.oskari.util.IOHelper;
 import fi.nls.oskari.util.OskariRuntimeException;
@@ -28,11 +29,15 @@ import java.util.stream.Collectors;
 public class LayerHelper {
 
     private static final Logger log = LogFactory.getLogger(LayerHelper.class);
-    private static final OskariLayerService layerService = new OskariLayerServiceMybatisImpl();
+
+    private static OskariLayerService getLayerService() {
+        return OskariComponentManager.getComponentOfType(OskariLayerService.class);
+    }
 
     public static int setupLayer(final String layerfile) throws IOException {
         final String jsonStr = readLayerFile(layerfile);
         MapLayer layer = LayerAdminJSONHelper.readJSON(jsonStr);
+        OskariLayerService layerService = getLayerService();
         final List<OskariLayer> dbLayers = layerService.findByUrlAndName(layer.getUrl(), layer.getName());
         if(!dbLayers.isEmpty()) {
             if(dbLayers.size() > 1) {
@@ -84,6 +89,7 @@ public class LayerHelper {
         } catch (Exception e) {
             throw new OskariRuntimeException("Couldn't get system crs list");
         }
+        OskariLayerService layerService = getLayerService();
         List<OskariLayer> layers = layerService.findAll().stream()
                 // skip localhost servers as the service is starting when this is called and geoserver will not answer
                 .filter(l -> !l.getUrl().startsWith("http://localhost:"))

--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/SystemViewsHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/SystemViewsHandler.java
@@ -43,9 +43,8 @@ public class SystemViewsHandler extends RestActionHandler {
     private final static String DEFAULT_SRS = PropertyUtil.get("oskari.native.srs", "EPSG:4326");
 
     public void init() {
-        viewService = ServiceFactory.getViewService();
-
-        layerService = ServiceFactory.getMapLayerService();
+        viewService = OskariComponentManager.getComponentOfType(ViewService.class);
+        layerService = OskariComponentManager.getComponentOfType(OskariLayerService.class);
         permissionsService = OskariComponentManager.getComponentOfType(PermissionService.class);
     }
 

--- a/control-admin/src/test/java/fi/nls/oskari/control/admin/UserCredentialsTest.java
+++ b/control-admin/src/test/java/fi/nls/oskari/control/admin/UserCredentialsTest.java
@@ -4,9 +4,12 @@ import fi.nls.oskari.control.ActionDeniedException;
 import fi.nls.oskari.control.ActionHandler;
 import fi.nls.oskari.domain.Role;
 import fi.nls.oskari.service.DummyUserService;
+import fi.nls.oskari.service.OskariComponent;
+import fi.nls.oskari.service.OskariComponentManager;
 import fi.nls.oskari.service.UserService;
 import fi.nls.oskari.util.PropertyUtil;
 import fi.nls.test.control.JSONActionRouteTest;
+import fi.nls.test.util.TestHelper;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -32,11 +35,14 @@ public class UserCredentialsTest extends JSONActionRouteTest {
 
     @BeforeClass
     public static void setup() throws Exception {
+        TestHelper.registerTestDataSource();
         PropertyUtil.addProperty("oskari.user.service", DummyUserService.class.getCanonicalName(), true);
     }
     @AfterClass
     public static void tearDown() {
         PropertyUtil.clearProperties();
+        OskariComponentManager.teardown();
+        TestHelper.teardown();
     }
 
     @Parameterized.Parameters

--- a/control-base/src/test/java/fi/nls/oskari/control/data/MapLayerGroupsHandlerTest.java
+++ b/control-base/src/test/java/fi/nls/oskari/control/data/MapLayerGroupsHandlerTest.java
@@ -1,5 +1,7 @@
 package fi.nls.oskari.control.data;
 
+import fi.nls.oskari.service.OskariComponentManager;
+import org.junit.BeforeClass;
 import org.oskari.service.maplayer.OskariMapLayerGroupService;
 import fi.nls.oskari.control.ActionConstants;
 import fi.nls.oskari.control.ActionDeniedException;
@@ -36,10 +38,17 @@ public class MapLayerGroupsHandlerTest extends JSONActionRouteTest {
 
     private OskariMapLayerGroupService oskariMapLayerGroupService;
     private MapLayerGroupsHandler handler = new MapLayerGroupsHandler();
-
+    @BeforeClass
+    public static void setup() throws Exception {
+        TestHelper.registerTestDataSource();
+        assumeTrue(TestHelper.dbAvailable());
+    }
+    @AfterClass
+    public static void teardown() {
+        TestHelper.teardown();
+    }
     @Before
     public void setUp() throws Exception {
-        assumeTrue(TestHelper.dbAvailable());
         oskariMapLayerGroupService = mock(OskariMapLayerGroupServiceMybatisImpl.class);
         MaplayerGroup theme1 = new MaplayerGroup();
         theme1.setId(1);

--- a/control-base/src/test/java/fi/nls/oskari/control/view/AppSetupHandlerTest.java
+++ b/control-base/src/test/java/fi/nls/oskari/control/view/AppSetupHandlerTest.java
@@ -19,6 +19,7 @@ import fi.nls.oskari.util.PropertyUtil;
 import fi.nls.oskari.view.modifier.ViewModifier;
 import fi.nls.test.control.JSONActionRouteTest;
 import fi.nls.test.util.ResourceHelper;
+import fi.nls.test.util.TestHelper;
 import fi.nls.test.view.ViewTestHelper;
 import org.json.JSONObject;
 import org.junit.AfterClass;
@@ -61,6 +62,7 @@ public class AppSetupHandlerTest extends JSONActionRouteTest {
 
     @BeforeClass
     public static void addProperties() throws Exception {
+        TestHelper.registerTestDataSource();
         PropertyUtil.addProperty("view.template.publish", "3", true);
         PropertyUtil.addProperty("oskari.domain", "//domain.com", true);
         PropertyUtil.addProperty("oskari.map.url", "/map", true);
@@ -91,6 +93,7 @@ public class AppSetupHandlerTest extends JSONActionRouteTest {
     @AfterClass
     public static void teardown() {
         PropertyUtil.clearProperties();
+        TestHelper.teardown();
     }
 
     private void mockViewService() {

--- a/control-base/src/test/java/fi/nls/oskari/control/view/GetAppSetupHandlerRolesFromPropertiesTest.java
+++ b/control-base/src/test/java/fi/nls/oskari/control/view/GetAppSetupHandlerRolesFromPropertiesTest.java
@@ -21,6 +21,7 @@ import fi.nls.oskari.util.PropertyUtil;
 import fi.nls.oskari.view.modifier.ViewModifier;
 import fi.nls.test.control.JSONActionRouteTest;
 import fi.nls.test.util.ResourceHelper;
+import fi.nls.test.util.TestHelper;
 import fi.nls.test.view.BundleTestHelper;
 import fi.nls.test.view.ViewTestHelper;
 import org.junit.Before;
@@ -69,6 +70,7 @@ public class GetAppSetupHandlerRolesFromPropertiesTest extends JSONActionRouteTe
 
     @BeforeClass
     public static void addLocales() throws Exception {
+        TestHelper.registerTestDataSource();
         Properties properties = new Properties();
         try {
             properties.load(GetAppSetupHandlerRolesFromPropertiesTest.class.getResourceAsStream("test.properties"));
@@ -108,6 +110,7 @@ public class GetAppSetupHandlerRolesFromPropertiesTest extends JSONActionRouteTe
         PropertyUtil.clearProperties();
         // To get fresh start for components
         OskariComponentManager.teardown();
+        TestHelper.teardown();
     }
 
     @Test

--- a/control-base/src/test/java/fi/nls/oskari/control/view/GetAppSetupHandlerTest.java
+++ b/control-base/src/test/java/fi/nls/oskari/control/view/GetAppSetupHandlerTest.java
@@ -6,6 +6,7 @@ import fi.nls.oskari.control.ActionParameters;
 import fi.nls.oskari.control.view.modifier.bundle.MapfullHandler;
 import fi.nls.oskari.control.view.modifier.param.CoordinateParamHandler;
 import fi.nls.oskari.control.view.modifier.param.WFSHighlightParamHandler;
+import fi.nls.oskari.db.DatasourceHelper;
 import fi.nls.oskari.domain.User;
 import fi.nls.oskari.domain.map.DataProvider;
 import fi.nls.oskari.domain.map.view.View;
@@ -18,6 +19,7 @@ import fi.nls.oskari.map.view.BundleService;
 import fi.nls.oskari.map.view.BundleServiceMybatisImpl;
 import fi.nls.oskari.map.view.ViewService;
 import fi.nls.oskari.map.view.AppSetupServiceMybatisImpl;
+import fi.nls.oskari.service.OskariComponent;
 import fi.nls.oskari.service.OskariComponentManager;
 import fi.nls.oskari.util.DuplicateException;
 import fi.nls.oskari.util.PropertyUtil;
@@ -26,6 +28,7 @@ import fi.nls.oskari.wfs.WFSSearchChannelsService;
 import fi.nls.oskari.wfs.WFSSearchChannelsServiceMybatisImpl;
 import fi.nls.test.control.JSONActionRouteTest;
 import fi.nls.test.util.ResourceHelper;
+import fi.nls.test.util.TestHelper;
 import fi.nls.test.view.BundleTestHelper;
 import fi.nls.test.view.ViewTestHelper;
 import org.json.JSONObject;
@@ -78,6 +81,7 @@ public class GetAppSetupHandlerTest extends JSONActionRouteTest {
 
     @BeforeClass
     public static void addLocales() throws Exception {
+        TestHelper.registerTestDataSource();
         Properties properties = new Properties();
         try {
             properties.load(GetAppSetupHandlerTest.class.getResourceAsStream("test.properties"));
@@ -108,6 +112,7 @@ public class GetAppSetupHandlerTest extends JSONActionRouteTest {
         PropertyUtil.clearProperties();
         // To get fresh start for components
         OskariComponentManager.teardown();
+        TestHelper.teardown();
     }
 
     @Test

--- a/control-base/src/test/java/fi/nls/oskari/util/WFSGetLayerFieldsTest.java
+++ b/control-base/src/test/java/fi/nls/oskari/util/WFSGetLayerFieldsTest.java
@@ -2,9 +2,13 @@ package fi.nls.oskari.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.service.OskariComponentManager;
 import org.json.JSONObject;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.oskari.capabilities.ogc.LayerCapabilitiesWFS;
+import org.oskari.capabilities.ogc.WFSCapabilitiesParser;
 import org.oskari.capabilities.ogc.wfs.FeaturePropertyType;
 
 import java.util.HashMap;
@@ -19,6 +23,16 @@ public class WFSGetLayerFieldsTest {
     private final String LAYER_URL = "https://example.com/";
     private final String USERNAME = "username";
     private final String PASSWORD = "pwd";
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        // prevent call to OskariComponentManager.addDefaultComponents() that adds components requiring db-connections
+        OskariComponentManager.addComponent(new WFSCapabilitiesParser());
+    }
+    @AfterClass
+    public static void teardown() throws Exception {
+        OskariComponentManager.teardown();
+    }
 
     @Test
     public void getLayerFieldsForWFS3Collections() throws Exception {

--- a/service-base/src/main/java/fi/nls/oskari/db/DatasourceHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/db/DatasourceHelper.java
@@ -17,7 +17,6 @@ import java.util.List;
  */
 public class DatasourceHelper {
 
-    private static final Logger LOGGER = LogFactory.getLogger(DatasourceHelper.class);
     private static final String DEFAULT_DATASOURCE_NAME = "jdbc/OskariPool";
     private static final String MSG_CHECKING_POOL = "Checking existance of database pool: %s";
     private static final String PREFIX_DB = "db.";
@@ -34,6 +33,10 @@ public class DatasourceHelper {
 
     public static DatasourceHelper getInstance() {
         return INSTANCE;
+    }
+
+    private Logger getLogger() {
+        return LogFactory.getLogger(DatasourceHelper.class);
     }
 
     public static String[] getAdditionalModules() {
@@ -98,10 +101,10 @@ public class DatasourceHelper {
             return dataSrc;
         }
         try {
-            LOGGER.info("Trying JNDI dataSource with name: " + dsName);
+            getLogger().info("Trying JNDI dataSource with name: " + dsName);
             return (DataSource) ctx.lookup(JNDI_PREFIX + dsName);
         } catch (Exception ex) {
-            LOGGER.info("Couldn't find pool with name '" + dsName + "': " + ex.getMessage());
+            getLogger().info("Couldn't find pool with name '" + dsName + "': " + ex.getMessage());
         }
         return null;
     }
@@ -120,14 +123,14 @@ public class DatasourceHelper {
      */
     public boolean checkDataSource(final Context ctx, final String prefix) {
         final String poolName = getOskariDataSourceName(prefix);
-        LOGGER.info(String.format(MSG_CHECKING_POOL, poolName));
+        getLogger().info(String.format(MSG_CHECKING_POOL, poolName));
         final DataSource ds = getDataSource(ctx, poolName);
         if (ds != null) {
             // using container provided datasource rather than one created by us
-            LOGGER.debug("Found dataSource for name: " + poolName);
+            getLogger().debug("Found dataSource for name: " + poolName);
             return true;
         }
-        LOGGER.info("Creating a DB DataSource based on configured properties");
+        getLogger().info("Creating a DB DataSource based on configured properties");
         return createDataSource(prefix) != null;
     }
 
@@ -164,7 +167,7 @@ public class DatasourceHelper {
             // try getting connection. If it fails we can tell the admin that the config is not good and try JNDI instead
             dataSource.getConnection();
         } catch (SQLException e) {
-            LOGGER.error(e, "Couldn't create database connection using:", info.url);
+            getLogger().error(e, "Couldn't create database connection using:", info.url);
             // return null so we don't add a non-functioning datasource to localDataSources
             // AND this makes the code always try to get a connection using JNDI instead
             return null;
@@ -199,7 +202,7 @@ public class DatasourceHelper {
             try {
                 context = new InitialContext();
             } catch (Exception ex) {
-                LOGGER.error("Couldn't get context: ", ex.getMessage());
+                getLogger().error("Couldn't get context: ", ex.getMessage());
             }
         }
         return context;
@@ -213,9 +216,9 @@ public class DatasourceHelper {
         for (BasicDataSource ds : localDataSources) {
             try {
                 ds.close();
-                LOGGER.debug("Closed locally created data source");
+                getLogger().debug("Closed locally created data source");
             } catch (final SQLException e) {
-                LOGGER.error(e, "Failed to close locally created data source");
+                getLogger().error(e, "Failed to close locally created data source");
             }
         }
     }

--- a/service-base/src/main/java/fi/nls/oskari/db/DatasourceHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/db/DatasourceHelper.java
@@ -7,9 +7,7 @@ import org.apache.commons.dbcp2.BasicDataSource;
 
 import javax.naming.Context;
 import javax.naming.InitialContext;
-import javax.naming.OperationNotSupportedException;
 import javax.sql.DataSource;
-import java.io.StringWriter;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
@@ -21,7 +19,7 @@ public class DatasourceHelper {
 
     private static final Logger LOGGER = LogFactory.getLogger(DatasourceHelper.class);
     private static final String DEFAULT_DATASOURCE_NAME = "jdbc/OskariPool";
-    private static final String MSG_CHECKING_POOL = " - checking existance of database pool: %s";
+    private static final String MSG_CHECKING_POOL = "Checking existance of database pool: %s";
     private static final String PREFIX_DB = "db.";
     private static final DatasourceHelper INSTANCE = new DatasourceHelper();
     private static final String KEY_MODULE_LIST = "db.additional.modules";
@@ -32,6 +30,10 @@ public class DatasourceHelper {
 
     protected DatasourceHelper() {
         // use getInstance()
+    }
+
+    public static DatasourceHelper getInstance() {
+        return INSTANCE;
     }
 
     public static String[] getAdditionalModules() {
@@ -53,11 +55,9 @@ public class DatasourceHelper {
 
 
 
-    public static DatasourceHelper getInstance() {
-        return INSTANCE;
-    }
     /**
-     * Finds a datasource name property matching module (db[.module].jndi.name)
+     * Returns the configured datasource name matching module (db[.module].jndi.name)
+     * from properties (or defaults to jdbc/OskariPool if not configured)
      * @param prefix module name like myplaces, analysis etc null means "core" oskari
      * @return defaults to jdbc/OskariPool if not configured
      */
@@ -67,39 +67,41 @@ public class DatasourceHelper {
     }
 
     /**
-     * Returns the default datasource (jdbc/OskariPool) from context.
+     * Returns the default datasource.
      */
     public DataSource getDataSource() {
         return getDataSource(getContext(), getOskariDataSourceName());
     }
     /**
-     * Returns a datasource matching the name from context.
+     * Returns a datasource matching the name
      * @param name for example jdbc/OskariPool
      */
     public DataSource getDataSource(final String name) {
         return getDataSource(getContext(), name);
     }
     /**
-     * Returns a datasource matching the name from the given context.
+     * Returns a datasource matching the name from locally created ones or from given context if not created by this code.
      * @param name for example jdbc/OskariPool
      */
     public DataSource getDataSource(final Context ctx, final String name) {
-        if (ctx == null) {
-            String jmxName;
-            if (name == null) {
-                jmxName = DEFAULT_DATASOURCE_NAME;
-            } else {
-                jmxName = name;
-            }
-            return localDataSources.stream()
-                    .filter(ds -> jmxName.equals(ds.getJmxName()))
-                    .findFirst()
-                    .orElse(null);
+        String dsName;
+        if (name == null) {
+            dsName = DEFAULT_DATASOURCE_NAME;
+        } else {
+            dsName = name;
+        }
+        DataSource dataSrc = localDataSources.stream()
+                .filter(ds -> dsName.equals(ds.getJmxName()))
+                .findFirst()
+                .orElse(null);
+        if (dataSrc != null) {
+            return dataSrc;
         }
         try {
-            return (DataSource) ctx.lookup(JNDI_PREFIX + name);
+            LOGGER.info("Trying JNDI dataSource with name: " + dsName);
+            return (DataSource) ctx.lookup(JNDI_PREFIX + dsName);
         } catch (Exception ex) {
-            LOGGER.info("Couldn't find pool with name '" + name + "': " + ex.getMessage());
+            LOGGER.info("Couldn't find pool with name '" + dsName + "': " + ex.getMessage());
         }
         return null;
     }
@@ -110,31 +112,23 @@ public class DatasourceHelper {
     }
 
     /**
-     * Ensures the datasource matching the module (prefix) is present in the given context.
-     * Creates the datasource and binds it to context if not present.
+     * Check that we have a functioning datasource matching the module (prefix).
+     * Creates the datasource using properties if it's not available on the context.
      * @param ctx
      * @param prefix module like myplaces, analysis
      * @return
      */
     public boolean checkDataSource(final Context ctx, final String prefix) {
-        final String poolToken = (prefix == null) ? "" : prefix + ".";
         final String poolName = getOskariDataSourceName(prefix);
-
         LOGGER.info(String.format(MSG_CHECKING_POOL, poolName));
         final DataSource ds = getDataSource(ctx, poolName);
-        boolean success = ds != null;
-        if (success) {
+        if (ds != null) {
             // using container provided datasource rather than one created by us
-            LOGGER.info("Found JNDI dataSource with name: " + poolName +
-                    ". Using it instead of properties configuration db." + poolToken + "url");
-        } else {
-            LOGGER.info(" - creating a DataSource with defaults based on configured properties");
-            final DataSource dataSource = createDataSource(prefix);
-            addDataSource(ctx, poolName, dataSource);
-            LOGGER.info(String.format(MSG_CHECKING_POOL, poolName));
-            success = (getDataSource(ctx, poolName) != null);
+            LOGGER.debug("Found dataSource for name: " + poolName);
+            return true;
         }
-        return success;
+        LOGGER.info("Creating a DB DataSource based on configured properties");
+        return createDataSource(prefix) != null;
     }
 
     public BasicDataSource createDataSource() {
@@ -147,6 +141,12 @@ public class DatasourceHelper {
      * @return
      */
     public BasicDataSource createDataSource(final String prefix) {
+        // check if we have the named connection already
+        BasicDataSource ds = (BasicDataSource) getDataSource(null, getOskariDataSourceName(prefix));
+        if (ds != null) {
+            return ds;
+        }
+
         final BasicDataSource dataSource = new BasicDataSource();
         ConnectionInfo info = getPropsForDS(prefix);
 
@@ -160,6 +160,15 @@ public class DatasourceHelper {
         dataSource.setValidationQueryTimeout(100);
         // Just for querying from local datasources when context can't be created (for example in Tomcat by default)
         dataSource.setJmxName(getOskariDataSourceName(prefix));
+        try {
+            // try getting connection. If it fails we can tell the admin that the config is not good and try JNDI instead
+            dataSource.getConnection();
+        } catch (SQLException e) {
+            LOGGER.error(e, "Couldn't create database connection using:", info.url);
+            // return null so we don't add a non-functioning datasource to localDataSources
+            // AND this makes the code always try to get a connection using JNDI instead
+            return null;
+        }
         localDataSources.add(dataSource);
         return dataSource;
     }
@@ -182,40 +191,6 @@ public class DatasourceHelper {
         return info;
     }
 
-    private void addDataSource(final Context ctx, final String name, final DataSource ds) {
-        if(ctx == null) {
-            return;
-        }
-        try {
-            constructContext(ctx, "comp", "env", "jdbc");
-            ctx.bind(JNDI_PREFIX + name, ds);
-        } catch (OperationNotSupportedException ex) {
-            // in Tomcat the context is (at least by default) read-only so we can't inject the context to it
-            // the datasource must be provided with context.xml or similar as JNDI resource.
-            LOGGER.error("Pool could not be created. You need to provide datasource with JNDI name '" + name +"' from servlet container: ", ex.getMessage());
-        } catch (Exception ex) {
-            LOGGER.error(ex, "Couldn't add pool with name '" + name +"': ", ex.getMessage());
-        }
-    }
-
-    /**
-     * Constructs the context path if not available yet.
-     * @param ctx
-     * @param path
-     */
-    private void constructContext(final Context ctx, final String... path) {
-        StringWriter current = new StringWriter();
-        current.append("java:");
-        for (String key : path) {
-            try {
-                current.append("/" + key);
-                ctx.createSubcontext(current.toString());
-            } catch (Exception ignored) {
-                LOGGER.ignore("Ignore context creation fail", ignored);
-            }
-        }
-    }
-
     /**
      * Creates an InitialContext if not created yet.
      */
@@ -235,7 +210,7 @@ public class DatasourceHelper {
      */
     public void teardown() {
         // clean up created datasources
-        for(BasicDataSource ds : localDataSources) {
+        for (BasicDataSource ds : localDataSources) {
             try {
                 ds.close();
                 LOGGER.debug("Closed locally created data source");

--- a/service-map/src/main/java/fi/nls/oskari/map/view/AppSetupServiceMybatisImpl.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/view/AppSetupServiceMybatisImpl.java
@@ -39,14 +39,18 @@ public class AppSetupServiceMybatisImpl extends ViewService {
     private SqlSessionFactory factory = null;
 
     public AppSetupServiceMybatisImpl() {
-
-        final DatasourceHelper helper = DatasourceHelper.getInstance();
-        DataSource dataSource = helper.getDataSource();
+        this(null);
+    }
+    public AppSetupServiceMybatisImpl(DataSource dataSource) {
         if (dataSource == null) {
-            dataSource = helper.createDataSource();
-        }
-        if (dataSource == null) {
-            LOG.error("Couldn't get datasource for app setup service");
+            final DatasourceHelper helper = DatasourceHelper.getInstance();
+            dataSource = helper.getDataSource();
+            if (dataSource == null) {
+                dataSource = helper.createDataSource();
+            }
+            if (dataSource == null) {
+                LOG.error("Couldn't get datasource for app setup service");
+            }
         }
         factory = initializeMyBatis(dataSource);
 

--- a/service-map/src/test/java/fi/nls/oskari/map/view/AppSetupServiceMybatisImplTest.java
+++ b/service-map/src/test/java/fi/nls/oskari/map/view/AppSetupServiceMybatisImplTest.java
@@ -4,9 +4,12 @@ import fi.nls.oskari.domain.GuestUser;
 import fi.nls.oskari.domain.User;
 import fi.nls.oskari.service.DummyUserService;
 import fi.nls.oskari.util.PropertyUtil;
+import fi.nls.test.util.TestHelper;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import javax.sql.DataSource;
 
 import static org.junit.Assert.assertEquals;
 
@@ -27,8 +30,9 @@ public class AppSetupServiceMybatisImplTest {
         PropertyUtil.addProperty("view.default.Guest", "4");
         PropertyUtil.addProperty("view.default.roles", "Admin, User, Guest");
         PropertyUtil.addProperty("oskari.user.service", DummyUserService.class.getCanonicalName(), true);
+        DataSource ds = TestHelper.createMemDBforUnitTest();
 
-        service = new AppSetupServiceMybatisImpl();
+        service = new AppSetupServiceMybatisImpl(ds);
     }
 
     @Test

--- a/service-myplaces/src/main/java/fi/nls/oskari/myplaces/MyPlacesServiceMybatisImpl.java
+++ b/service-myplaces/src/main/java/fi/nls/oskari/myplaces/MyPlacesServiceMybatisImpl.java
@@ -62,7 +62,7 @@ public class MyPlacesServiceMybatisImpl extends MyPlacesService {
     }
 
     public static String getCacheKey(long id) {
-        return Long.toString(id);
+        return UserContentMyPlacesService.getPlaceCacheKey(id);
     }
 
     private MyPlaceCategory cache(MyPlaceCategory layer) {

--- a/service-myplaces/src/main/java/fi/nls/oskari/myplaces/UserContentMyPlacesService.java
+++ b/service-myplaces/src/main/java/fi/nls/oskari/myplaces/UserContentMyPlacesService.java
@@ -11,6 +11,15 @@ public class UserContentMyPlacesService extends UserContentService {
 
     private MyPlacesServiceMybatisImpl myPlacesService = null;
 
+    /**
+     * Cache key for my places place
+     * This was in MyPlacesServiceMybatisImpl, but it requires too much mocking for static variable services in tests...
+     * @param id
+     * @return
+     */
+    public static String getPlaceCacheKey(long id) {
+        return Long.toString(id);
+    }
     @Override
     public void init() {
         super.init();

--- a/service-myplaces/src/main/java/org/oskari/myplaces/service/mybatis/MyPlacesLayersServiceMybatisImpl.java
+++ b/service-myplaces/src/main/java/org/oskari/myplaces/service/mybatis/MyPlacesLayersServiceMybatisImpl.java
@@ -11,6 +11,7 @@ import javax.sql.DataSource;
 import fi.nls.oskari.cache.Cache;
 import fi.nls.oskari.cache.CacheManager;
 import fi.nls.oskari.myplaces.MyPlacesServiceMybatisImpl;
+import fi.nls.oskari.myplaces.UserContentMyPlacesService;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.ExecutorType;
@@ -114,7 +115,7 @@ public class MyPlacesLayersServiceMybatisImpl implements MyPlacesLayersService {
             for (MyPlaceCategory category : categories) {
                 mapper.update(category);
                 n++;
-                cache.remove(MyPlacesServiceMybatisImpl.getCacheKey(category.getId()));
+                cache.remove(UserContentMyPlacesService.getPlaceCacheKey(category.getId()));
             }
             session.commit();
             return n;
@@ -128,7 +129,7 @@ public class MyPlacesLayersServiceMybatisImpl implements MyPlacesLayersService {
             int n = 0;
             for (long id : ids) {
                 n += mapper.delete(id);
-                cache.remove(MyPlacesServiceMybatisImpl.getCacheKey(id));
+                cache.remove(UserContentMyPlacesService.getPlaceCacheKey(id));
             }
             session.commit();
             return n;

--- a/service-search-wfs/src/main/java/fi/nls/oskari/search/channel/WFSSearchChannel.java
+++ b/service-search-wfs/src/main/java/fi/nls/oskari/search/channel/WFSSearchChannel.java
@@ -92,7 +92,7 @@ public class WFSSearchChannel extends SearchChannel {
 
     public WFSChannelHandler getHandler() {
         Map<String, WFSChannelHandler> handlers = OskariComponentManager.getComponentsOfType(WFSChannelHandler.class);
-        if(handlers.containsKey(config.getHandler())) {
+        if (handlers.containsKey(config.getHandler())) {
             return handlers.get(config.getHandler());
         }
         return handlers.get(WFSChannelHandler.ID);

--- a/service-search-wfs/src/test/java/fi/nls/oskari/search/channel/WFSSearchChannelTest.java
+++ b/service-search-wfs/src/test/java/fi/nls/oskari/search/channel/WFSSearchChannelTest.java
@@ -3,7 +3,9 @@ package fi.nls.oskari.search.channel;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import fi.nls.oskari.service.OskariComponentManager;
 import org.json.JSONObject;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -46,6 +48,12 @@ public class WFSSearchChannelTest {
                 + "}";
         point.replace('\'', '"');
         pointFeature = new JSONObject(point);
+        // prevent call to OskariComponentManager.addDefaultComponents() that adds components requiring db-connections
+        OskariComponentManager.addComponent(new WFSChannelHandler());
+    }
+    @AfterClass
+    public static void teardown() throws Exception {
+        OskariComponentManager.teardown();
     }
 
     @Test

--- a/shared-test-resources/src/main/java/fi/nls/test/util/TestHelper.java
+++ b/shared-test-resources/src/main/java/fi/nls/test/util/TestHelper.java
@@ -6,10 +6,15 @@ import fi.nls.oskari.service.ServiceRuntimeException;
 import fi.nls.oskari.util.PropertyUtil;
 import org.h2.jdbcx.JdbcDataSource;
 
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.naming.OperationNotSupportedException;
 import javax.sql.DataSource;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.StringWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.sql.Connection;
@@ -25,6 +30,7 @@ import java.util.Properties;
 public class TestHelper {
 
     public static final String DB_PROPS_KEY = "oskari_db_test_props";
+
     public static final String TEST_URL = "http://httpbin.org/ip";
     private static enum STATUS {
         NONE,
@@ -124,6 +130,26 @@ public class TestHelper {
         // deal with first to get this running
         return ds;
     }
+
+
+    public static void registerTestDataSource() throws SQLException {
+        registerTestDataSource(createMemDBforUnitTest());
+    }
+
+    public static void registerTestDataSource(final DataSource ds) {
+        try {
+            DatasourceHelper.getInstance()
+                    .registerDataSource(
+                            DatasourceHelper.DEFAULT_DATASOURCE_NAME, ds);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+    }
+
+    public static void teardown() {
+        DatasourceHelper.getInstance().teardown();
+    }
+
 
     public static DataSource createMemDBforUnitTest(List<String> sqlStatementsForInit) throws SQLException {
         DataSource ds = createMemDBforUnitTest();


### PR DESCRIPTION
For example in Tomcat the context is read-only (by default at least) and we need to provide the JNDI context datasource from Tomcat. As we don't need JNDI anymore after migrating from Ibatis to Mybatis we could just keep references to BasicDataSource we create  and NOT trying to inject them into context (as this is problematic in for example Tomcat). We already keep references to created datasources for teardown purposes.

This should enable bundling in the Postgres/JDBC driver inside the war-file and make for example Azure App Service deployments easier.