### PR TITLE
Attach capabilities update cron line for admin

### DIFF
--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerAdminMetadataHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerAdminMetadataHandler.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.oskari.capabilities.UpdateCapabilitiesJob;
 import org.oskari.maplayer.admin.LayerValidator;
 import org.oskari.permissions.PermissionService;
 import org.oskari.permissions.model.PermissionType;
@@ -36,6 +37,8 @@ public class LayerAdminMetadataHandler extends RestActionHandler {
     private final static String JSKEY_ID = "id";
     private final static String JSKEY_NAME = "name";
 
+    private String capabilitiesCron = null;
+
     @Override
     public void init() {
         try {
@@ -51,6 +54,14 @@ public class LayerAdminMetadataHandler extends RestActionHandler {
         }
     }
 
+    private String getCapabilitiesUpdateCron() {
+        if (capabilitiesCron == null) {
+            // "oskari.scheduler.job.UpdateCapabilitiesJob.cronLine" in oskari-ext.properties or default from class
+            capabilitiesCron = new UpdateCapabilitiesJob().getCronLine();
+        }
+        return capabilitiesCron;
+    }
+
     @Override
     public void preProcess(ActionParameters params) throws ActionException {
         params.requireAdminUser();
@@ -63,6 +74,7 @@ public class LayerAdminMetadataHandler extends RestActionHandler {
             JSONHelper.putValue(root, "roles", getRoles());
             JSONHelper.putValue(root, "permissionTypes", getPermissionTypes(params.getLocale().getLanguage()));
             JSONHelper.putValue(root, "layerTypes", getMandatoryFields());
+            JSONHelper.putValue(root, "capabilitiesCron", getCapabilitiesUpdateCron());
             ResponseHelper.writeResponse(params, root);
         } catch (Exception e) {
             throw new ActionException("Something went wrong getting roles and permission types from the platform", e);

--- a/control-admin/src/test/java/fi/nls/oskari/control/admin/LayerAdminMetadataHandlerTest.java
+++ b/control-admin/src/test/java/fi/nls/oskari/control/admin/LayerAdminMetadataHandlerTest.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 
 import fi.nls.oskari.service.DummyUserService;
 import fi.nls.oskari.util.PropertyUtil;
+import fi.nls.test.util.TestHelper;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -26,6 +27,8 @@ import fi.nls.oskari.service.UserService;
 import fi.nls.test.control.JSONActionRouteTest;
 import fi.nls.test.util.ResourceHelper;
 
+import javax.sql.DataSource;
+
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({OskariComponentManager.class})
 public class LayerAdminMetadataHandlerTest extends JSONActionRouteTest {
@@ -36,11 +39,13 @@ public class LayerAdminMetadataHandlerTest extends JSONActionRouteTest {
     public static void setup() throws Exception {
         PropertyUtil.addProperty("oskari.user.service", DummyUserService.class.getCanonicalName(), true);
         setupPermissionsServiceMock();
+        TestHelper.registerTestDataSource();
         handler.init();
     }
     @AfterClass
     public static void tearDown() {
         PropertyUtil.clearProperties();
+        TestHelper.teardown();
     }
 
     private static void setupPermissionsServiceMock() {

--- a/control-admin/src/test/resources/fi/nls/oskari/control/admin/LayerAdminMetadataHandlerTests-expected.json
+++ b/control-admin/src/test/resources/fi/nls/oskari/control/admin/LayerAdminMetadataHandlerTests-expected.json
@@ -1,4 +1,5 @@
 {
+  "capabilitiesCron": "0 0 0 * * ?",
   "layerTypes": {
     "wmtslayer": [
       "name",


### PR DESCRIPTION
So we can help the user (=admin) configuring capabilities update for a layer in a sensical way.