### PR TITLE
Handle 404 errors more consistently

### DIFF
--- a/service-map/src/main/java/fi/nls/oskari/map/view/AppSetupServiceMybatisImpl.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/view/AppSetupServiceMybatisImpl.java
@@ -174,7 +174,9 @@ public class AppSetupServiceMybatisImpl extends ViewService {
         try (final SqlSession session = factory.openSession()) {
             final AppSetupMapper mapper = session.getMapper(AppSetupMapper.class);
             View view = mapper.getViewWithConfByUuId(uuId);
-            view.setBundles(mapper.getBundlesByViewId(view.getId()));
+            if (view != null) {
+                view.setBundles(mapper.getBundlesByViewId(view.getId()));
+            }
             return view;
         } catch (Exception e) {
             LOG.warn(e, "Exception while getting view with config by uuid: " + uuId);

--- a/servlet-map/src/main/java/fi/nls/oskari/MapController.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/MapController.java
@@ -66,7 +66,7 @@ public class MapController {
 
     @RequestMapping("/")
     public String getMap(Model model, @OskariParam ActionParameters params) {
-        if(paramHandlers.isEmpty()) {
+        if (paramHandlers.isEmpty()) {
             // check control params to pass for getappsetup
             // setup on first call to allow more flexibility regarding timing issues
             paramHandlers.addAll(ParamControl.getHandlerKeys());
@@ -77,7 +77,7 @@ public class MapController {
 
         // JSP
         final String viewJSP = setupRenderParameters(params, model);
-        if(viewJSP == null) {
+        if (viewJSP == null) {
             // view not found
             log.debug("View not found, going to error/404");
             params.getResponse().setStatus(HttpServletResponse.SC_NOT_FOUND);
@@ -243,6 +243,9 @@ public class MapController {
 
         log.debug("Using id to fetch a view:", viewId);
         View view = viewService.getViewWithConf(viewId);
+        if (view == null) {
+            return null;
+        }
         if(!isDefault && view.isOnlyForUuId()) {
             log.warn("View can only be loaded by uuid. ViewId:", viewId);
             return null;

--- a/servlet-map/src/main/java/fi/nls/oskari/spring/GlobalExceptionHandlerController.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/spring/GlobalExceptionHandlerController.java
@@ -1,12 +1,24 @@
 package fi.nls.oskari.spring;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
-public class GlobalExceptionHandlerController {
+import javax.servlet.http.HttpServletResponse;
 
+@Controller
+public class GlobalExceptionHandlerController {
+    /**
+     * Catch all that didn't match
+     * */
+    @GetMapping("/**")
+    public String handle(HttpServletResponse resp) {
+        resp.setStatus(HttpServletResponse.SC_NOT_FOUND);
+        return "error/404";
+    }
     @ExceptionHandler(NoHandlerFoundException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public String handle(NoHandlerFoundException ex) {

--- a/servlet-map/src/main/java/fi/nls/oskari/spring/GlobalExceptionHandlerController.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/spring/GlobalExceptionHandlerController.java
@@ -1,0 +1,15 @@
+package fi.nls.oskari.spring;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+public class GlobalExceptionHandlerController {
+
+    @ExceptionHandler(NoHandlerFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public String handle(NoHandlerFoundException ex) {
+        return "error/404";
+    }
+}

--- a/servlet-map/src/main/java/fi/nls/oskari/spring/SpringInitializer.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/spring/SpringInitializer.java
@@ -35,6 +35,7 @@ public class SpringInitializer extends AbstractHttpSessionApplicationInitializer
         dispatcher.setLoadOnStartup(1);
         dispatcher.addMapping("/");
         dispatcher.setAsyncSupported(true);
+        dispatcher.setInitParameter("throwExceptionIfNoHandlerFound", "true");
         if (isRedisSessionActived(context)) {
             // only start handling sessions if redis is used to store them.
             // Otherwise just use session tracking provided by the servlet container (Jetty/Tomcat)


### PR DESCRIPTION
With these changes the MapController detects private appsetups directly and returns the 404 page for these in the same way when requesting an appsetup that doesn't exist:
![image](https://github.com/oskariorg/oskari-server/assets/2210335/85bf02df-7aad-4c92-933c-6f5295ee683a)

This page is now also used for global NOT FOUND handling.

The page can be overridden on Oskari instances like other JSP-pages.

------------
Previously/currently when a published map has been changed from "public" to "private", users accessing the map got this page:

![image](https://github.com/oskariorg/oskari-server/assets/2210335/60d65e7c-01d1-4a2e-a005-0e095bda7566)

The controller selecting the base JSP didn't check for the public access and started opening the frontend part as usual. However the GetAppSetup controller DOES check for public/private and threw 403 forbidden on these changes which resulted in the page above.

Also previously the server responded to funky/non-functioning urls with an error page from the servlet container (with this change the same 404 is used for these as well):
![image](https://github.com/oskariorg/oskari-server/assets/2210335/f67123b1-d0ba-4b1b-84e5-2348a5e62d99)

