### PR TITLE
Move all default allowed bundles for publisher to code

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/view/AppSetupHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/view/AppSetupHandler.java
@@ -141,7 +141,8 @@ public class AppSetupHandler extends RestActionHandler {
                 ViewModifier.BUNDLE_PUBLISHEDGRID, ViewModifier.BUNDLE_FEATUREDATA2,
                 ViewModifier.BUNDLE_COORDINATETOOL, ViewModifier.BUNDLE_STATSGRID,
                 ViewModifier.BUNDLE_FEEDBACKSERVICE, ViewModifier.BUNDLE_CAMERA_CONTROLS_3D,
-                ViewModifier.BUNDLE_METADATACATALOGUE, ViewModifier.BUNDLE_METADATAFLYOUT));
+                ViewModifier.BUNDLE_METADATACATALOGUE, ViewModifier.BUNDLE_METADATAFLYOUT,
+                ViewModifier.BUNDLE_MAPROTATOR, ViewModifier.BUNDLE_MAPLEGEND));
         for(String bundleId : configBundles) {
             SIMPLE_BUNDLES.add(bundleId);
         }

--- a/service-control/src/main/java/fi/nls/oskari/view/modifier/ViewModifier.java
+++ b/service-control/src/main/java/fi/nls/oskari/view/modifier/ViewModifier.java
@@ -37,6 +37,7 @@ public abstract class ViewModifier {
     public static final String BUNDLE_TIMESERIES = "timeseries";
     public static final String BUNDLE_GUIDEDTOUR = "guidedtour";
     public static final String BUNDLE_MAPROTATOR = "maprotator";
+    public static final String BUNDLE_MAPLEGEND = "maplegend";
     public static final String BUNDLE_METADATACATALOGUE = "metadatacatalogue";
     public static final String BUNDLE_CAMERA_CONTROLS_3D = "camera-controls-3d";
     public static final String BUNDLE_METADATAFLYOUT = "metadataflyout";

--- a/servlet-map/src/main/resources/oskari.properties
+++ b/servlet-map/src/main/resources/oskari.properties
@@ -122,8 +122,8 @@ actionhandler.GetAppSetup.dynamic.bundle.admin-layerselector.roles = Admin
 actionhandler.GetAppSetup.dynamic.bundle.admin-users.roles = Admin
 actionhandler.GetAppSetup.dynamic.bundle.admin.roles = Admin
 
-# comma-separated list of bundles that are whitelisted for publishing
-actionhandler.AppSetup.bundles.simple=maprotator,maplegend
+# comma-separated list of bundles that are whitelisted for publishing like "maprotator,maplegend"
+actionhandler.AppSetup.bundles.simple=
 ##################################
 
 ##################################


### PR DESCRIPTION
So it's easier to figure out what needs to be configured on an instance if there's more bundles that should be allowed with publisher to enable on an embedded map: 
```
actionhandler.AppSetup.bundles.simple=bundle, ids, as, list
```

Without this the default values in `oskari.properties`  (maprotator,maplegend) need to be added for any override list in `oskari-ext.properties` as well. After this PR the instance config can be used to allow more bundles and not overrides these defaults.