### PR TITLE
Disable telephone number autoformatting

### DIFF
--- a/servlet-map/src/main/resources/META-INF/resources/spring-map-jsp/index.jsp
+++ b/servlet-map/src/main/resources/META-INF/resources/spring-map-jsp/index.jsp
@@ -7,6 +7,7 @@
 <head>
     <title>Oskari - ${viewName}</title>
     <link rel="shortcut icon" href="${clientDomain}/Oskari${path}/logo.png" type="image/png" />
+    <meta name="format-detection" content="telephone=no" />
 
     <!-- ############# css ################# -->
     <link

--- a/servlet-map/src/main/resources/META-INF/resources/spring-map-jsp/published.jsp
+++ b/servlet-map/src/main/resources/META-INF/resources/spring-map-jsp/published.jsp
@@ -5,6 +5,7 @@
     <title>${viewName}</title>
     <link rel="shortcut icon" href="${clientDomain}/Oskari${path}/logo.png" type="image/png" />
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
+    <meta name="format-detection" content="telephone=no" />
 
     <!-- ############# css ################# -->
     <link


### PR DESCRIPTION
Since usually the feature properties are not phone numbers, but might be accidentally formatted as such on mobile devices.