### PR TITLE
Fix/admin vector style

### DIFF
--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerAdminHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerAdminHandler.java
@@ -34,6 +34,7 @@ import org.oskari.maplayer.model.MapLayerAdminInput;
 import org.oskari.maplayer.model.MapLayerAdminOutput;
 import org.oskari.log.AuditLog;
 
+import java.time.OffsetDateTime;
 import java.util.*;
 
 @OskariActionRoute("LayerAdmin")
@@ -231,11 +232,12 @@ public class LayerAdminHandler extends AbstractLayerAdminHandler {
     }
     private void updateVectorStyles(MapLayerAdminInput layer) {
         List<VectorStyle> styles = layer.getVectorStyles();
-        if (styles == null) {
+        Map<Long, MapLayerAdminInput.Status> status = layer.getVectorStyleStatus();
+        if (styles == null || status == null) {
+            // no styles or no changes
             return;
         }
         VectorStyleService vss = getVectorStyleService();
-        Map<Long, MapLayerAdminInput.Status> status = layer.getVectorStyleStatus();
 
         styles.forEach(style -> {
             long id = style.getId();
@@ -248,6 +250,7 @@ public class LayerAdminHandler extends AbstractLayerAdminHandler {
                     break;
                 case UPDATED:
                     LOG.debug("UPDATED");
+                    style.setUpdated(OffsetDateTime.now());
                     vss.updateAdminStyle(style);
                     break;
                 case DELETED:

--- a/control-announcements/src/main/java/org/oskari/announcements/model/Announcement.java
+++ b/control-announcements/src/main/java/org/oskari/announcements/model/Announcement.java
@@ -10,7 +10,7 @@ import fi.nls.oskari.util.JSONHelper;
 import org.json.JSONObject;
 
 public class Announcement  {
-    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_DATE_TIME;
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_INSTANT;
     private int id;
     private OffsetDateTime beginDate;
     private OffsetDateTime endDate;

--- a/control-base/src/main/java/fi/nls/oskari/control/style/VectorStyleHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/style/VectorStyleHandler.java
@@ -11,6 +11,7 @@ import fi.nls.oskari.service.OskariComponentManager;
 import fi.nls.oskari.util.ResponseHelper;
 import org.oskari.log.AuditLog;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 
 @OskariActionRoute("VectorStyle")
@@ -64,6 +65,7 @@ public class VectorStyleHandler extends RestActionHandler {
             if (userId != old.getCreator() || style.getLayerId() != old.getLayerId()) {
                 throw new ActionDeniedException("User or layerId doesn't match");
             }
+            style.setUpdated(OffsetDateTime.now());
             // creator isn't updated so no need to set it here
             long id = getService().updateStyle(style);
             AuditLog.user(params.getClientIp(), params.getUser())

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/style/VectorStyle.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/style/VectorStyle.java
@@ -36,7 +36,6 @@ public class VectorStyle implements Serializable {
         this.id = id;
     }
 
-    @JsonIgnore
     public Integer getLayerId() {
         return layerId;
     }
@@ -88,7 +87,6 @@ public class VectorStyle implements Serializable {
         this.style = new JSONObject(style);
     }
 
-    @JsonIgnore
     public OffsetDateTime getCreated() {
         return created;
     }
@@ -97,7 +95,6 @@ public class VectorStyle implements Serializable {
         this.created = created;
     }
 
-    @JsonIgnore
     public OffsetDateTime getUpdated() {
         return updated;
     }

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/style/VectorStyle.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/style/VectorStyle.java
@@ -19,7 +19,7 @@ public class VectorStyle implements Serializable {
     public static final String TYPE_OSKARI = "oskari";
     public static final String TYPE_MAPBOX = "mapbox";
     public static final String TYPE_3D = "cesium";
-    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_DATE_TIME;
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_INSTANT;
 
     private long id;
     private Integer layerId; // null for default instance style

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/style/VectorStyle.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/style/VectorStyle.java
@@ -3,6 +3,7 @@ package fi.nls.oskari.domain.map.style;
 
 import java.io.Serializable;
 import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
@@ -18,6 +19,7 @@ public class VectorStyle implements Serializable {
     public static final String TYPE_OSKARI = "oskari";
     public static final String TYPE_MAPBOX = "mapbox";
     public static final String TYPE_3D = "cesium";
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_DATE_TIME;
 
     private long id;
     private Integer layerId; // null for default instance style
@@ -87,6 +89,10 @@ public class VectorStyle implements Serializable {
         this.style = new JSONObject(style);
     }
 
+    @JsonGetter("created")
+    public String getFormattedCreated () {
+        return created != null ? created.format(FORMATTER) : null;
+    }
     public OffsetDateTime getCreated() {
         return created;
     }
@@ -95,6 +101,10 @@ public class VectorStyle implements Serializable {
         this.created = created;
     }
 
+    @JsonGetter("updated")
+    public String getFormattedUpdated () {
+        return updated != null ? updated.format(FORMATTER) : null;
+    }
     public OffsetDateTime getUpdated() {
         return updated;
     }

--- a/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleMapper.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleMapper.java
@@ -48,8 +48,8 @@ public interface VectorStyleMapper {
     long saveStyle(final VectorStyle style);
 
     @Select("UPDATE oskari_maplayer_style"
-            + " SET layer_id = #{layerId}, type = #{type},"
-            + " name = #{name} , style = #{style}"
+            + " SET updated = #{updated},"
+            + " name = #{name}, style = #{style}"
             + " WHERE id = #{id}"
             + " RETURNING id")
     @Options(flushCache = Options.FlushCachePolicy.TRUE)

--- a/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleMapper.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleMapper.java
@@ -17,7 +17,7 @@ public interface VectorStyleMapper {
             @Result(property="created", column="created", javaType=OffsetDateTime.class),
             @Result(property="updated", column="updated", javaType= OffsetDateTime.class)
     })
-    @Select("SELECT * FROM oskari_maplayer_style WHERE layer_id IS NULL AND creator IS NULL")
+    @Select("SELECT * FROM oskari_maplayer_style WHERE layer_id IS NULL AND creator IS NULL and type = 'default' limit 1")
     VectorStyle getDefaultStyle();
 
     @ResultMap("VectorStyle")

--- a/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleServiceMybatisImpl.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleServiceMybatisImpl.java
@@ -89,6 +89,10 @@ public class VectorStyleServiceMybatisImpl extends VectorStyleService {
     }
     public long saveStyle(final VectorStyle style) {
         try (final SqlSession session = factory.openSession()) {
+            if (style.getLayerId() == null) {
+                // layer_id column is nullable because instance default style doesn't have layerId
+                throw new IllegalArgumentException("Tried to add vector style without layerId");
+            }
             final VectorStyleMapper mapper = session.getMapper(VectorStyleMapper.class);
             return mapper.saveStyle(style);
         } catch (Exception e) {
@@ -125,6 +129,10 @@ public class VectorStyleServiceMybatisImpl extends VectorStyleService {
     }
     public long saveAdminStyle(final VectorStyle style) {
         try (final SqlSession session = factory.openSession()) {
+            if (style.getLayerId() == null) {
+                // layer_id column is nullable because instance default style doesn't have layerId
+                throw new IllegalArgumentException("Tried to add vector style without layerId");
+            }
             if (style.getCreator() != null) {
                 log.warn("Tried to add admin style with userId: " + style.getCreator() + ". Updated to null.");
                 style.setCreator(null);


### PR DESCRIPTION
Changes:
- don't ignore layerId, created and updated from json as UserStyles tab needs them. Added time formatter because Jackson doesn't support OffsetDateTime by default (requires jackson-datatype-jsr310 module)
- safety checks for inserting null layerId and limit 1 for getdefaultstyle

Bug fixes:
- add updated time
- remove layerId and creator from update query. only save/insert set layerId so in update layerId was removed
- if style exist and wasn't modified => status caused NPE on admin layer save