### PR TITLE
Allow hyphen/dash in email domain name

### DIFF
--- a/control-users/src/main/java/fi/nls/oskari/control/users/RegistrationUtil.java
+++ b/control-users/src/main/java/fi/nls/oskari/control/users/RegistrationUtil.java
@@ -23,7 +23,7 @@ public class RegistrationUtil {
     }
 
     public static boolean isValidEmail(String email) {
-        String regex = "^[\\w-_\\.+]*[\\w-_\\.]\\@([\\w]+\\.)+[\\w]+[\\w]$";
+        String regex = "^[\\w-_\\.+]*[\\w-_\\.]\\@([\\w]+\\.\\-)+[\\w]+[\\w]$";
         return email != null && !email.isEmpty() && email.matches(regex);
     }
 


### PR DESCRIPTION
Hyphen (dash) is the only spacing character allowed in a domain name