### PR TITLE
VectorStyle add to options

### DIFF
--- a/control-announcements/src/main/java/org/oskari/announcements/model/Announcement.java
+++ b/control-announcements/src/main/java/org/oskari/announcements/model/Announcement.java
@@ -10,7 +10,7 @@ import fi.nls.oskari.util.JSONHelper;
 import org.json.JSONObject;
 
 public class Announcement  {
-    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_INSTANT;
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_DATE_TIME;
     private int id;
     private OffsetDateTime beginDate;
     private OffsetDateTime endDate;

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/style/VectorStyle.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/style/VectorStyle.java
@@ -97,6 +97,7 @@ public class VectorStyle implements Serializable {
         return created;
     }
 
+    @JsonIgnore
     public void setCreated(OffsetDateTime created) {
         this.created = created;
     }
@@ -109,6 +110,7 @@ public class VectorStyle implements Serializable {
         return updated;
     }
 
+    @JsonIgnore
     public void setUpdated(OffsetDateTime updated) {
         this.updated = updated;
     }

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
@@ -78,16 +78,24 @@ public class LayerJSONFormatter {
     protected void addVectorStylesToOptions(int layerId, JSONObject layer) {
         VectorStyleService service = OskariComponentManager.getComponentOfType(VectorStyleService.class);
         JSONObject styles = new JSONObject();
+        JSONObject external = new JSONObject();
         service.getAdminStyles(layerId).forEach(vs -> {
             LOG.debug("setting style for:" , layerId, "with name", vs.getName());
             JSONObject style = vs.getStyle();
-            String name = Long.toString(vs.getId());
-            JSONHelper.putValue(style, "title", vs.getName());
-            JSONHelper.putValue(styles, name, style);
+            String id = Long.toString(vs.getId());
+            String name = vs.getName();
+            if (vs.getType().equals(VectorStyle.TYPE_OSKARI)) {
+                JSONHelper.putValue(style, "title", name);
+                JSONHelper.putValue(styles, id, style);
+            } else {
+                JSONHelper.putValue(external, name, style);
+            }
+
         });
 
         JSONObject options = JSONHelper.getJSONObject(layer, "options");
         JSONHelper.putValue(options, "styles", styles);
+        JSONHelper.putValue(options, "externalStyles", external);
     }
 
     /**

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
@@ -1,9 +1,12 @@
 package fi.nls.oskari.map.layer.formatters;
 
 import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.domain.map.style.VectorStyle;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.map.geometry.WKTHelper;
+import fi.nls.oskari.map.style.VectorStyleService;
+import fi.nls.oskari.service.OskariComponentManager;
 import fi.nls.oskari.util.IOHelper;
 import fi.nls.oskari.util.JSONHelper;
 import fi.nls.oskari.util.PropertyUtil;
@@ -69,6 +72,22 @@ public class LayerJSONFormatter {
             return formatter;
         }
         return null;
+    }
+    // This is temporal solution to add styles to options
+    // For now styles are migrated to new table and frontend doesn't handle async DescribeLayer response properly
+    protected void addVectorStylesToOptions(int layerId, JSONObject layer) {
+        VectorStyleService service = OskariComponentManager.getComponentOfType(VectorStyleService.class);
+        JSONObject styles = new JSONObject();
+        service.getAdminStyles(layerId).forEach(vs -> {
+            LOG.debug("setting style for:" , layerId, "with name", vs.getName());
+            JSONObject style = vs.getStyle();
+            String name = Long.toString(vs.getId());
+            JSONHelper.putValue(style, "title", vs.getName());
+            JSONHelper.putValue(styles, name, style);
+        });
+
+        JSONObject options = JSONHelper.getJSONObject(layer, "options");
+        JSONHelper.putValue(options, "styles", styles);
     }
 
     /**

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterVectorTile.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterVectorTile.java
@@ -12,7 +12,10 @@ public class LayerJSONFormatterVectorTile extends LayerJSONFormatter {
 
     @Override
     public JSONObject getJSON(OskariLayer layer, String lang, boolean isSecure, String crs) {
-        return getBaseJSON(layer, lang, isSecure, crs);
+        JSONObject layerJson = getBaseJSON(layer, lang, isSecure, crs);
+        // This is temporal solution to add styles to options
+        addVectorStylesToOptions(layer.getId(), layerJson);
+        return layerJson;
     }
 
     @Override

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWFS.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWFS.java
@@ -18,6 +18,10 @@ public class LayerJSONFormatterWFS extends LayerJSONFormatter {
 
         final JSONObject layerJson = getBaseJSON(layer, lang, isSecure, crs);
         JSONHelper.putValue(layerJson, KEY_ISQUERYABLE, true);
+        // This is temporal solution to add styles to options
+        if (!layer.isInternal()) {
+            addVectorStylesToOptions(layer.getId(), layerJson);
+        }
         return layerJson;
     }
 }

--- a/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleMapper.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleMapper.java
@@ -54,4 +54,7 @@ public interface VectorStyleMapper {
             + " RETURNING id")
     @Options(flushCache = Options.FlushCachePolicy.TRUE)
     long updateStyle(final VectorStyle style);
+
+    @Select("SELECT creator FROM oskari_maplayer_style WHERE id = #{id}")
+    long getUserId(@Param("id") long id);
 }

--- a/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleService.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleService.java
@@ -1,6 +1,8 @@
 package fi.nls.oskari.map.style;
 
 import java.util.List;
+
+import fi.nls.oskari.domain.User;
 import fi.nls.oskari.domain.map.style.VectorStyle;
 import fi.nls.oskari.service.OskariComponent;
 
@@ -9,6 +11,7 @@ public abstract class VectorStyleService extends OskariComponent  {
     public abstract VectorStyle getStyleById(final long id);
     public abstract List<VectorStyle> getStylesByUser (final long user);
     public abstract List<VectorStyle> getStyles (final long userId, final int layerId);
+    public abstract boolean hasPermissionToUpdate(final long id, final User user);
     public abstract long deleteStyle(final long id);
     public abstract long saveStyle(final VectorStyle style);
     public abstract long updateStyle(final VectorStyle style);

--- a/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleServiceMybatisImpl.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleServiceMybatisImpl.java
@@ -2,6 +2,7 @@ package fi.nls.oskari.map.style;
 
 import fi.nls.oskari.annotation.Oskari;
 import fi.nls.oskari.db.DatasourceHelper;
+import fi.nls.oskari.domain.User;
 import fi.nls.oskari.domain.map.style.VectorStyle;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
@@ -77,6 +78,15 @@ public class VectorStyleServiceMybatisImpl extends VectorStyleService {
             return mapper.getStyles(userId, layerId);
         } catch (Exception e) {
             throw new ServiceRuntimeException("Failed to get vector styles for layer: " + layerId, e);
+        }
+    }
+    public boolean hasPermissionToUpdate(final long id, final User user) {
+        try (final SqlSession session = factory.openSession()) {
+            final VectorStyleMapper mapper = session.getMapper(VectorStyleMapper.class);
+            long userId = mapper.getUserId(id);
+            return user.getId() == userId;
+        } catch (Exception e) {
+            throw new ServiceRuntimeException("Failed to delete vector style: " + id, e);
         }
     }
     public long deleteStyle(final long id) {

--- a/service-map/src/test/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERLAYERTest.java
+++ b/service-map/src/test/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERLAYERTest.java
@@ -40,6 +40,7 @@ public class LayerJSONFormatterUSERLAYERTest {
     @Test
     public void parseFields() throws JSONException {
         OskariLayer baseLayer = new OskariLayer();
+        baseLayer.setInternal(true);
         baseLayer.getAttributes().put("namespaceURL", NAMESPACE);
         UserLayer ulayer = new UserLayer();
         ulayer.setFields(new JSONArray(FIELDS));
@@ -71,6 +72,7 @@ public class LayerJSONFormatterUSERLAYERTest {
     @Test
     public void parseAttributes() throws JSONException {
         OskariLayer baseLayer = new OskariLayer();
+        baseLayer.setInternal(true);
         baseLayer.getAttributes().put("namespaceURL", NAMESPACE);
         UserLayer ulayer = new UserLayer();
         JSONArray fields = new JSONArray(FIELDS);


### PR DESCRIPTION
Recently had too much JS or at least too less Java to compare long == Long. Added permission check function. Update doesn't modify layerId so no need to check that.

Add VectorStyles to layer options to check that everything is working properly after migration. Note that user own layers (analysis, categories and user_layer) have styles still inside options.

Not sure how json date string should be parsed to OffsetDateTime. Reverted Announcement change and ignored setters from VectorStyle as we don't need them from json. With ISO_INSTANT -> DateTimeException: Unable to obtain ZoneOffset from TemporalAccessor. Another solution would formatting and parsing with own formatters.

Note:
Forget to modify appsetups before re-running migrations locally. So not sure if Map key Long -> String works properly and updates style names/ids.
