### PR TITLE
Vector style service

### DIFF
--- a/content-resources/src/main/java/flyway/oskari/V2_11_2__migrate_maplayer_styles.java
+++ b/content-resources/src/main/java/flyway/oskari/V2_11_2__migrate_maplayer_styles.java
@@ -174,10 +174,10 @@ public class V2_11_2__migrate_maplayer_styles extends BaseJavaMigration  {
     protected void insertStyle (Connection conn, StyleConfig style) throws SQLException {
         String name = style.title.isEmpty() ? style.name : style.title;
         final String sql = "INSERT INTO oskari_maplayer_style"
-                + " (layer, type, name, style) VALUES"
+                + " (layer_id, type, name, style) VALUES"
                 + " (?, ?, ?, ?)";
         try (PreparedStatement statement = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
-            statement.setString(1, Integer.toString(style.layerId));
+            statement.setInt(1, style.layerId);
             statement.setString(2, style.type);
             statement.setString(3, name);
             statement.setString(4, style.def.toString());

--- a/content-resources/src/main/java/flyway/oskari/V2_11_2__migrate_maplayer_styles.java
+++ b/content-resources/src/main/java/flyway/oskari/V2_11_2__migrate_maplayer_styles.java
@@ -112,10 +112,15 @@ public class V2_11_2__migrate_maplayer_styles extends BaseJavaMigration  {
         // Bypass possible layer definitions
         if (!style.has("featureStyle") && !style.has("optionalStyles")) {
             String key = style.keys().next().toString();
+            // TODO: npe??
             return parseOskari(layerId, name, JSONHelper.getJSONObject(style, key));
         }
+        String title = JSONHelper.optString(style, "title");
+        style.remove("title");
+
         StyleConfig conf = new StyleConfig(layerId, VectorStyle.TYPE_OSKARI, name, style);
-        conf.title = JSONHelper.optString(style, "title");
+        conf.title = title;
+
         return conf;
     }
     private boolean isFeatureStyleDef(JSONObject styleLike) {

--- a/content-resources/src/main/java/flyway/oskari/V2_11_2__migrate_maplayer_styles.java
+++ b/content-resources/src/main/java/flyway/oskari/V2_11_2__migrate_maplayer_styles.java
@@ -1,0 +1,254 @@
+package flyway.oskari;
+
+import java.sql.*;
+import java.util.*;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.util.JSONHelper;
+import fi.nls.oskari.domain.map.style.VectorStyle;
+import fi.nls.oskari.domain.map.OskariLayer;
+
+public class V2_11_2__migrate_maplayer_styles extends BaseJavaMigration  {
+    private static final String KEY_OSKARI = "styles";
+    private static final String KEY_EXTERNAL = "externalStyles";
+    private static final String DEFAULT_STYLE = "default";
+    private static final List<String> FEATURE_STYLE_KEYS = Arrays.asList("fill", "stroke", "image", "text");
+    private static final List<String> MAPBOX_STYLE_KEYS = Arrays.asList("version", "layers", "sources");
+    private static final List<String> CESIUM_STYLE_KEYS = Arrays.asList("show", "color");
+
+    @Override
+    public void migrate(Context context) throws Exception {
+        Logger log = LogFactory.getLogger(V2_11_2__migrate_maplayer_styles.class);
+        Connection conn = context.getConnection();
+        List<StyleConfig> styles = new ArrayList();
+
+        List<OskariLayer> wfs = getLayers(conn, OskariLayer.TYPE_WFS);
+        log.info("Found: " + wfs.size() + " WFS layers to migrate");
+        for (OskariLayer layer: wfs) {
+            styles.addAll(getOskariStyleDefs(layer));
+        }
+
+        List<OskariLayer> tiles3d = getLayers(conn, OskariLayer.TYPE_3DTILES);
+        log.info("Found: " + tiles3d.size() + " tiles 3D layers to migrate");
+        for (OskariLayer layer: tiles3d) {
+            styles.addAll(getOskariStyleDefs(layer));
+            styles.addAll(getCesiumStyleDefs(layer));
+        }
+
+        List<OskariLayer> vectortile = getLayers(conn, OskariLayer.TYPE_VECTOR_TILE);
+        log.info("Found: " + vectortile.size() + " vector tile layers to migrate");
+        for (OskariLayer layer: vectortile) {
+            styles.addAll(getOskariStyleDefs(layer));
+            styles.addAll(getMapboxStyleDefs(layer));
+        }
+
+        // insert styles
+        log.info("Parsed: " + styles.size() + " styles from layers");
+        for (StyleConfig style: styles) {
+            insertStyle(conn, style);
+        }
+
+        // update appsetup styles
+        long mapfullId = getMapfullId(conn);
+        Map<Long, JSONObject> states = getAppsetupStates(conn, mapfullId);
+        for (long appId : states.keySet()) {
+            boolean update = false;
+            JSONObject state = states.get(appId);
+            JSONArray stateLayers = JSONHelper.getEmptyIfNull(JSONHelper.getJSONArray(state, "selectedLayers"));
+            for (int i = 0; i < stateLayers.length(); i++) {
+                JSONObject layer = JSONHelper.getJSONObject(stateLayers, i);
+                int layerId = layer.optInt("id", -1);
+                String styleName = layer.optString("style");
+                Optional<StyleConfig> style = styles.stream().filter(s -> s.layerId == layerId && styleName.equals(s.name)).findFirst();
+                if (style.isPresent()) {
+                    JSONHelper.putValue(layer, "style", style.get().id);
+                    update = true;
+                }
+            }
+            if (update) {
+                try {
+                    updateAppsetupState(conn, mapfullId, appId, state);
+                } catch (SQLException e) {
+                    log.error(e, "Error updating mapfull bundle state for appsetup: " + appId);
+                    throw e;
+                }
+            }
+        }
+    }
+
+    protected List<StyleConfig> getOskariStyleDefs(OskariLayer layer) {
+        JSONObject stylesJson = JSONHelper.getJSONObject(layer.getOptions(), KEY_OSKARI);
+        if (stylesJson == null) {
+            return Collections.emptyList();
+        }
+        int layerId = layer.getId();
+        if (isFeatureStyleDef(stylesJson)) {
+            // style def without name
+            return Collections.singletonList(new StyleConfig(layerId, VectorStyle.TYPE_OSKARI, DEFAULT_STYLE, stylesJson));
+        }
+        List<StyleConfig> styles = new ArrayList<>();
+
+        Iterator it = stylesJson.keys();
+        while(it.hasNext()) {
+            String name = (String) it.next();
+            JSONObject styleJson = JSONHelper.getJSONObject(stylesJson, name);
+            styles.add(parseOskari(layerId, name, styleJson));
+        }
+        return styles;
+    }
+
+    protected StyleConfig parseOskari (int layerId, String name, JSONObject style) {
+        // 3D-layers have not required featureStyle
+        // for consistency wrap inside featureStyle
+        if (isFeatureStyleDef(style)) {
+            style = JSONHelper.createJSONObject("featureStyle", style);
+        }
+        // Bypass possible layer definitions
+        if (!style.has("featureStyle") && !style.has("optionalStyles")) {
+            String key = style.keys().next().toString();
+            return parseOskari(layerId, name, JSONHelper.getJSONObject(style, key));
+        }
+        StyleConfig conf = new StyleConfig(layerId, VectorStyle.TYPE_OSKARI, name, style);
+        conf.title = JSONHelper.optString(style, "title");
+        return conf;
+    }
+    private boolean isFeatureStyleDef(JSONObject styleLike) {
+        return FEATURE_STYLE_KEYS.stream().filter(key -> styleLike.has(key)).findAny().isPresent();
+    }
+    protected List<StyleConfig> getCesiumStyleDefs (OskariLayer layer) {
+        JSONObject external = JSONHelper.getJSONObject(layer.getOptions(), KEY_EXTERNAL);
+        if (external == null || external.length() == 0) {
+            return Collections.emptyList();
+        }
+        int layerId = layer.getId();
+        List<StyleConfig> styles = new ArrayList<>();
+        for (String name: JSONObject.getNames(external)) {
+            if (CESIUM_STYLE_KEYS.contains(name)) {
+                // style def without name
+                return Collections.singletonList(new StyleConfig(layerId, VectorStyle.TYPE_3D, DEFAULT_STYLE, external));
+            }
+            try {
+                JSONObject style = JSONHelper.getJSONObject(external, name);
+                styles.add(new StyleConfig(layerId, VectorStyle.TYPE_3D, name, style));
+            } catch (Exception ignored) {
+                // if we have def without style name, style.name might be something else than style def (JSONObject)
+                // in that case styles list is ignored and external json is used as style def
+            }
+        }
+        return styles;
+    }
+    protected List<StyleConfig> getMapboxStyleDefs (OskariLayer layer) {
+        JSONObject external = JSONHelper.getJSONObject(layer.getOptions(), KEY_EXTERNAL);
+        if (external == null || external.length() == 0) {
+            return Collections.emptyList();
+        }
+        int layerId = layer.getId();
+        List<StyleConfig> styles = new ArrayList<>();
+        for (String name: JSONObject.getNames(external)) {
+            if (MAPBOX_STYLE_KEYS.contains(name)) {
+                // style def without name
+                return Collections.singletonList(new StyleConfig(layerId, VectorStyle.TYPE_MAPBOX, DEFAULT_STYLE, external));
+            }
+            try {
+                JSONObject style = JSONHelper.getJSONObject(external, name);
+                styles.add(new StyleConfig(layerId, VectorStyle.TYPE_MAPBOX, name, style));
+            } catch (Exception ignored) {
+                // if we have def without style name, style.name might be something else than style def (JSONObject)
+                // in that case styles list is ignored and external json is used as style def
+            }
+        }
+        return styles;
+    }
+
+    protected void insertStyle (Connection conn, StyleConfig style) throws SQLException {
+        String name = style.title.isEmpty() ? style.name : style.title;
+        final String sql = "INSERT INTO oskari_maplayer_style"
+                + " (layer, type, name, style) VALUES"
+                + " (?, ?, ?, ?)";
+        try (PreparedStatement statement = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            statement.setString(1, Integer.toString(style.layerId));
+            statement.setString(2, style.type);
+            statement.setString(3, name);
+            statement.setString(4, style.def.toString());
+            statement.execute();
+            try (ResultSet rs = statement.getGeneratedKeys()) {
+                if (!rs.next()) {
+                    throw new SQLException ("Couldn't get generated id for inserted style");
+                }
+                style.id = rs.getLong(1);
+            }
+        }
+    }
+    private void updateAppsetupState (Connection conn, long bundleId,  long appId, JSONObject state) throws SQLException {
+        final String sql = "UPDATE oskari_appsetup_bundles SET state=? where bundle_id=? AND appsetup_id=?";
+        try(PreparedStatement statement = conn.prepareStatement(sql)) {
+            statement.setString(1, state.toString());
+            statement.setLong(2, bundleId);
+            statement.setLong(3, appId);
+            statement.execute();
+        }
+    }
+    protected long getMapfullId (Connection conn) throws SQLException {
+        final String sql = "SELECT id from oskari_bundle WHERE name = 'mapfull'";
+        try (PreparedStatement statement = conn.prepareStatement(sql)) {
+            try (ResultSet rs = statement.executeQuery()) {
+                if (!rs.next()) {
+                    throw new SQLException ("Couldn't find id for mapfull bundle");
+                }
+                return rs.getLong("id");
+            }
+        }
+    }
+    protected List<OskariLayer> getLayers(Connection conn, String layerType) throws SQLException {
+        List<OskariLayer> layers = new ArrayList();
+        final String sql = "SELECT id, options FROM oskari_maplayer where type=?";
+        try (PreparedStatement statement = conn.prepareStatement(sql)) {
+            statement.setString(1, layerType);
+            try (ResultSet rs = statement.executeQuery()) {
+                while (rs.next()) {
+                    OskariLayer layer = new OskariLayer();
+                    layer.setId(rs.getInt("id"));
+                    layer.setOptions(JSONHelper.createJSONObject(rs.getString("options")));
+                    layers.add(layer);
+                }
+            }
+        }
+        return layers;
+    }
+    protected Map<Long, JSONObject> getAppsetupStates(Connection conn, long mapfullId) throws SQLException {
+        Map<Long, JSONObject> states = new HashMap();
+        final String sql = "SELECT appsetup_id, state from oskari_appsetup_bundles where bundle_id = ?";
+        try (PreparedStatement statement = conn.prepareStatement(sql)) {
+            statement.setLong(1, mapfullId);
+            try (ResultSet rs = statement.executeQuery()) {
+                while (rs.next()) {
+                    long id = rs.getLong("appsetup_id");
+                    JSONObject state = JSONHelper.createJSONObject(rs.getString("state"));
+                    states.put(id, state);
+                }
+            }
+        }
+        return states;
+    }
+
+    class StyleConfig {
+        long id;
+        int layerId;
+        String type;
+        String name;
+        JSONObject def;
+        String title = ""; // optional for oskari style
+        StyleConfig(int layerId, String type, String name, JSONObject def) {
+            this.layerId = layerId;
+            this.type = type;
+            this.name = name;
+            this.def = def;
+        }
+    }
+}

--- a/content-resources/src/main/resources/flyway/oskari/V2_11_0__add_style_table.sql
+++ b/content-resources/src/main/resources/flyway/oskari/V2_11_0__add_style_table.sql
@@ -1,13 +1,17 @@
 CREATE TABLE IF NOT EXISTS oskari_maplayer_style (
     id bigserial NOT NULL,
-    layer character varying(64) NOT NULL,
+    layer_id integer,
     type character varying(20) NOT NULL,
-    creator bigint DEFAULT (-1) NOT NULL,
+    creator bigint,
     name character varying(256) NOT NULL,
     style text NOT NULL,
     created timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     updated timestamp with time zone,
-    CONSTRAINT oskari_maplayer_style_pkey PRIMARY KEY (id)
+    CONSTRAINT oskari_maplayer_style_pkey PRIMARY KEY (id),
+    CONSTRAINT oskari_maplayer_style_creator_fkey FOREIGN KEY (creator)
+          REFERENCES oskari_users(id) ON DELETE CASCADE,
+    CONSTRAINT oskari_maplayer_style_layer_fkey FOREIGN KEY (layer_id)
+          REFERENCES oskari_maplayer(id) ON DELETE CASCADE
 );
 
 COMMENT ON TABLE oskari_maplayer_style IS 'Style configurations for vector maplayers';

--- a/content-resources/src/main/resources/flyway/oskari/V2_11_0__add_style_table.sql
+++ b/content-resources/src/main/resources/flyway/oskari/V2_11_0__add_style_table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS oskari_maplayer_style (
+    id bigserial NOT NULL,
+    layer character varying(64) NOT NULL,
+    type character varying(20) NOT NULL,
+    creator bigint DEFAULT (-1) NOT NULL,
+    name character varying(256) NOT NULL,
+    style text NOT NULL,
+    created timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated timestamp with time zone,
+    CONSTRAINT oskari_maplayer_style_pkey PRIMARY KEY (id)
+);
+
+COMMENT ON TABLE oskari_maplayer_style IS 'Style configurations for vector maplayers';

--- a/content-resources/src/main/resources/flyway/oskari/V2_11_1__add_default_style.sql
+++ b/content-resources/src/main/resources/flyway/oskari/V2_11_1__add_default_style.sql
@@ -1,10 +1,8 @@
 INSERT INTO oskari_maplayer_style (
-    layer,
     type,
     name,
     style
 ) VALUES (
-    '',
     'default',
     'default',
     '{"featureStyle":{"image":{"shape":5,"size":3,"fill":{"color":"#FAEBD7"}},"fill":{"area":{"pattern":-1},"color":"#FAEBD7"},"stroke":{"area":{"color":"#000000","lineDash":"solid","width":1,"lineJoin":"round"},"color":"#000000","lineCap":"round","lineDash":"solid","width":1,"lineJoin":"round"}}}'

--- a/content-resources/src/main/resources/flyway/oskari/V2_11_1__add_default_style.sql
+++ b/content-resources/src/main/resources/flyway/oskari/V2_11_1__add_default_style.sql
@@ -1,0 +1,11 @@
+INSERT INTO oskari_maplayer_style (
+    layer,
+    type,
+    name,
+    style
+) VALUES (
+    '',
+    'default',
+    'default',
+    '{"featureStyle":{"image":{"shape":5,"size":3,"fill":{"color":"#FAEBD7"}},"fill":{"area":{"pattern":-1},"color":"#FAEBD7"},"stroke":{"area":{"color":"#000000","lineDash":"solid","width":1,"lineJoin":"round"},"color":"#000000","lineCap":"round","lineDash":"solid","width":1,"lineJoin":"round"}}}'
+);

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/style/VectorStyle.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/style/VectorStyle.java
@@ -41,7 +41,7 @@ public class VectorStyle implements Serializable {
         return layerId;
     }
 
-    public void setLayer(int layerId) {
+    public void setLayerId(int layerId) {
         this.layerId = layerId;
     }
 

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/style/VectorStyle.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/style/VectorStyle.java
@@ -1,0 +1,108 @@
+package fi.nls.oskari.domain.map.style;
+
+
+import java.io.Serializable;
+import java.time.OffsetDateTime;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import fi.nls.oskari.util.JSONHelper;
+import org.json.JSONObject;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class VectorStyle implements Serializable {
+    public static final String TYPE_OSKARI = "oskari";
+    public static final String TYPE_MAPBOX = "mapbox";
+    public static final String TYPE_3D = "cesium";
+
+    private long id;
+    private String layer;
+    private String type;
+    private long creator;
+    private String name;
+    private JSONObject style;
+    private OffsetDateTime created;
+    private OffsetDateTime updated;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    @JsonIgnore
+    public String getLayer() {
+        return layer;
+    }
+
+    public void setLayer(String layer) {
+        this.layer = layer;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    @JsonIgnore
+    public long getCreator() {
+        return creator;
+    }
+
+    public void setCreator(long creator) {
+        this.creator = creator;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public JSONObject getStyle() {
+        return style;
+    }
+
+    @JsonGetter("style")
+    public Map getStyleMap() {
+        return JSONHelper.getObjectAsMap(style);
+    }
+
+    public void setStyle(JSONObject style) {
+        this.style = style;
+    }
+
+    @JsonSetter("style")
+    public void setStyleMap(Map<String, Object> style) {
+        this.style = new JSONObject(style);
+    }
+
+    @JsonIgnore
+    public OffsetDateTime getCreated() {
+        return created;
+    }
+
+    public void setCreated(OffsetDateTime created) {
+        this.created = created;
+    }
+
+    @JsonIgnore
+    public OffsetDateTime getUpdated() {
+        return updated;
+    }
+
+    public void setUpdated(OffsetDateTime updated) {
+        this.updated = updated;
+    }
+}

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/style/VectorStyle.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/style/VectorStyle.java
@@ -20,7 +20,7 @@ public class VectorStyle implements Serializable {
     public static final String TYPE_3D = "cesium";
 
     private long id;
-    private String layer;
+    private int layerId;
     private String type;
     private long creator;
     private String name;
@@ -37,12 +37,12 @@ public class VectorStyle implements Serializable {
     }
 
     @JsonIgnore
-    public String getLayer() {
-        return layer;
+    public int getLayerId() {
+        return layerId;
     }
 
-    public void setLayer(String layer) {
-        this.layer = layer;
+    public void setLayer(int layerId) {
+        this.layerId = layerId;
     }
 
     public String getType() {

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/style/VectorStyle.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/style/VectorStyle.java
@@ -20,9 +20,9 @@ public class VectorStyle implements Serializable {
     public static final String TYPE_3D = "cesium";
 
     private long id;
-    private int layerId;
+    private Integer layerId; // null for default instance style
     private String type;
-    private long creator;
+    private Long creator; // null for admin created styles
     private String name;
     private JSONObject style;
     private OffsetDateTime created;
@@ -37,11 +37,11 @@ public class VectorStyle implements Serializable {
     }
 
     @JsonIgnore
-    public int getLayerId() {
+    public Integer getLayerId() {
         return layerId;
     }
 
-    public void setLayerId(int layerId) {
+    public void setLayerId(Integer layerId) {
         this.layerId = layerId;
     }
 
@@ -54,11 +54,11 @@ public class VectorStyle implements Serializable {
     }
 
     @JsonIgnore
-    public long getCreator() {
+    public Long getCreator() {
         return creator;
     }
 
-    public void setCreator(long creator) {
+    public void setCreator(Long creator) {
         this.creator = creator;
     }
 

--- a/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleHelper.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleHelper.java
@@ -1,0 +1,44 @@
+package fi.nls.oskari.map.style;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import java.util.Arrays;
+import java.util.List;
+
+import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.domain.map.style.VectorStyle;
+import fi.nls.oskari.service.ServiceRuntimeException;
+
+import static fi.nls.oskari.domain.map.OskariLayer.*;
+
+public class VectorStyleHelper {
+    private static final List<String> TYPES = Arrays.asList(TYPE_WFS, TYPE_3DTILES, TYPE_VECTOR_TILE);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    static {
+        OBJECT_MAPPER.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+        OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        OBJECT_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+    }
+    public static VectorStyle readJSON(String json) {
+        try {
+            return OBJECT_MAPPER.readValue(json, VectorStyle.class);
+        } catch (Exception ex) {
+            throw new ServiceRuntimeException("Coudn't parse vector style from: " + json, ex);
+        }
+    }
+
+    public static String writeJSON(List<VectorStyle> style) {
+        try {
+            return OBJECT_MAPPER.writeValueAsString(style);
+        } catch (Exception ex) {
+            throw new ServiceRuntimeException("Coudn't write vector style to JSON", ex);
+        }
+    }
+
+    public static boolean isVectorLayer (OskariLayer layer) {
+        return TYPES.contains(layer.getType());
+    }
+}

--- a/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleMapper.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleMapper.java
@@ -1,0 +1,52 @@
+package fi.nls.oskari.map.style;
+
+import fi.nls.oskari.domain.map.style.VectorStyle;
+import org.apache.ibatis.annotations.*;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public interface VectorStyleMapper {
+    @Results(id = "VectorStyle", value = {
+            @Result(property="id", column="id", id=true),
+            @Result(property="layer", column="layer"),
+            @Result(property="type", column="type"),
+            @Result(property="creator", column="creator"),
+            @Result(property="name", column="name"),
+            @Result(property="style", column="style"),
+            @Result(property="created", column="created", javaType=OffsetDateTime.class),
+            @Result(property="updated", column="updated", javaType= OffsetDateTime.class)
+    })
+    @Select("SELECT * FROM oskari_maplayer_style WHERE id = #{id}")
+    VectorStyle getStyleById(long id);
+
+    @ResultMap("VectorStyle")
+    @Select("SELECT * FROM oskari_maplayer_style WHERE creator = #{creator}")
+    List<VectorStyle> getStylesByUser(@Param("creator") long creator);
+
+    @ResultMap("VectorStyle")
+    @Select("SELECT * FROM oskari_maplayer_style WHERE layer = #{layer} AND creator=-1")
+    List<VectorStyle> getStylesByLayerId(@Param("layer") String layer);
+
+    @ResultMap("VectorStyle")
+    @Select("SELECT * FROM oskari_maplayer_style WHERE layer = #{layer} AND (creator=-1 OR creator=#{user})")
+    List<VectorStyle> getStyles(@Param("user") long user, @Param("layer") String layer);
+
+    @Delete("DELETE FROM oskari_maplayer_style WHERE id = #{id} RETURNING id")
+    long deleteStyle(@Param("id") long id);
+
+    @Select("INSERT INTO oskari_maplayer_style"
+            + " (layer, type, creator, name, style) VALUES"
+            + " (#{layer}, #{type}, #{creator}, #{name}, #{style})"
+            + " RETURNING id")
+    @Options(flushCache = Options.FlushCachePolicy.TRUE)
+    long saveStyle(final VectorStyle style);
+
+    @Select("UPDATE oskari_maplayer_style"
+            + " SET layer = #{layer}, type = #{type},"
+            + " name = #{name} , style = #{style}"
+            + " WHERE id = #{id}"
+            + " RETURNING id")
+    @Options(flushCache = Options.FlushCachePolicy.TRUE)
+    long updateStyle(final VectorStyle style);
+}

--- a/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleMapper.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleMapper.java
@@ -9,7 +9,7 @@ import java.util.List;
 public interface VectorStyleMapper {
     @Results(id = "VectorStyle", value = {
             @Result(property="id", column="id", id=true),
-            @Result(property="layer", column="layer"),
+            @Result(property="layerId", column="layer_id"),
             @Result(property="type", column="type"),
             @Result(property="creator", column="creator"),
             @Result(property="name", column="name"),
@@ -25,25 +25,25 @@ public interface VectorStyleMapper {
     List<VectorStyle> getStylesByUser(@Param("creator") long creator);
 
     @ResultMap("VectorStyle")
-    @Select("SELECT * FROM oskari_maplayer_style WHERE layer = #{layer} AND creator=-1")
-    List<VectorStyle> getStylesByLayerId(@Param("layer") String layer);
+    @Select("SELECT * FROM oskari_maplayer_style WHERE layer_id = #{layerId} AND creator IS NULL")
+    List<VectorStyle> getStylesByLayerId(@Param("layerId") int layerId);
 
     @ResultMap("VectorStyle")
-    @Select("SELECT * FROM oskari_maplayer_style WHERE layer = #{layer} AND (creator=-1 OR creator=#{user})")
-    List<VectorStyle> getStyles(@Param("user") long user, @Param("layer") String layer);
+    @Select("SELECT * FROM oskari_maplayer_style WHERE layer_id = #{layerId} AND (creator IS NULL OR creator=#{user})")
+    List<VectorStyle> getStyles(@Param("user") long user, @Param("layerId") int layerId);
 
     @Delete("DELETE FROM oskari_maplayer_style WHERE id = #{id} RETURNING id")
     long deleteStyle(@Param("id") long id);
 
     @Select("INSERT INTO oskari_maplayer_style"
-            + " (layer, type, creator, name, style) VALUES"
-            + " (#{layer}, #{type}, #{creator}, #{name}, #{style})"
+            + " (layer_id, type, creator, name, style) VALUES"
+            + " (#{layerId}, #{type}, #{creator}, #{name}, #{style})"
             + " RETURNING id")
     @Options(flushCache = Options.FlushCachePolicy.TRUE)
     long saveStyle(final VectorStyle style);
 
     @Select("UPDATE oskari_maplayer_style"
-            + " SET layer = #{layer}, type = #{type},"
+            + " SET layer_id = #{layerId}, type = #{type},"
             + " name = #{name} , style = #{style}"
             + " WHERE id = #{id}"
             + " RETURNING id")

--- a/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleService.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleService.java
@@ -1,9 +1,8 @@
 package fi.nls.oskari.map.style;
 
+import java.util.List;
 import fi.nls.oskari.domain.map.style.VectorStyle;
 import fi.nls.oskari.service.OskariComponent;
-
-import java.util.List;
 
 public abstract class VectorStyleService extends OskariComponent  {
     public abstract VectorStyle getStyleById(final long id);

--- a/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleService.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleService.java
@@ -1,0 +1,16 @@
+package fi.nls.oskari.map.style;
+
+import fi.nls.oskari.domain.map.style.VectorStyle;
+import fi.nls.oskari.service.OskariComponent;
+
+import java.util.List;
+
+public abstract class VectorStyleService extends OskariComponent  {
+    public abstract VectorStyle getStyleById(final long id);
+    public abstract List<VectorStyle> getStylesByUser (final long user);
+    public abstract List<VectorStyle> getStylesByLayerId (final int layerId);
+    public abstract List<VectorStyle> getStyles (final long userId, final int layerId);
+    public abstract long deleteStyle(final long id);
+    public abstract long saveStyle(final VectorStyle style);
+    public abstract long updateStyle(final VectorStyle style);
+}

--- a/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleServiceMybatisImpl.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleServiceMybatisImpl.java
@@ -1,0 +1,103 @@
+package fi.nls.oskari.map.style;
+
+import fi.nls.oskari.annotation.Oskari;
+import fi.nls.oskari.db.DatasourceHelper;
+import fi.nls.oskari.domain.map.style.VectorStyle;
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.service.ServiceRuntimeException;
+import org.apache.ibatis.mapping.Environment;
+import org.apache.ibatis.session.Configuration;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.apache.ibatis.transaction.TransactionFactory;
+import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
+
+import javax.sql.DataSource;
+import java.util.List;
+
+@Oskari
+public class VectorStyleServiceMybatisImpl extends VectorStyleService {
+    private static final Logger log = LogFactory.getLogger(VectorStyleServiceMybatisImpl.class);
+    private SqlSessionFactory factory = null;
+
+    public VectorStyleServiceMybatisImpl() {
+        final DatasourceHelper helper = DatasourceHelper.getInstance();
+        DataSource dataSource = helper.getDataSource();
+        if (dataSource == null) {
+            dataSource = helper.createDataSource();
+        }
+        if (dataSource == null) {
+            log.error("Couldn't get datasource for vector style service");
+        }
+        factory = initializeMyBatis(dataSource);
+    }
+    private SqlSessionFactory initializeMyBatis(final DataSource dataSource) {
+        final TransactionFactory transactionFactory = new JdbcTransactionFactory();
+        final Environment environment = new Environment("development", transactionFactory, dataSource);
+
+        final Configuration configuration = new Configuration(environment);
+        configuration.getTypeAliasRegistry().registerAlias(VectorStyle.class);
+        configuration.setLazyLoadingEnabled(true);
+        configuration.addMapper(VectorStyleMapper.class);
+
+        return new SqlSessionFactoryBuilder().build(configuration);
+    }
+    public VectorStyle getStyleById(final long id) {
+        try (final SqlSession session = factory.openSession()) {
+            final VectorStyleMapper mapper = session.getMapper(VectorStyleMapper.class);
+            return mapper.getStyleById(id);
+        } catch (Exception e) {
+            throw new ServiceRuntimeException("Failed to get vector style for id: " + id, e);
+        }
+    }
+    public List<VectorStyle> getStylesByUser(final long user) {
+        try (final SqlSession session = factory.openSession()) {
+            final VectorStyleMapper mapper = session.getMapper(VectorStyleMapper.class);
+            return mapper.getStylesByUser(user);
+        } catch (Exception e) {
+            throw new ServiceRuntimeException("Failed to get vector styles for user: " + user, e);
+        }
+    }
+    public List<VectorStyle> getStylesByLayerId(final int layerId) {
+        try (final SqlSession session = factory.openSession()) {
+            final VectorStyleMapper mapper = session.getMapper(VectorStyleMapper.class);
+            return mapper.getStylesByLayerId(Integer.toString(layerId));
+        } catch (Exception e) {
+            throw new ServiceRuntimeException("Failed to get vector styles for layer: " + layerId, e);
+        }
+    }
+    public List<VectorStyle> getStyles(final long userId, final int layerId) {
+        try (final SqlSession session = factory.openSession()) {
+            final VectorStyleMapper mapper = session.getMapper(VectorStyleMapper.class);
+            return mapper.getStyles(userId, Integer.toString(layerId));
+        } catch (Exception e) {
+            throw new ServiceRuntimeException("Failed to get vector styles for layer: " + layerId, e);
+        }
+    }
+    public long deleteStyle(final long id) {
+        try (final SqlSession session = factory.openSession()) {
+            final VectorStyleMapper mapper = session.getMapper(VectorStyleMapper.class);
+            return mapper.deleteStyle(id);
+        } catch (Exception e) {
+            throw new ServiceRuntimeException("Failed to delete vector style: " + id, e);
+        }
+    }
+    public long saveStyle(final VectorStyle style) {
+        try (final SqlSession session = factory.openSession()) {
+            final VectorStyleMapper mapper = session.getMapper(VectorStyleMapper.class);
+            return mapper.saveStyle(style);
+        } catch (Exception e) {
+            throw new ServiceRuntimeException("Failed to save vector style", e);
+        }
+    }
+    public long updateStyle(final VectorStyle style) {
+        try (final SqlSession session = factory.openSession()) {
+            final VectorStyleMapper mapper = session.getMapper(VectorStyleMapper.class);
+            return mapper.updateStyle(style);
+        } catch (Exception e) {
+            throw new ServiceRuntimeException("Failed to update vector style", e);
+        }
+    }
+}

--- a/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleServiceMybatisImpl.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleServiceMybatisImpl.java
@@ -65,7 +65,7 @@ public class VectorStyleServiceMybatisImpl extends VectorStyleService {
     public List<VectorStyle> getStylesByLayerId(final int layerId) {
         try (final SqlSession session = factory.openSession()) {
             final VectorStyleMapper mapper = session.getMapper(VectorStyleMapper.class);
-            return mapper.getStylesByLayerId(Integer.toString(layerId));
+            return mapper.getStylesByLayerId(layerId);
         } catch (Exception e) {
             throw new ServiceRuntimeException("Failed to get vector styles for layer: " + layerId, e);
         }
@@ -73,7 +73,7 @@ public class VectorStyleServiceMybatisImpl extends VectorStyleService {
     public List<VectorStyle> getStyles(final long userId, final int layerId) {
         try (final SqlSession session = factory.openSession()) {
             final VectorStyleMapper mapper = session.getMapper(VectorStyleMapper.class);
-            return mapper.getStyles(userId, Integer.toString(layerId));
+            return mapper.getStyles(userId, layerId);
         } catch (Exception e) {
             throw new ServiceRuntimeException("Failed to get vector styles for layer: " + layerId, e);
         }

--- a/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleServiceMybatisImpl.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleServiceMybatisImpl.java
@@ -5,6 +5,7 @@ import fi.nls.oskari.db.DatasourceHelper;
 import fi.nls.oskari.domain.map.style.VectorStyle;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.mybatis.JSONObjectMybatisTypeHandler;
 import fi.nls.oskari.service.ServiceRuntimeException;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.session.Configuration;
@@ -40,6 +41,7 @@ public class VectorStyleServiceMybatisImpl extends VectorStyleService {
         final Configuration configuration = new Configuration(environment);
         configuration.getTypeAliasRegistry().registerAlias(VectorStyle.class);
         configuration.setLazyLoadingEnabled(true);
+        configuration.getTypeHandlerRegistry().register(JSONObjectMybatisTypeHandler.class);
         configuration.addMapper(VectorStyleMapper.class);
 
         return new SqlSessionFactoryBuilder().build(configuration);


### PR DESCRIPTION
- create table for vector styles
- add instance default vector style
- migrate styles from wfs, vectortile and tiles3d options to new table
- add service, service impl and mapper

Migrate style consistency:
https://github.com/oskariorg/oskari-frontend/blob/master/bundles/mapping/mapmodule/domain/VectorStyle.js#L49-L84

Instance default style (wrapped inside featureStyle) from:
https://github.com/oskariorg/oskari-server/blob/master/service-base/src/main/java/fi/nls/oskari/domain/map/wfs/WFSLayerOptions.java#L137-L172

style column content:
- oskari: {featureStyle: {}, optionalStyles: []}
- external: { ..external style definitions.. }

UPDATED:
- layer -> layer_id and column type nullable integer (instance default style)
- creator nullable (admin styles)
- foreign key constraint for creator and layer_id -> on delete cascade
