### PR TITLE
New routes for layer permissions bundle

### DIFF
--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/AbstractLayerAdminHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/AbstractLayerAdminHandler.java
@@ -78,7 +78,7 @@ public abstract class AbstractLayerAdminHandler extends RestActionHandler {
         }
         return roles;
     }
-    private Set<String> getAvailablePermissions() {
+    protected Set<String> getAvailablePermissions() {
         if (availablePermissionTypes != null) {
             return availablePermissionTypes;
         }

--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/GetAllRolesHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/GetAllRolesHandler.java
@@ -15,9 +15,11 @@ import org.json.JSONObject;
 
 /**
  * Route returning all roles in the system.
+ * @deprecated Use ManageRoles instead
  * @author SMAKINEN
  */
 @OskariActionRoute("GetAllRoles")
+@Deprecated
 public class GetAllRolesHandler extends RestActionHandler {
 
     private Logger log = LogFactory.getLogger(GetAllRolesHandler.class);

--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerPermissionHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerPermissionHandler.java
@@ -1,0 +1,116 @@
+package fi.nls.oskari.control.admin;
+
+import fi.nls.oskari.annotation.OskariActionRoute;
+import fi.nls.oskari.control.ActionException;
+import fi.nls.oskari.control.ActionParameters;
+import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.map.layer.OskariLayerService;
+import fi.nls.oskari.service.OskariComponentManager;
+import fi.nls.oskari.util.JSONHelper;
+import fi.nls.oskari.util.PropertyUtil;
+import fi.nls.oskari.util.ResponseHelper;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.oskari.permissions.PermissionService;
+import org.oskari.permissions.model.*;
+
+import java.util.*;
+
+import static fi.nls.oskari.control.ActionConstants.*;
+
+/**
+ * Configuring additional permission types in oskari-ext.properties
+ * <p>
+ * permission.types = EDIT_LAYER_CONTENT
+ * permission.EDIT_LAYER_CONTENT.name.fi=Muokkaa tasoa
+ * permission.EDIT_LAYER_CONTENT.name.en=Edit layer
+ */
+@OskariActionRoute("LayerPermission")
+public class LayerPermissionHandler extends AbstractLayerAdminHandler {
+
+    private OskariLayerService mapLayerService;
+    private PermissionService permissionsService;
+    private Set<String> availablePermissionTypes;
+
+    private static final String KEY_NAMES = "names";
+    private static final String KEY_LAYERS = "layers";
+    private static final String KEY_PERMISSION = "permission";
+
+    @Override
+    public void init() {
+        super.init();
+        mapLayerService = OskariComponentManager.getComponentOfType(OskariLayerService.class);
+        permissionsService = OskariComponentManager.getComponentOfType(PermissionService.class);
+        // Just so we don't need to do this on the first request
+        availablePermissionTypes = getAvailablePermissions();
+    }
+
+    public void preProcess(ActionParameters params) throws ActionException {
+        // require admin user
+        params.requireAdminUser();
+    }
+
+    /**
+     * Returns permissions for all layers for the given role
+     *
+     * @param params
+     * @throws ActionException
+     */
+    @Override
+    public void handleGet(ActionParameters params) throws ActionException {
+        int roleId = params.getRequiredParamInt(PARAM_ID);
+        String lang = params.getLocale().getLanguage();
+
+        final JSONObject root = new JSONObject();
+        JSONHelper.putValue(root, KEY_NAMES, getPermissionNames(lang));
+        JSONArray layerPermission = new JSONArray();
+        JSONHelper.putValue(root, KEY_LAYERS, layerPermission);
+
+        final List<OskariLayer> layers = mapLayerService.findAll();
+        Collections.sort(layers);
+
+        List<Resource> resources = permissionsService.findResourcesByType(ResourceType.maplayer);
+        PermissionSet permissions = new PermissionSet(resources);
+        for (OskariLayer layer : layers) {
+            if (layer.isInternal()) {
+                // skip internal layers
+                continue;
+            }
+            try {
+                JSONObject layerJSON = new JSONObject();
+                layerJSON.put(KEY_ID, layer.getId());
+                layerJSON.put(KEY_NAME, layer.getName(PropertyUtil.getDefaultLanguage()));
+                layerJSON.put(KEY_PERMISSION, getPermissionsForLayer(permissions, layer.getId(), roleId));
+            } catch (JSONException e) {
+                throw new ActionException("Something is wrong with doPermissionResourcesJson ajax reguest", e);
+            }
+        }
+
+        ResponseHelper.writeResponse(params, root.toString());
+    }
+
+    @Override
+    public void handlePost(ActionParameters params) throws ActionException {
+        // TODO: basically SaveLayerPermissionHandler, but check if the syntax still makes sense
+    }
+    
+    private JSONObject getPermissionNames(String lang) {
+        final JSONObject permissionNames = new JSONObject();
+        for (String id : availablePermissionTypes) {
+            JSONHelper.putValue(permissionNames, id, permissionsService.getPermissionName(id, lang));
+        }
+        return permissionNames;
+    }
+    private JSONObject getPermissionsForLayer(PermissionSet permissions, int layerId, int roleId) {
+        JSONObject permissionJSON = new JSONObject();
+        Optional<Resource> layerResource = permissions.get(ResourceType.maplayer, Integer.toString(layerId));
+        for (String permission : availablePermissionTypes) {
+            boolean hasPermission = layerResource
+                    .map(r -> r.hasRolePermission(roleId, permission))
+                    .orElse(false);
+            JSONHelper.putValue(permissionJSON, permission, hasPermission);
+        }
+        return permissionJSON;
+    }
+}

--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerPermissionHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerPermissionHandler.java
@@ -19,6 +19,7 @@ import org.oskari.permissions.PermissionService;
 import org.oskari.permissions.model.*;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static fi.nls.oskari.control.ActionConstants.*;
 
@@ -143,14 +144,14 @@ public class LayerPermissionHandler extends AbstractLayerAdminHandler {
         Optional<Resource> layerResource = permissions.get(ResourceType.maplayer, Integer.toString(layerId));
 
         for (Role role : getRoles()) {
-            JSONObject permissionJSON = new JSONObject();
             long roleId = role.getId();
-            JSONHelper.putValue(rolesJSON, Long.toString(roleId), permissionJSON);
-            for (String permission : availablePermissionTypes) {
-                boolean hasPermission = layerResource
-                        .map(r -> r.hasRolePermission(roleId, permission))
-                        .orElse(false);
-                JSONHelper.putValue(permissionJSON, permission, hasPermission);
+            Set<String> allowedPermissions = availablePermissionTypes.stream()
+                    .filter(perm -> layerResource
+                            .map(r -> r.hasRolePermission(roleId, perm))
+                            .orElse(false))
+                    .collect(Collectors.toSet());
+            if (!allowedPermissions.isEmpty()) {
+                JSONHelper.putValue(rolesJSON, Long.toString(roleId), allowedPermissions);
             }
         }
         return rolesJSON;

--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerPermissionHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerPermissionHandler.java
@@ -94,7 +94,7 @@ public class LayerPermissionHandler extends AbstractLayerAdminHandler {
     public void handlePost(ActionParameters params) throws ActionException {
         // TODO: basically SaveLayerPermissionHandler, but check if the syntax still makes sense
     }
-    
+
     private JSONObject getPermissionNames(String lang) {
         final JSONObject permissionNames = new JSONObject();
         for (String id : availablePermissionTypes) {

--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerPermissionHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerPermissionHandler.java
@@ -84,8 +84,8 @@ public class LayerPermissionHandler extends AbstractLayerAdminHandler {
         PermissionSet permissions = new PermissionSet(resources);
 
         for (OskariLayer layer : layers) {
-            if (layer.isInternal()) {
-                // skip internal layers
+            if (layer.isInternal() || layer.getParentId() != -1) {
+                // skip internal layers and sublayers
                 continue;
             }
             try {
@@ -93,6 +93,7 @@ public class LayerPermissionHandler extends AbstractLayerAdminHandler {
                 layerJSON.put(KEY_ID, layer.getId());
                 layerJSON.put(KEY_NAME, layer.getName(PropertyUtil.getDefaultLanguage()));
                 layerJSON.put(KEY_PERMISSION, getPermissionsForLayer(permissions, layer.getId()));
+                layerPermission.put(layerJSON);
             } catch (JSONException e) {
                 throw new ActionException("Something is wrong with doPermissionResourcesJson ajax reguest", e);
             }

--- a/control-base/src/main/java/fi/nls/oskari/control/layer/GetPermissionsLayerHandlers.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/GetPermissionsLayerHandlers.java
@@ -23,6 +23,7 @@ import static fi.nls.oskari.control.ActionConstants.KEY_ID;
 import static fi.nls.oskari.control.ActionConstants.KEY_NAME;
 
 /**
+ * @deprecated Use LayerPermissionHandler instead
  * Configuring additional permission types in oskari-ext.properties
  * <p>
  * permission.types = EDIT_LAYER_CONTENT
@@ -30,6 +31,7 @@ import static fi.nls.oskari.control.ActionConstants.KEY_NAME;
  * permission.EDIT_LAYER_CONTENT.name.en=Edit layer
  */
 @OskariActionRoute("GetPermissionsLayerHandlers")
+@Deprecated
 public class GetPermissionsLayerHandlers extends ActionHandler {
 
     private static String JSON_NAMES_SPACE = "namespace";

--- a/control-base/src/main/java/fi/nls/oskari/control/layer/SaveLayerPermissionHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/SaveLayerPermissionHandler.java
@@ -24,7 +24,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * @deprecated This will be replaced by LayerPermissionHandler
+ */
 @OskariActionRoute("SaveLayerPermission")
+@Deprecated
 public class SaveLayerPermissionHandler extends RestActionHandler {
 
     private final static Logger log = LogFactory.getLogger(SaveLayerPermissionHandler.class);


### PR DESCRIPTION
`LayerPermissionHandler` would be replacement for `GetPermissionsLayerHandlers` and `SaveLayerPermissionHandler`. Also `GetAllRolesHandler` can be removed since the newer `ManageRoles` does basically the same thing.

The response from LayerPermissionHandler for GET request would be layers and their permissions for each role (that have permissions):
```
{
    "names": {
        "VIEW_PUBLISHED": "Katseluoikeus",
        "EDIT_LAYER_CONTENT": "Muokkaa tasoa",
        "DOWNLOAD": "Latausoikeus",
        "PUBLISH": "Julkaisuoikeus",
        "VIEW_LAYER": "Listausoikeus"
    },
    "layers": [{
            "id": 234,
            "name": "Layer name 1",
            "permissions": {
                "12": [
                    "VIEW_PUBLISHED",
                    "DOWNLOAD",
                    "VIEW_LAYER"
                ],
                "43": [
                    "VIEW_PUBLISHED",
                    "DOWNLOAD",
                    "VIEW_LAYER"
                ],
                "23": [
                    "VIEW_PUBLISHED",
                    "DOWNLOAD",
                    "PUBLISH",
                    "VIEW_LAYER"
                ]
            }
        },
        {
            "id": 76,
            "name": "Layer name 35",
            "permissions": {
                "12": [
                    "VIEW_PUBLISHED",
                    "DOWNLOAD",
                    "VIEW_LAYER"
                ],
                "43": [
                    "VIEW_PUBLISHED",
                    "DOWNLOAD",
                    "PUBLISH",
                    "VIEW_LAYER"
                ],
                "23": [
                    "VIEW_PUBLISHED",
                    "DOWNLOAD",
                    "PUBLISH",
                    "VIEW_LAYER"
                ]
            }
    }]
}
```
Where "12", "43" and "23" are role ids corresponding to roles like "Guest" or "User" or "Admin" and the array lists permissions that the role has.

Sending id-parameter with a layer id can be used to get permissions for single layer.