### PR TITLE
Handle metadata search where free text query is not given

### DIFF
--- a/service-csw/src/main/java/fi/nls/oskari/search/channel/MetadataCatalogueChannelSearchService.java
+++ b/service-csw/src/main/java/fi/nls/oskari/search/channel/MetadataCatalogueChannelSearchService.java
@@ -20,8 +20,6 @@ import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.map.geometry.GeometryHelper;
 import fi.nls.oskari.map.geometry.WKTHelper;
-import fi.nls.oskari.map.layer.OskariLayerService;
-import fi.nls.oskari.service.OskariComponentManager;
 import fi.nls.oskari.util.IOHelper;
 import fi.nls.oskari.util.PropertyUtil;
 import org.oskari.xml.XmlHelper;
@@ -69,8 +67,6 @@ public class MetadataCatalogueChannelSearchService extends SearchChannel {
 
     private MetadataCatalogueResultParser RESULT_PARSER = null;
     private final MetadataCatalogueQueryHelper QUERY_HELPER = new MetadataCatalogueQueryHelper();
-
-    private OskariLayerService mapLayerService = OskariComponentManager.getComponentOfType(OskariLayerService.class);
 
     @Override
     public void init() {

--- a/service-csw/src/main/java/fi/nls/oskari/search/channel/MetadataCatalogueQueryHelper.java
+++ b/service-csw/src/main/java/fi/nls/oskari/search/channel/MetadataCatalogueQueryHelper.java
@@ -77,7 +77,10 @@ public class MetadataCatalogueQueryHelper {
         }
         List<Filter> queryFilters = new ArrayList<>();
         for (String field: queryFields) {
-            queryFilters.add(createLikeFilter(searchCriteria.getSearchString(), field));
+            Filter query = createLikeFilter(searchCriteria.getSearchString(), field);
+            if (query != null) {
+                queryFilters.add(query);
+            }
         }
         if (queryFilters.size() == 1) {
             list.add(queryFilters.get(0));


### PR DESCRIPTION
Having no query resulted in a null being added to the filter list which resulted in a single filter being wrapped in a `<ogc:And>` tag when querying the CSW service.