### PR TITLE
Don't treat char encoding issues as blockers for capabilities parsing

### DIFF
--- a/service-capabilities/src/main/java/org/oskari/capabilities/ogc/CapabilitiesValidator.java
+++ b/service-capabilities/src/main/java/org/oskari/capabilities/ogc/CapabilitiesValidator.java
@@ -27,8 +27,11 @@ public class CapabilitiesValidator {
             String xmlEncoding = xsr.getCharacterEncodingScheme();
             if (xmlEncoding != null) {
                 if (encoding != null && !xmlEncoding.equalsIgnoreCase(encoding)) {
-                    throw new ServiceException("Content-Type header specified a different encoding than XML prolog!");
+                    // this is not critical, but any special characters are probably going to be rendered wrong
+                    LOG.warn("Capabilities documents Content-Type header specified a different encoding (",
+                            encoding, ") than XML prolog (", xmlEncoding, ")!");
                 }
+                // favor xml encoding
                 encoding = xmlEncoding;
             }
             if (encoding == null) {


### PR DESCRIPTION
Having http header:
```
Content-Type: application/xml;charset=ISO-8859-1
```
And XML-content:
```
<?xml version="1.0" encoding="UTF-8"?> 
```

Isn't really that big of a deal to halt capabilities parsing.