### PR TITLE
Add vectorlayer properties to DescribeLayer

### DIFF
--- a/control-base/src/main/java/org/oskari/control/layer/DescribeLayerHandler.java
+++ b/control-base/src/main/java/org/oskari/control/layer/DescribeLayerHandler.java
@@ -36,6 +36,7 @@ import java.util.Map;
 
 import static fi.nls.oskari.control.ActionConstants.PARAM_ID;
 import static fi.nls.oskari.control.ActionConstants.PARAM_SRS;
+import static fi.nls.oskari.domain.map.OskariLayer.TYPE_WFS;
 
 /**
  * An action route that returns metadata for layers
@@ -110,6 +111,9 @@ public class DescribeLayerHandler extends RestActionHandler {
     }
 
     private List<FeatureProperties> getProperties(OskariLayer layer, String lang) {
+        if (!OskariLayer.TYPE_WFS.equals(layer.getType())) {
+            return null;
+        }
         LayerCapabilitiesWFS caps = CapabilitiesService.fromJSON(layer.getCapabilities().toString(), layer.getType());
         List<FeatureProperties> props = new ArrayList<>();
 

--- a/control-base/src/main/java/org/oskari/control/layer/DescribeLayerHandler.java
+++ b/control-base/src/main/java/org/oskari/control/layer/DescribeLayerHandler.java
@@ -18,14 +18,18 @@ import fi.nls.oskari.service.ServiceRuntimeException;
 import fi.nls.oskari.util.ConversionHelper;
 import fi.nls.oskari.util.JSONHelper;
 import fi.nls.oskari.util.ResponseHelper;
+import fi.nls.oskari.util.WFSConversionHelper;
 import org.json.JSONObject;
 import org.oskari.capabilities.CapabilitiesService;
+import org.oskari.capabilities.ogc.LayerCapabilitiesWFS;
 import org.oskari.capabilities.ogc.LayerCapabilitiesWMTS;
 import org.oskari.capabilities.ogc.wmts.TileMatrixLink;
+import org.oskari.control.layer.model.FeatureProperties;
 import org.oskari.control.layer.model.LayerExtendedOutput;
 import org.oskari.control.layer.model.LayerOutput;
 import org.oskari.permissions.PermissionService;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -97,11 +101,50 @@ public class DescribeLayerHandler extends RestActionHandler {
         }
         if (VectorStyleHelper.isVectorLayer(layer)) {
             output.styles = getVectorStyles(params, layerId);
+            output.properties = getProperties(layer, lang);
         }
         if (OskariLayer.TYPE_WMTS.equals(layer.getType())) {
             output.capabilities = getCapabilitiesJSON(layer, crs);
         }
         return output;
+    }
+
+    private List<FeatureProperties> getProperties(OskariLayer layer, String lang) {
+        LayerCapabilitiesWFS caps = CapabilitiesService.fromJSON(layer.getCapabilities().toString(), layer.getType());
+        List<FeatureProperties> props = new ArrayList<>();
+
+        JSONObject locale = getPropertiesLocale(layer);
+        caps.getFeatureProperties().stream().forEach(prop -> {
+            FeatureProperties p = new FeatureProperties();
+            p.name = prop.name;
+            p.type = WFSConversionHelper.getSimpleType(prop.type);
+            p.rawType = prop.type;
+            p.label = getLabelForProperty(locale, prop.name, lang);
+            props.add(p);
+        });
+        return props;
+    }
+    private JSONObject getPropertiesLocale(OskariLayer layer) {
+        JSONObject attrs = layer.getAttributes();
+        if (attrs == null) {
+            return null;
+        }
+        JSONObject data = attrs.optJSONObject("data");
+        if (data == null) {
+            return null;
+        }
+        return data.optJSONObject("locale");
+    }
+
+    private String getLabelForProperty(JSONObject locale, String prop, String lang) {
+        if (locale == null) {
+            return null;
+        }
+        JSONObject labelsForLang = locale.optJSONObject(lang);
+        if (labelsForLang == null) {
+            return null;
+        }
+        return labelsForLang.optString(prop, null);
     }
 
     private List<VectorStyle> getVectorStyles (ActionParameters params, int layerId) {

--- a/control-base/src/main/java/org/oskari/control/layer/model/FeatureProperties.java
+++ b/control-base/src/main/java/org/oskari/control/layer/model/FeatureProperties.java
@@ -1,0 +1,8 @@
+package org.oskari.control.layer.model;
+
+public class FeatureProperties {
+    public String name;
+    public String type;
+    public String rawType;
+    public String label;
+}

--- a/control-base/src/main/java/org/oskari/control/layer/model/LayerExtendedOutput.java
+++ b/control-base/src/main/java/org/oskari/control/layer/model/LayerExtendedOutput.java
@@ -10,4 +10,6 @@ public class LayerExtendedOutput extends LayerOutput {
     public String coverage;
     public List<VectorStyle> styles;
     public Map<String, Object> capabilities;
+
+    public List<FeatureProperties> properties;
 }


### PR DESCRIPTION
Initial version for adding wfs-layer properties to DescribeLayer response:
```
{
... ,
properties: [
  {
    "name": "vuosi",
    "type": "number",
    "rawType": "int",
    "label": null
  },
  {
    "name": "avi",
    "type": "string",
    "rawType": "string",
    "label": null
  },
  {
    "name": "nimi",
    "type": "string",
    "rawType": "string",
    "label": null
  },
  {
    "name": "namn",
    "type": "string",
    "rawType": "string",
    "label": null
  },
  {
    "name": "name",
    "type": "string",
    "rawType": "string",
    "label": null
  },
  {
    "name": "the_geom",
    "type": "geometry",
    "rawType": "GeometryPropertyType",
    "label": null
  }
]
}
```
Label would come from layer attributes based on current locale. This could be used to get rid of the additional `GetWFSLayerFields` route: https://github.com/oskariorg/oskari-server/blob/2.10.1/control-base/src/main/java/fi/nls/oskari/control/layer/GetWFSLayerFieldsHandler.java

Maybe we should process the layer attributes.filter config as well to remove some properties from this list based on those filtered properties.