### PR TITLE
Attach list of system roles for admin UI so we can disable some settings

### DIFF
--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/ManageRolesHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/ManageRolesHandler.java
@@ -107,7 +107,13 @@ public class ManageRolesHandler extends RestActionHandler {
 
         final JSONObject response = new JSONObject();
         JSONHelper.put(response, "rolelist", roleValues);
-        
+
+        final JSONArray systemRoles = new JSONArray();
+        systemRoles.put(JSONHelper.createJSONObject("anonymous", "Guest"));
+        systemRoles.put(JSONHelper.createJSONObject("user", Role.getDefaultUserRole().getName()));
+        systemRoles.put(JSONHelper.createJSONObject("admin", Role.getAdminRole().getName()));
+        JSONHelper.put(response, "systemRoles", systemRoles);
+
         return response;
     }
     


### PR DESCRIPTION
With current admin UI it's easy to break something if the admin renames a role that is used for all logged in users or admin. This allows the UI to disable or confirm edits on these as editing them means that the server config (oskari-ext.properties) will need to be changed as well and the server restarted.