### PR TITLE
Remove OpenStreetMap and What3Words search channels from control-example dependencies

### DIFF
--- a/MigrationGuide.md
+++ b/MigrationGuide.md
@@ -1,5 +1,20 @@
 # Migration guide
 
+## 2.11.0
+
+Remove OpenStreetMap and What3Words search channels from control-example dependencies.
+
+If you want to use these as your applications search backend you can add them in the app dependencies on pom.xml like this:
+
+```
+<dependency>
+    <groupId>org.oskari</groupId>
+    <artifactId>service-search-opendata</artifactId>
+</dependency>
+```
+
+This fixes an issue where (most) applications that have their own search backend implementations either need to black list the OSM channel OR exclude this depedency. This makes the choice of using the channel more explicit.
+
 ## 2.10.0
 
 Sample-server-extension now includes JSTL dependency by default so the web app works out-of-the-box in for example Tomcat environment:

--- a/control-example/pom.xml
+++ b/control-example/pom.xml
@@ -18,10 +18,6 @@
             <groupId>org.oskari</groupId>
             <artifactId>control-base</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.oskari</groupId>
-            <artifactId>service-search-opendata</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
If you want to use these as your applications search backend you can add them in the app dependencies on pom.xml like this:

```
<dependency>
    <groupId>org.oskari</groupId>
    <artifactId>service-search-opendata</artifactId>
</dependency>
```

This fixes an issue where (most) applications that have their own search backend implementations either need to "blacklist" the OSM channel OR exclude this dependency. This makes the choice of including the channel more explicit as it is no longer included by default.