### PR TITLE
Initial styles for vector layers

### DIFF
--- a/content-resources/src/main/java/org/oskari/helpers/LayerHelper.java
+++ b/content-resources/src/main/java/org/oskari/helpers/LayerHelper.java
@@ -2,11 +2,14 @@ package org.oskari.helpers;
 
 import fi.nls.oskari.domain.map.MaplayerGroup;
 import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.domain.map.style.VectorStyle;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.map.layer.OskariLayerService;
 import fi.nls.oskari.map.layer.OskariLayerServiceMybatisImpl;
 import fi.nls.oskari.map.layer.formatters.LayerJSONFormatter;
+import fi.nls.oskari.map.style.VectorStyleHelper;
+import fi.nls.oskari.map.style.VectorStyleService;
 import fi.nls.oskari.service.OskariComponentManager;
 import fi.nls.oskari.service.ServiceException;
 import fi.nls.oskari.util.IOHelper;
@@ -59,11 +62,23 @@ public class LayerHelper {
                                 "might work slower than normal with capabilities/tilegrids not cached. Try caching the capabilities later using the admin UI.");
                     }
                 }
-
             }
             // insert to db
             int id = layerService.insert(oskariLayer);
             MapLayerPermissionsHelper.setLayerPermissions(id, layer.getRole_permissions());
+
+            // insert styles if available
+            List<VectorStyle> styles = layer.getVectorStyles();
+            if (VectorStyleHelper.isVectorLayer(oskariLayer) && styles != null && !styles.isEmpty()) {
+                VectorStyleService vss = OskariComponentManager.getComponentOfType(VectorStyleService.class);
+                styles.forEach(style -> {
+                    style.setLayerId(id);
+                    vss.saveAdminStyle(style);
+                });
+                // update default style for layer
+                oskariLayer.setStyle("" + styles.get(0).getId());
+                layerService.update(oskariLayer);
+            }
 
             if (layer.getGroups() != null) {
                 List<MaplayerGroup> groups = MapLayerGroupsHelper.findGroupsForNames_dangerzone_(layer.getGroups());

--- a/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleMapper.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleMapper.java
@@ -41,18 +41,16 @@ public interface VectorStyleMapper {
 
     @Select("INSERT INTO oskari_maplayer_style"
             + " (layer_id, type, creator, name, style) VALUES"
-            + " (#{layerId}, #{type}, #{creator}, #{name}, #{style})"
-            + " RETURNING id")
+            + " (#{layerId}, #{type}, #{creator}, #{name}, #{style})")
     @Options(flushCache = Options.FlushCachePolicy.TRUE)
-    long saveStyle(final VectorStyle style);
+    void saveStyle(final VectorStyle style);
 
     @Select("UPDATE oskari_maplayer_style"
             + " SET updated = #{updated},"
             + " name = #{name}, style = #{style}"
-            + " WHERE id = #{id}"
-            + " RETURNING id")
+            + " WHERE id = #{id}")
     @Options(flushCache = Options.FlushCachePolicy.TRUE)
-    long updateStyle(final VectorStyle style);
+    void updateStyle(final VectorStyle style);
 
     @Select("SELECT creator FROM oskari_maplayer_style WHERE id = #{id}")
     long getUserId(@Param("id") long id);

--- a/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleMapper.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleMapper.java
@@ -39,17 +39,17 @@ public interface VectorStyleMapper {
     @Delete("DELETE FROM oskari_maplayer_style WHERE id = #{id}")
     void deleteStyle(long id);
 
-    @Select("INSERT INTO oskari_maplayer_style"
+    @Insert("INSERT INTO oskari_maplayer_style"
             + " (layer_id, type, creator, name, style) VALUES"
             + " (#{layerId}, #{type}, #{creator}, #{name}, #{style})")
-    @Options(flushCache = Options.FlushCachePolicy.TRUE)
+    @Options(useGeneratedKeys = true, keyProperty = "id", flushCache = Options.FlushCachePolicy.TRUE)
     void saveStyle(final VectorStyle style);
 
-    @Select("UPDATE oskari_maplayer_style"
+    @Update("UPDATE oskari_maplayer_style"
             + " SET updated = #{updated},"
             + " name = #{name}, style = #{style}"
             + " WHERE id = #{id}")
-    @Options(flushCache = Options.FlushCachePolicy.TRUE)
+    @Options(useGeneratedKeys = true, keyProperty = "id", flushCache = Options.FlushCachePolicy.TRUE)
     void updateStyle(final VectorStyle style);
 
     @Select("SELECT creator FROM oskari_maplayer_style WHERE id = #{id}")

--- a/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleServiceMybatisImpl.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleServiceMybatisImpl.java
@@ -105,7 +105,8 @@ public class VectorStyleServiceMybatisImpl extends VectorStyleService {
                 throw new IllegalArgumentException("Tried to add vector style without layerId");
             }
             final VectorStyleMapper mapper = session.getMapper(VectorStyleMapper.class);
-            return mapper.saveStyle(style);
+            mapper.saveStyle(style);
+            return style.getId();
         } catch (Exception e) {
             throw new ServiceRuntimeException("Failed to save vector style", e);
         }
@@ -113,7 +114,8 @@ public class VectorStyleServiceMybatisImpl extends VectorStyleService {
     public long updateStyle(final VectorStyle style) {
         try (final SqlSession session = factory.openSession()) {
             final VectorStyleMapper mapper = session.getMapper(VectorStyleMapper.class);
-            return mapper.updateStyle(style);
+            mapper.updateStyle(style);
+            return style.getId();
         } catch (Exception e) {
             throw new ServiceRuntimeException("Failed to update vector style", e);
         }
@@ -150,7 +152,8 @@ public class VectorStyleServiceMybatisImpl extends VectorStyleService {
                 style.setCreator(null);
             }
             final VectorStyleMapper mapper = session.getMapper(VectorStyleMapper.class);
-            return mapper.saveStyle(style);
+            mapper.saveStyle(style);
+            return style.getId();
         } catch (Exception e) {
             throw new ServiceRuntimeException("Failed to save vector style", e);
         }
@@ -162,7 +165,8 @@ public class VectorStyleServiceMybatisImpl extends VectorStyleService {
                 style.setCreator(null);
             }
             final VectorStyleMapper mapper = session.getMapper(VectorStyleMapper.class);
-            return mapper.updateStyle(style);
+            mapper.updateStyle(style);
+            return style.getId();
         } catch (Exception e) {
             throw new ServiceRuntimeException("Failed to update vector style", e);
         }

--- a/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleServiceMybatisImpl.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/style/VectorStyleServiceMybatisImpl.java
@@ -106,6 +106,7 @@ public class VectorStyleServiceMybatisImpl extends VectorStyleService {
             }
             final VectorStyleMapper mapper = session.getMapper(VectorStyleMapper.class);
             mapper.saveStyle(style);
+            session.commit();
             return style.getId();
         } catch (Exception e) {
             throw new ServiceRuntimeException("Failed to save vector style", e);
@@ -115,6 +116,7 @@ public class VectorStyleServiceMybatisImpl extends VectorStyleService {
         try (final SqlSession session = factory.openSession()) {
             final VectorStyleMapper mapper = session.getMapper(VectorStyleMapper.class);
             mapper.updateStyle(style);
+            session.commit();
             return style.getId();
         } catch (Exception e) {
             throw new ServiceRuntimeException("Failed to update vector style", e);
@@ -153,6 +155,7 @@ public class VectorStyleServiceMybatisImpl extends VectorStyleService {
             }
             final VectorStyleMapper mapper = session.getMapper(VectorStyleMapper.class);
             mapper.saveStyle(style);
+            session.commit();
             return style.getId();
         } catch (Exception e) {
             throw new ServiceRuntimeException("Failed to save vector style", e);
@@ -166,6 +169,7 @@ public class VectorStyleServiceMybatisImpl extends VectorStyleService {
             }
             final VectorStyleMapper mapper = session.getMapper(VectorStyleMapper.class);
             mapper.updateStyle(style);
+            session.commit();
             return style.getId();
         } catch (Exception e) {
             throw new ServiceRuntimeException("Failed to update vector style", e);


### PR DESCRIPTION
The styles are no longer stored in `options` column on `oskari_maplayer` database table. Instead they are stored to a new `oskari_maplayer_style` so some changes needed to be made for vector layer styles saving when using FlywayDB migrations. This makes it possible to fix an issue where the style is missing completely from the default map layer on the sample application. Another PR is coming shortly for sample-server-extension to fix the content to match this change on our sample application.