### PR TITLE
Describe layer wfs

### DIFF
--- a/control-base/src/main/java/org/oskari/control/layer/DescribeLayerHandler.java
+++ b/control-base/src/main/java/org/oskari/control/layer/DescribeLayerHandler.java
@@ -164,13 +164,14 @@ public class DescribeLayerHandler extends RestActionHandler {
         data.put(WFSLayerAttributes.KEY_COMMON_ID, attr.getCommonId());
         data.put(WFSLayerAttributes.KEY_ID_PROPERTY, attrData.optString(WFSLayerAttributes.KEY_ID_PROPERTY, null));
 
-        String geometryType = attrData.optString(WFSLayerAttributes.KEY_GEOMETRY_TYPE, null);
-        if (geometryType == null) {
+        // TODO: should admin store geometryType => styleType
+        String styleType = attrData.optString(WFSLayerAttributes.KEY_GEOMETRY_TYPE, null);
+        if (styleType == null) {
             String geomName = caps.getGeometryField();
             FeaturePropertyType fpt = caps.getFeatureProperty(geomName);
-            geometryType = WFSConversionHelper.getStyleType(fpt.type);
+            styleType = WFSConversionHelper.getStyleType(fpt.type);
         }
-        data.put(WFSLayerAttributes.KEY_GEOMETRY_TYPE, geometryType);
+        data.put(WFSLayerAttributes.KEY_STYLE_TYPE, styleType);
 
         data.put(WFSLayerOptions.KEY_RENDER_MODE, opts.getRenderMode());
         data.put(WFSLayerOptions.KEY_CLUSTER, opts.getClusteringDistance());

--- a/control-base/src/main/java/org/oskari/control/layer/DescribeLayerHandler.java
+++ b/control-base/src/main/java/org/oskari/control/layer/DescribeLayerHandler.java
@@ -6,6 +6,8 @@ import fi.nls.oskari.control.*;
 import fi.nls.oskari.control.layer.PermissionHelper;
 import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.domain.map.style.VectorStyle;
+import fi.nls.oskari.domain.map.wfs.WFSLayerAttributes;
+import fi.nls.oskari.domain.map.wfs.WFSLayerOptions;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.map.geometry.WKTHelper;
@@ -15,24 +17,19 @@ import fi.nls.oskari.map.style.VectorStyleHelper;
 import fi.nls.oskari.map.style.VectorStyleService;
 import fi.nls.oskari.service.OskariComponentManager;
 import fi.nls.oskari.service.ServiceRuntimeException;
-import fi.nls.oskari.util.ConversionHelper;
-import fi.nls.oskari.util.JSONHelper;
-import fi.nls.oskari.util.ResponseHelper;
-import fi.nls.oskari.util.WFSConversionHelper;
+import fi.nls.oskari.util.*;
 import org.json.JSONObject;
 import org.oskari.capabilities.CapabilitiesService;
 import org.oskari.capabilities.ogc.LayerCapabilitiesWFS;
 import org.oskari.capabilities.ogc.LayerCapabilitiesWMTS;
+import org.oskari.capabilities.ogc.wfs.FeaturePropertyType;
 import org.oskari.capabilities.ogc.wmts.TileMatrixLink;
 import org.oskari.control.layer.model.FeatureProperties;
 import org.oskari.control.layer.model.LayerExtendedOutput;
 import org.oskari.control.layer.model.LayerOutput;
 import org.oskari.permissions.PermissionService;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static fi.nls.oskari.control.ActionConstants.PARAM_ID;
 import static fi.nls.oskari.control.ActionConstants.PARAM_SRS;
@@ -92,6 +89,7 @@ public class DescribeLayerHandler extends RestActionHandler {
         final String lang = params.getLocale().getLanguage();
         final String crs = params.getHttpParam(PARAM_SRS);
         final int layerId = layer.getId();
+        final String layerType = layer.getType();
 
         LayerExtendedOutput output = new LayerExtendedOutput();
         output.id = layerId;
@@ -102,53 +100,83 @@ public class DescribeLayerHandler extends RestActionHandler {
         }
         if (VectorStyleHelper.isVectorLayer(layer)) {
             output.styles = getVectorStyles(params, layerId);
-            output.properties = getProperties(layer, lang);
+            output.hover = JSONHelper.getObjectAsMap(layer.getOptions().optJSONObject("hover"));
         }
-        if (OskariLayer.TYPE_WMTS.equals(layer.getType())) {
+        if (OskariLayer.TYPE_WFS.equals(layerType)) {
+            setDetailsForWFS(output, layer, lang);
+        }
+        if (OskariLayer.TYPE_WMTS.equals(layerType)) {
             output.capabilities = getCapabilitiesJSON(layer, crs);
         }
         return output;
     }
-
-    private List<FeatureProperties> getProperties(OskariLayer layer, String lang) {
-        if (!OskariLayer.TYPE_WFS.equals(layer.getType())) {
-            return null;
-        }
+    private void setDetailsForWFS (LayerExtendedOutput output, OskariLayer layer, String lang) {
         LayerCapabilitiesWFS caps = CapabilitiesService.fromJSON(layer.getCapabilities().toString(), layer.getType());
+        WFSLayerAttributes attr = new WFSLayerAttributes(layer.getAttributes());
+        WFSLayerOptions opts = new WFSLayerOptions(layer.getOptions());
+        output.properties = getProperties(caps, attr, lang);
+        output.data = getData(caps, attr, opts);
+    }
+
+    private List<FeatureProperties> getProperties(LayerCapabilitiesWFS caps, WFSLayerAttributes attr , String lang) {
         List<FeatureProperties> props = new ArrayList<>();
 
-        JSONObject locale = getPropertiesLocale(layer);
+        List<String> selected = attr.getSelectedAttributes(lang);
+        Optional<JSONObject> locale = attr.getLocalization(lang);
+        JSONObject format = attr.getAttributesData().optJSONObject("format");
+
         caps.getFeatureProperties().stream().forEach(prop -> {
             FeatureProperties p = new FeatureProperties();
             p.name = prop.name;
             p.type = WFSConversionHelper.getSimpleType(prop.type);
             p.rawType = prop.type;
-            p.label = getLabelForProperty(locale, prop.name, lang);
+            p.label = locale.isPresent() ? locale.get().optString(prop.name, null) : null;
+            p.format = getPropertyFormat(format, prop.name);
+            if (!selected.isEmpty()) {
+                int index = selected.indexOf(p.name);
+                if (index == -1) {
+                    p.hidden = true;
+                    p.order = selected.size();
+                } else {
+                    p.order = index;
+                }
+            }
             props.add(p);
         });
+        if (!selected.isEmpty()) {
+            props.sort(Comparator.comparingInt(a -> a.order));
+        }
         return props;
     }
-    private JSONObject getPropertiesLocale(OskariLayer layer) {
-        JSONObject attrs = layer.getAttributes();
-        if (attrs == null) {
+    private Map<String, Object> getPropertyFormat (JSONObject format, String name) {
+        if (format == null) {
             return null;
         }
-        JSONObject data = attrs.optJSONObject("data");
-        if (data == null) {
-            return null;
-        }
-        return data.optJSONObject("locale");
+        return JSONHelper.getObjectAsMap(format.optJSONObject(name));
     }
 
-    private String getLabelForProperty(JSONObject locale, String prop, String lang) {
-        if (locale == null) {
-            return null;
+    private Map<String, Object> getData (LayerCapabilitiesWFS caps, WFSLayerAttributes attr, WFSLayerOptions opts) {
+        Map<String, Object> data = new HashMap<>();
+
+        JSONObject attrData = attr.getAttributesData();
+        data.put(WFSLayerAttributes.KEY_NO_DATA_VALUE, attr.getNoDataValue());
+        data.put(WFSLayerAttributes.KEY_COMMON_ID, attr.getCommonId());
+        data.put(WFSLayerAttributes.KEY_WPS_TYPE, attrData.optString(WFSLayerAttributes.KEY_WPS_TYPE, null));
+        data.put(WFSLayerAttributes.KEY_ID_PROPERTY, attrData.optString(WFSLayerAttributes.KEY_ID_PROPERTY, null));
+
+        String geometryType = attrData.optString(WFSLayerAttributes.KEY_GEOMETRY_TYPE, null);
+        if (geometryType == null) {
+            String geomName = caps.getGeometryField();
+            FeaturePropertyType fpt = caps.getFeatureProperty(geomName);
+            if (fpt != null) {
+                geometryType = fpt.type;
+            }
         }
-        JSONObject labelsForLang = locale.optJSONObject(lang);
-        if (labelsForLang == null) {
-            return null;
-        }
-        return labelsForLang.optString(prop, null);
+        data.put(WFSLayerAttributes.KEY_GEOMETRY_TYPE, geometryType);
+
+        data.put(WFSLayerOptions.KEY_RENDER_MODE, opts.getRenderMode());
+        data.put(WFSLayerOptions.KEY_CLUSTER, opts.getClusteringDistance());
+        return data;
     }
 
     private List<VectorStyle> getVectorStyles (ActionParameters params, int layerId) {

--- a/control-base/src/main/java/org/oskari/control/layer/model/FeatureProperties.java
+++ b/control-base/src/main/java/org/oskari/control/layer/model/FeatureProperties.java
@@ -1,8 +1,16 @@
 package org.oskari.control.layer.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import java.util.Map;
+
 public class FeatureProperties {
     public String name;
     public String type;
     public String rawType;
     public String label;
+    public boolean hidden;
+    public Map<String,Object> format;
+    @JsonIgnore
+    public int order;
 }

--- a/control-base/src/main/java/org/oskari/control/layer/model/LayerExtendedOutput.java
+++ b/control-base/src/main/java/org/oskari/control/layer/model/LayerExtendedOutput.java
@@ -13,5 +13,5 @@ public class LayerExtendedOutput extends LayerOutput {
     public Map<String, Object> capabilities;
 
     public List<FeatureProperties> properties;
-    public Map<String, Object> data;
+    public Map<String, Object> controlData;
 }

--- a/control-base/src/main/java/org/oskari/control/layer/model/LayerExtendedOutput.java
+++ b/control-base/src/main/java/org/oskari/control/layer/model/LayerExtendedOutput.java
@@ -9,7 +9,9 @@ public class LayerExtendedOutput extends LayerOutput {
 
     public String coverage;
     public List<VectorStyle> styles;
+    public Map<String, Object> hover;
     public Map<String, Object> capabilities;
 
     public List<FeatureProperties> properties;
+    public Map<String, Object> data;
 }

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/wfs/WFSLayerAttributes.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/wfs/WFSLayerAttributes.java
@@ -65,6 +65,7 @@ import java.util.*;
  *         "noDataValue": -1,
  *         "commonId": "grd_id",
  *         "geometryType": GeometryType,
+ *         "styleType": "point" || "line" || "area" || "collection"
  *         "idProperty": "id_nro"
  *     },
  *     "maxFeatures": 100,
@@ -77,6 +78,8 @@ public class WFSLayerAttributes {
     public static final String KEY_NO_DATA_VALUE = "noDataValue";
     public static final String KEY_COMMON_ID = "commonId";
 
+    public static final String KEY_STYLE_TYPE = "styleType";
+    // TODO: should admin store geometryType => styleType
     public static final String KEY_GEOMETRY_TYPE = "geometryType";
     public static final String KEY_ID_PROPERTY = "idProperty";
 

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/wfs/WFSLayerAttributes.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/wfs/WFSLayerAttributes.java
@@ -50,9 +50,23 @@ import java.util.*;
  *                 "id_nro": "ID No."
  *             }
  *         },
+ *         "format": {
+ *             "kunta_fi": {
+ *                 "type": "link"
+ *             },
+ *             "id_nro": {
+ *                 "skipEmpty": true,
+ *                 "type": "number"
+ *             },
+ *             "grd_id": {
+ *                 "type": "link"
+ *             }
+ *         },
  *         "noDataValue": -1,
  *         "commonId": "grd_id",
- *         "wpsInputType": "gs_vector"
+ *         "wpsInputType": "gs_vector",
+ *         "geometryType": GeometryType,
+ *         "idProperty": "id_nro"
  *     },
  *     "maxFeatures": 100,
  *     "namespaceURL": "http://oskari.org"
@@ -63,7 +77,9 @@ public class WFSLayerAttributes {
     public static final String KEY_MAXFEATURES = "maxFeatures";
     public static final String KEY_NO_DATA_VALUE = "noDataValue";
     public static final String KEY_COMMON_ID = "commonId";
-    public static final String KEY_WPS_TYPE = "wpsType";
+    public static final String KEY_WPS_TYPE = "wpsInputType";
+    public static final String KEY_GEOMETRY_TYPE = "geometryType";
+    public static final String KEY_ID_PROPERTY = "idProperty";
 
     private Map<String, List<String>> params = new HashMap<>();
     private JSONObject locales = null;
@@ -133,7 +149,8 @@ public class WFSLayerAttributes {
 
     public List<String> getSelectedAttributes(String lang) {
         return params.getOrDefault(lang,
-                params.getOrDefault(PropertyUtil.getDefaultLanguage(), Collections.emptyList()));
+                params.getOrDefault("default",
+                params.getOrDefault(PropertyUtil.getDefaultLanguage(), Collections.emptyList())));
     }
 
     public String getNamespaceURL() {

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/wfs/WFSLayerAttributes.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/wfs/WFSLayerAttributes.java
@@ -64,7 +64,6 @@ import java.util.*;
  *         },
  *         "noDataValue": -1,
  *         "commonId": "grd_id",
- *         "wpsInputType": "gs_vector",
  *         "geometryType": GeometryType,
  *         "idProperty": "id_nro"
  *     },
@@ -77,7 +76,7 @@ public class WFSLayerAttributes {
     public static final String KEY_MAXFEATURES = "maxFeatures";
     public static final String KEY_NO_DATA_VALUE = "noDataValue";
     public static final String KEY_COMMON_ID = "commonId";
-    public static final String KEY_WPS_TYPE = "wpsInputType";
+
     public static final String KEY_GEOMETRY_TYPE = "geometryType";
     public static final String KEY_ID_PROPERTY = "idProperty";
 
@@ -187,5 +186,9 @@ public class WFSLayerAttributes {
         }
         JSONObject data = JSONHelper.getJSONObject(attributes, "data");
         return data == null ? new JSONObject() : data;
+    }
+    public Optional<JSONObject> getFieldFormatMetadata () {
+        JSONObject format = getAttributesData().optJSONObject("format");
+        return format == null ? Optional.empty() : Optional.of(format);
     }
 }

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/wfs/WFSLayerOptions.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/wfs/WFSLayerOptions.java
@@ -32,6 +32,7 @@ import org.json.JSONObject;
 public class WFSLayerOptions {
     public static final String KEY_RENDER_MODE = "renderMode";
     public static final String KEY_CLUSTER = "clusteringDistance";
+    private static final String KEY_HOVER = "hover";
     private static final String KEY_LABEL = "labelProperty";
     private static final String KEY_STYLES = "styles";
     private static final String KEY_DEFAULT_STYLE = "default";
@@ -78,15 +79,20 @@ public class WFSLayerOptions {
         }
         JSONHelper.putValue(defaultStyle, KEY_FEATURE_STYLE, style);
     }
-    public JSONObject getDefaultFeatureStyle () {
+    public JSONObject getDefaultStyle () {
         JSONObject styles = JSONHelper.getJSONObject(options, KEY_STYLES);
         JSONObject defaultStyle = JSONHelper.getJSONObject(styles, KEY_DEFAULT_STYLE);
-        JSONObject featureStyle =  JSONHelper.getJSONObject(defaultStyle, KEY_FEATURE_STYLE);
-        if (featureStyle == null) {
+        if (defaultStyle != null) {
             // all UserDataLayer should have one 'default' named style with featureStyle definitions
-            return getDefaultOskariStyle();
+            return defaultStyle;
         }
-        return featureStyle;
+        return JSONHelper.createJSONObject(KEY_FEATURE_STYLE, getDefaultOskariStyle());
+    }
+    public JSONObject getDefaultFeatureStyle () {
+        JSONObject defaultStyle = getDefaultStyle();
+        return defaultStyle.has(KEY_FEATURE_STYLE)
+                ? JSONHelper.getJSONObject(defaultStyle, KEY_FEATURE_STYLE)
+                : getDefaultOskariStyle();
     }
     /*-- Common --*/
     public void setProperty (String key, Object value) {
@@ -105,6 +111,7 @@ public class WFSLayerOptions {
     public void setClusteringDistance (int cluster) {
         JSONHelper.putValue(options, KEY_CLUSTER, cluster);
     }
+    public JSONObject getHover () { return options.optJSONObject(KEY_HOVER); }
 
     /**
      * Should match https://github.com/oskariorg/oskari-frontend/blob/master/src/react/components/StyleEditor/OskariDefaultStyle.js

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/wfs/WFSLayerOptions.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/wfs/WFSLayerOptions.java
@@ -30,8 +30,8 @@ import org.json.JSONObject;
  * }
  */
 public class WFSLayerOptions {
-    private static final String KEY_RENDER_MODE = "renderMode";
-    private static final String KEY_CLUSTER = "clusteringDistance";
+    public static final String KEY_RENDER_MODE = "renderMode";
+    public static final String KEY_CLUSTER = "clusteringDistance";
     private static final String KEY_LABEL = "labelProperty";
     private static final String KEY_STYLES = "styles";
     private static final String KEY_DEFAULT_STYLE = "default";

--- a/service-base/src/main/java/fi/nls/oskari/util/WFSConversionHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/WFSConversionHelper.java
@@ -24,15 +24,15 @@ public class WFSConversionHelper {
                 "number",
                 "integer",
                 "long",
-                "negativeInteger",
-                "nonNegativeInteger",
-                "nonPositiveInteger",
-                "positiveInteger",
+                "negativeinteger",
+                "nonnegativeinteger",
+                "nonpositiveinteger",
+                "positiveinteger",
                 "short",
-                "unsignedLong",
-                "unsignedInt",
-                "unsignedShort",
-                "unsignedByte"
+                "unsignedlong",
+                "unsignedint",
+                "unsignedshort",
+                "unsignedbyte"
             )
     );
     private static final Set<String> GEOMETRY_TYPES = new HashSet<>(
@@ -72,16 +72,20 @@ public class WFSConversionHelper {
         return GEOMETRY_TYPES.contains(type);
     }
     public static String getSimpleType (String type) {
+        if (type == null) {
+            return UNKNOWN;
+        }
         if (isGeometryType(type)) {
             return GEOMETRY;
         }
-        if (isStringType(type)) {
+        String lower = type.toLowerCase();
+        if (isStringType(lower)) {
             return STRING;
         }
-        if (isNumberType(type)) {
+        if (isNumberType(lower)) {
             return NUMBER;
         }
-        if (isBooleanType(type)) {
+        if (isBooleanType(lower)) {
             return BOOLEAN;
         }
         return UNKNOWN;

--- a/service-base/src/main/java/fi/nls/oskari/util/WFSConversionHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/WFSConversionHelper.java
@@ -10,6 +10,11 @@ public class WFSConversionHelper {
     public static final String BOOLEAN = "boolean";
     public static final String GEOMETRY = "geometry";
     public static final String UNKNOWN = "unknown";
+    public static final String TYPE_COLLECTION = "collection";
+    public static final String TYPE_POINT = "point";
+    public static final String TYPE_LINE = "line";
+    public static final String TYPE_AREA = "area";
+
     private static final Set<String> NUMBER_TYPES = new HashSet<>(
             Arrays.asList("double",
                 "float",
@@ -81,6 +86,24 @@ public class WFSConversionHelper {
         }
         return UNKNOWN;
     }
+
+    public static String getStyleType (String rawGeometryType) {
+        if (rawGeometryType == null) {
+            return UNKNOWN;
+        }
+        String lower = rawGeometryType.toLowerCase();
+        if (lower.contains("surface") || lower.contains("polygon")) {
+            return TYPE_AREA;
+        }
+        if (lower.contains(TYPE_POINT)) {
+            return TYPE_POINT;
+        }
+        if (lower.contains(TYPE_LINE)) {
+            return TYPE_LINE;
+        }
+        return TYPE_COLLECTION;
+    }
+
     public static String getStringOrNumber (String type) {
         return isNumberType(type) ? NUMBER : STRING;
 

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
@@ -41,6 +41,7 @@ public class LayerJSONFormatter {
     protected static final String KEY_LOCALIZED_NAME = "name"; // FIXME: title
     protected static final String KEY_SUBTITLE = "subtitle";
     protected static final String KEY_OPTIONS = "options";
+    protected static final String KEY_ATTRIBUTES = "attributes";
     protected static final String KEY_DATA_PROVIDER = "orgName";
     protected static final String[] STYLE_KEYS ={"name", "title", "legend"};
 
@@ -140,13 +141,12 @@ public class LayerJSONFormatter {
         if(layer.getMaxScale() != null && layer.getMaxScale() != -1) {
             JSONHelper.putValue(layerJson, "maxScale", layer.getMaxScale());
         }
-        JSONObject attributes = layer.getAttributes();
         if (!useProxy) {
             // don't write additional params for proxied urls
             JSONHelper.putValue(layerJson, "params", layer.getParams());
         }
         JSONHelper.putValue(layerJson, KEY_OPTIONS, layer.getOptions());
-        JSONHelper.putValue(layerJson, "attributes", attributes);
+        JSONHelper.putValue(layerJson, KEY_ATTRIBUTES, layer.getAttributes());
 
         JSONHelper.putValue(layerJson, "realtime", layer.getRealtime());
         JSONHelper.putValue(layerJson, "refreshRate", layer.getRefreshRate());

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterANALYSIS.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterANALYSIS.java
@@ -48,7 +48,8 @@ public class LayerJSONFormatterANALYSIS extends LayerJSONFormatterUSERDATA {
         return layerJson;
     }
     @Override
-    protected String getGeometryType() {
+    protected String getStyleType(JSONArray properties) {
+        // no need to find from properties
         return WFSConversionHelper.TYPE_COLLECTION;
     }
     @Override
@@ -68,6 +69,7 @@ public class LayerJSONFormatterANALYSIS extends LayerJSONFormatterUSERDATA {
                 props.put(prop);
             }
         }
+        props.put(DEAULT_GEOMETRY_PROPERTY);
         return props;
     }
     @Override

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterANALYSIS.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterANALYSIS.java
@@ -1,19 +1,18 @@
 package fi.nls.oskari.map.layer.formatters;
 
 import fi.mml.map.mapwindow.util.OskariLayerWorker;
-import fi.nls.oskari.analysis.AnalysisHelper;
 import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.domain.map.UserDataLayer;
 import fi.nls.oskari.domain.map.analysis.Analysis;
 import fi.nls.oskari.domain.map.wfs.WFSLayerAttributes;
+import fi.nls.oskari.domain.map.wfs.WFSLayerOptions;
+import fi.nls.oskari.map.geometry.WKTHelper;
 import fi.nls.oskari.util.JSONHelper;
 import fi.nls.oskari.util.PropertyUtil;
 import fi.nls.oskari.util.WFSConversionHelper;
 import org.json.JSONArray;
-import org.json.JSONException;
 import org.json.JSONObject;
 import org.oskari.permissions.model.PermissionType;
-
-import static fi.nls.oskari.service.capabilities.CapabilitiesConstants.KEY_LAYER_COVERAGE;
 
 /**
  * Analysis layer to Oskari layer JSON
@@ -22,9 +21,7 @@ public class LayerJSONFormatterANALYSIS extends LayerJSONFormatterUSERDATA {
     private static final String ANALYSIS_BASELAYER_ID = PropertyUtil.get("analysis.baselayer.id");
 
     private static final String JSKEY_LAYERID = "layerId";
-    private static final String JSKEY_OPACITY = "opacity";
-    private static final String JSKEY_MINSCALE = "minScale";
-    private static final String JSKEY_MAXSCALE = "maxScale";
+    private static final String JSKEY_LAYER_TYPE = "layerType";
     private static final String JSKEY_METHODPARAMS = "methodParams";
     private static final String JSKEY_NO_DATA = "no_data";
     private static final String JSKEY_METHOD = "method";
@@ -33,11 +30,7 @@ public class LayerJSONFormatterANALYSIS extends LayerJSONFormatterUSERDATA {
     private static final String JSKEY_TOP = "top";
     private static final String JSKEY_LEFT = "left";
     private static final String JSKEY_RIGHT = "right";
-    private static final String JSKEY_WPSURL = "wpsUrl";
-    private static final String JSKEY_WPSNAME = "wpsName";
-    private static final String JSKEY_WPSLAYERID = "wpsLayerId";
-
-    private static final String ANALYSIS_RENDERING_ELEMENT = PropertyUtil.get("analysis.rendering.element");
+    private static final String JSKEY_WPS_TYPE = "wpsInputType";
 
     public JSONObject getJSON(OskariLayer baseLayer, Analysis analysis, String srs, String lang) {
         final JSONObject layerJson = super.getJSON(baseLayer, analysis, srs, lang);
@@ -52,42 +45,72 @@ public class LayerJSONFormatterANALYSIS extends LayerJSONFormatterUSERDATA {
             }
             JSONHelper.putValue(layerJson, KEY_ID, id);
         }
-
-        JSONHelper.putValue(layerJson, JSKEY_WPSURL, AnalysisHelper.getAnalysisRenderingUrl());
-        JSONHelper.putValue(layerJson, JSKEY_WPSNAME, ANALYSIS_RENDERING_ELEMENT);
-        JSONHelper.putValue(layerJson, JSKEY_WPSLAYERID, analysis.getId());
-
-        int opacity = layerJson.optInt(JSKEY_OPACITY, -1);
-        if (opacity > -1) {
-            JSONHelper.putValue(layerJson, JSKEY_OPACITY, opacity);
-        }
-        if (layerJson.has(JSKEY_MINSCALE)) {
-            JSONHelper.putValue(layerJson, JSKEY_MINSCALE, layerJson.optInt(JSKEY_MINSCALE, -1));
-        }
-        if (layerJson.has(JSKEY_MINSCALE)) {
-            JSONHelper.putValue(layerJson, JSKEY_MAXSCALE,  layerJson.optInt(JSKEY_MAXSCALE, -1));
-        }
-        JSONObject bbox = JSONHelper.getJSONObject(analyseJson, JSKEY_BBOX);
-        if (bbox != null) {
-            try {
-                // TODO: ReverencedEnvelope or WKT -> WKTHelper.transform(native, srs)
-                Double bottom = bbox.getDouble(JSKEY_BOTTOM);
-                Double top = bbox.getDouble(JSKEY_TOP);
-                Double left = bbox.getDouble(JSKEY_LEFT);
-                Double right = bbox.getDouble(JSKEY_RIGHT);
-                String geom = "POLYGON ((" + left + " " + bottom + ", " + right + " " + bottom + ", " +
-                        right + " " + top + ", " + left + " " + top + ", " + left + " " + bottom + "))";
-                layerJson.put(KEY_LAYER_COVERAGE, geom);
-            } catch (JSONException ignored) {
-                // Don't add geom if some value is missing or invalid
-            }
-        }
-        JSONObject baseAttributes = JSONHelper.getJSONObject(layerJson, "attributes");
-        JSONObject layerAttributes = parseAttributes(analysis, analyseJson, lang);
-        // baseAttributes comes from baseLayer merge layer attributes
-        JSONHelper.putValue(layerJson, "attributes", JSONHelper.merge(baseAttributes, layerAttributes));
         return layerJson;
     }
+    @Override
+    protected String getGeometryType() {
+        return WFSConversionHelper.TYPE_COLLECTION;
+    }
+    @Override
+    protected JSONArray getProperties (UserDataLayer layer, WFSLayerAttributes wfsAttr, String lang) {
+        Analysis analysis = (Analysis) layer;
+        JSONArray props = new JSONArray();
+        // Analysis json contains fields and fieldTypes, maybe should use them instead of 't' or 'n' prefixed names
+        // Requires changes in frontend so use columns for now
+        for (int i = 1; i < 11; i++) {
+            String col = analysis.getColx(i);
+            if (col != null && col.contains("=")) {
+                String[] splitted = col.split("=");
+                JSONObject prop = JSONHelper.createJSONObject("name", splitted[0]); // t${i} || n${i}
+                JSONHelper.putValue(prop, "label", splitted[1]);
+                String type = splitted[0].startsWith("n") ? WFSConversionHelper.NUMBER : WFSConversionHelper.STRING;
+                JSONHelper.putValue(prop, "type", type);
+                props.put(prop);
+            }
+        }
+        return props;
+    }
+    @Override
+    protected String getCoverage (UserDataLayer layer, String srs) {
+        Analysis analysis = (Analysis) layer;
+        JSONObject analyseJson = JSONHelper.createJSONObject(analysis.getAnalyse_json());
+        JSONObject bbox = JSONHelper.getJSONObject(analyseJson, JSKEY_BBOX);
+        if (bbox == null) {
+            return null;
+        }
+        try {
+            Double bottom = bbox.getDouble(JSKEY_BOTTOM);
+            Double top = bbox.getDouble(JSKEY_TOP);
+            Double left = bbox.getDouble(JSKEY_LEFT);
+            Double right = bbox.getDouble(JSKEY_RIGHT);
+            String geomWKT = WKTHelper.getBBOX(left,bottom, right, top);
+            String nativeSrs = PropertyUtil.get("oskari.native.srs", "EPSG:4326");
+            if (nativeSrs.equals(srs)) {
+                return geomWKT;
+            }
+            return WKTHelper.transform(geomWKT, nativeSrs, srs);
+        } catch (Exception ignored) {
+            // Don't add geom if some value is missing or invalid
+        }
+        return null;
+    }
+    @Override
+    protected JSONObject getControlData (UserDataLayer layer, WFSLayerOptions wfsOpts) {
+        JSONObject controlData = super.getControlData(layer, wfsOpts);
+        Analysis analysis = (Analysis) layer;
+        JSONObject analyseJson = JSONHelper.createJSONObject(analysis.getAnalyse_json());
+        JSONObject params = JSONHelper.getJSONObject(analyseJson, JSKEY_METHODPARAMS);
+        if (params != null) {
+            JSONHelper.putValue(controlData, WFSLayerAttributes.KEY_NO_DATA_VALUE, JSONHelper.get(params, JSKEY_NO_DATA));
+        }
+        JSONHelper.putValue(controlData, JSKEY_METHOD, JSONHelper.optString(analyseJson, JSKEY_METHOD));
+        // JSONHelper.putValue(controlData, JSKEY_WPS_TYPE, attrData.optString(JSKEY_WPS_TYPE, null));
+        JSONHelper.putValue(controlData, "analysisId", analysis.getId());
+        JSONHelper.putValue(controlData, "baseLayerId", JSONHelper.optString(analyseJson, JSKEY_LAYERID));
+        JSONHelper.putValue(controlData, "baseLayerType", JSONHelper.optString(analyseJson, JSKEY_LAYER_TYPE));
+        return controlData;
+    }
+
     private static JSONObject parseAttributes (Analysis analysis, JSONObject analysisJSON, String lang) {
         JSONObject attributes = new JSONObject();
         JSONObject data = new JSONObject();

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterMYPLACES.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterMYPLACES.java
@@ -2,6 +2,7 @@ package fi.nls.oskari.map.layer.formatters;
 
 import fi.nls.oskari.domain.map.UserDataLayer;
 import fi.nls.oskari.domain.map.wfs.WFSLayerAttributes;
+import fi.nls.oskari.domain.map.wfs.WFSLayerOptions;
 import fi.nls.oskari.util.JSONHelper;
 import fi.nls.oskari.util.WFSConversionHelper;
 import org.json.JSONArray;
@@ -20,16 +21,26 @@ public class LayerJSONFormatterMYPLACES extends LayerJSONFormatterUSERDATA {
     private static final String KEY_IS_DEFAULT = "isDefault";
 
     public JSONObject getJSON(OskariLayer baseLayer, MyPlaceCategory category, String srs, String lang) {
-        category.getWFSLayerOptions().setProperty(KEY_IS_DEFAULT, category.isDefault());
         final JSONObject layerJson = super.getJSON(baseLayer, category, srs, lang);
-
         // If user doesn't have category, default category is added with empty locale
         // Categories isn't always handled by MyPlaces bundle so default localized names are stored in baselayer
         if (category.getNames().isEmpty()) {
             // use locale from baselayer
             JSONHelper.putValue(layerJson, KEY_LOCALE, baseLayer.getLocale());
+        } else {
+            // Override localized name (from baselayer) if available
+            // if MyPlaces bundle doesn't handle layer, locale isn't used
+            JSONHelper.putValue(layerJson, KEY_LOCALIZED_NAME, category.getName(lang));
         }
         return layerJson;
+    }
+
+    @Override
+    protected JSONObject getControlData(UserDataLayer layer, WFSLayerOptions wfsOpts) {
+        MyPlaceCategory cat = (MyPlaceCategory) layer;
+        JSONObject controlData = super.getControlData(layer, wfsOpts);
+        JSONHelper.putValue(controlData, KEY_IS_DEFAULT, cat.isDefault());
+        return controlData;
     }
 
     @Override

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterMYPLACES.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterMYPLACES.java
@@ -1,6 +1,10 @@
 package fi.nls.oskari.map.layer.formatters;
 
+import fi.nls.oskari.domain.map.UserDataLayer;
+import fi.nls.oskari.domain.map.wfs.WFSLayerAttributes;
 import fi.nls.oskari.util.JSONHelper;
+import fi.nls.oskari.util.WFSConversionHelper;
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 import fi.nls.oskari.domain.map.MyPlaceCategory;
@@ -26,4 +30,23 @@ public class LayerJSONFormatterMYPLACES extends LayerJSONFormatterUSERDATA {
         return layerJson;
     }
 
+    @Override
+    protected JSONArray getProperties (UserDataLayer layer, WFSLayerAttributes wfsAttr, String lang) {
+        JSONArray props = new JSONArray();
+        JSONObject format = wfsAttr.getFieldFormatMetadata().orElse(new JSONObject());
+        JSONObject locale = wfsAttr.getLocalization(lang).orElse(new JSONObject());
+        wfsAttr.getSelectedAttributes(lang).stream().forEach(name -> {
+            JSONObject prop = JSONHelper.createJSONObject("name", name);
+            JSONHelper.putValue(prop, "type", "string");
+            JSONHelper.putValue(prop, "rawType", "string");
+            JSONHelper.putValue(prop, "label", locale.optString(name, null));
+            JSONHelper.putValue(prop, "format", JSONHelper.getJSONObject(format, name));
+            props.put(prop);
+        });
+        return props;
+    }
+    @Override
+    protected String getGeometryType() {
+        return WFSConversionHelper.TYPE_COLLECTION;
+    }
 }

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterMYPLACES.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterMYPLACES.java
@@ -10,6 +10,8 @@ import org.json.JSONObject;
 import fi.nls.oskari.domain.map.MyPlaceCategory;
 import fi.nls.oskari.domain.map.OskariLayer;
 
+import java.util.List;
+
 /**
  * MyPlaces category to Oskari layer JSON
  */
@@ -35,12 +37,19 @@ public class LayerJSONFormatterMYPLACES extends LayerJSONFormatterUSERDATA {
         JSONArray props = new JSONArray();
         JSONObject format = wfsAttr.getFieldFormatMetadata().orElse(new JSONObject());
         JSONObject locale = wfsAttr.getLocalization(lang).orElse(new JSONObject());
+        // not visible/selected properties should be found from filter, format and/or locale
+        // MyPlaces has hard coded values (columns in db and frontend), so just add to list
+        List<String> selected = wfsAttr.getSelectedAttributes(lang);
+        selected.add("attention_text");
         wfsAttr.getSelectedAttributes(lang).stream().forEach(name -> {
             JSONObject prop = JSONHelper.createJSONObject("name", name);
             JSONHelper.putValue(prop, "type", "string");
             JSONHelper.putValue(prop, "rawType", "String");
             JSONHelper.putValue(prop, "label", locale.optString(name, null));
             JSONHelper.putValue(prop, "format", JSONHelper.getJSONObject(format, name));
+            if (name == "attention_text") {
+                JSONHelper.putValue(prop, "hidden", true);
+            }
             props.put(prop);
         });
         props.put(DEAULT_GEOMETRY_PROPERTY);

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterMYPLACES.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterMYPLACES.java
@@ -38,15 +38,17 @@ public class LayerJSONFormatterMYPLACES extends LayerJSONFormatterUSERDATA {
         wfsAttr.getSelectedAttributes(lang).stream().forEach(name -> {
             JSONObject prop = JSONHelper.createJSONObject("name", name);
             JSONHelper.putValue(prop, "type", "string");
-            JSONHelper.putValue(prop, "rawType", "string");
+            JSONHelper.putValue(prop, "rawType", "String");
             JSONHelper.putValue(prop, "label", locale.optString(name, null));
             JSONHelper.putValue(prop, "format", JSONHelper.getJSONObject(format, name));
             props.put(prop);
         });
+        props.put(DEAULT_GEOMETRY_PROPERTY);
         return props;
     }
     @Override
-    protected String getGeometryType() {
+    protected String getStyleType(JSONArray properties) {
+        // no need to find from properties
         return WFSConversionHelper.TYPE_COLLECTION;
     }
 }

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterMYPLACES.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterMYPLACES.java
@@ -51,8 +51,11 @@ public class LayerJSONFormatterMYPLACES extends LayerJSONFormatterUSERDATA {
         // not visible/selected properties should be found from filter, format and/or locale
         // MyPlaces has hard coded values (columns in db and frontend), so just add to list
         List<String> selected = wfsAttr.getSelectedAttributes(lang);
+        if (selected.isEmpty()) {
+            return props;
+        }
         selected.add("attention_text");
-        wfsAttr.getSelectedAttributes(lang).stream().forEach(name -> {
+        selected.stream().forEach(name -> {
             JSONObject prop = JSONHelper.createJSONObject("name", name);
             JSONHelper.putValue(prop, "type", "string");
             JSONHelper.putValue(prop, "rawType", "String");

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERDATA.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERDATA.java
@@ -3,9 +3,12 @@ package fi.nls.oskari.map.layer.formatters;
 import fi.mml.map.mapwindow.util.OskariLayerWorker;
 import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.domain.map.UserDataLayer;
+import fi.nls.oskari.domain.map.wfs.WFSLayerAttributes;
 import fi.nls.oskari.domain.map.wfs.WFSLayerOptions;
 import fi.nls.oskari.util.JSONHelper;
 import fi.nls.oskari.util.PropertyUtil;
+import fi.nls.oskari.util.WFSConversionHelper;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.oskari.permissions.model.PermissionType;
 
@@ -32,28 +35,57 @@ public abstract class LayerJSONFormatterUSERDATA extends LayerJSONFormatter {
         JSONHelper.putValue(layerJson, KEY_ID, layer.getPrefixedId());
         JSONHelper.putValue(layerJson, KEY_LOCALE, layer.getLocale());
 
-        // TODO: remove name when all userdata layers can handle locale
-        // override default name only if userdatalayer has name
-        // add all localized names to allow user to edit them
-        String name = layer.getName();
-        Map<String, String> localized = layer.getNames();
-        if (!localized.isEmpty()) {
-            JSONObject names = new JSONObject();
-            localized.entrySet().forEach(entry -> JSONHelper.putValue(names, entry.getKey(), entry.getValue()));
-            JSONHelper.putValue(layerJson, KEY_LOCALIZED_NAME, names);
-        } else if (name != null && !name.isEmpty()) {
-            JSONHelper.putValue(layerJson, KEY_LOCALIZED_NAME, name);
-        }
         // FIXME: base layer should have correct data provider and title.
         layerJson.remove(KEY_SUBTITLE);
         layerJson.remove(KEY_DATA_PROVIDER);
 
+        // getBaseJSON adds these but model builder isn't using them. Frontend uses DescribeLayer response
+        layerJson.remove(KEY_OPTIONS);
+        layerJson.remove(KEY_ATTRIBUTES);
+
+        WFSLayerAttributes wfsAttr = new WFSLayerAttributes(baseLayer.getAttributes());
         WFSLayerOptions wfsOpts = layer.getWFSLayerOptions();
         wfsOpts.injectBaseLayerOptions(baseLayer.getOptions());
-        JSONHelper.putValue(layerJson, KEY_OPTIONS, wfsOpts.getOptions());
+
+        // Gather values from options and attributes like DescribeLayerHandler
+        // see: org.oskari.control.layer.model.LayerExtendedOutput
+        // For now user can't edit labels or other localized values => return only lang related values
+        JSONObject describeLayer = new JSONObject();
+        // has only one 'default' named style
+        JSONObject vectorStyleLike = JSONHelper.createJSONObject("id", "default");
+        JSONHelper.putValue(vectorStyleLike, "style", wfsOpts.getDefaultStyle());
+        JSONHelper.put(describeLayer, "styles", JSONHelper.createJSONArray(vectorStyleLike));
+
+        JSONHelper.putValue(describeLayer, "hover", wfsOpts.getHover());
+
+        JSONHelper.putValue(describeLayer, "properties", getProperties(layer, wfsAttr, lang));
+
+        JSONHelper.putValue(describeLayer, "controlData", getControlData(layer, wfsOpts));
+
+        JSONHelper.putValue(describeLayer, "coverage", getCoverage(layer, srs));
+
+        JSONHelper.putValue(layerJson, "describeLayer", describeLayer);
 
         return layerJson;
     }
+    protected String getCoverage (UserDataLayer layer, String srs) {
+        return null;
+    }
+    protected JSONArray getProperties (UserDataLayer layer, WFSLayerAttributes wfsAttr, String lang) {
+        return new JSONArray();
+    }
+
+    protected JSONObject getControlData (UserDataLayer layer, WFSLayerOptions wfsOpts) {
+        JSONObject controlData = new JSONObject();
+        JSONHelper.putValue(controlData, WFSLayerOptions.KEY_RENDER_MODE, wfsOpts.getRenderMode());
+        JSONHelper.putValue(controlData, WFSLayerOptions.KEY_CLUSTER, wfsOpts.getClusteringDistance());
+        JSONHelper.putValue(controlData, WFSLayerAttributes.KEY_GEOMETRY_TYPE, getGeometryType());
+        return controlData;
+    }
+    protected String getGeometryType() {
+        return WFSConversionHelper.UNKNOWN;
+    }
+
     public static void setDefaultPermissions(JSONObject layerJson) {
         JSONObject permissions = new JSONObject();
         JSONHelper.putValue(permissions, PermissionType.PUBLISH.getJsonKey(), OskariLayerWorker.PUBLICATION_PERMISSION_OK);

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERDATA.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERDATA.java
@@ -12,8 +12,6 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.oskari.permissions.model.PermissionType;
 
-import java.util.Map;
-
 import static fi.nls.oskari.service.capabilities.CapabilitiesConstants.KEY_ISQUERYABLE;
 
 public abstract class LayerJSONFormatterUSERDATA extends LayerJSONFormatter {

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERDATA.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERDATA.java
@@ -3,6 +3,7 @@ package fi.nls.oskari.map.layer.formatters;
 import fi.mml.map.mapwindow.util.OskariLayerWorker;
 import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.domain.map.UserDataLayer;
+import fi.nls.oskari.domain.map.style.VectorStyle;
 import fi.nls.oskari.domain.map.wfs.WFSLayerAttributes;
 import fi.nls.oskari.domain.map.wfs.WFSLayerOptions;
 import fi.nls.oskari.util.JSONHelper;
@@ -38,6 +39,7 @@ public abstract class LayerJSONFormatterUSERDATA extends LayerJSONFormatter {
         // FIXME: base layer should have correct data provider and title.
         layerJson.remove(KEY_SUBTITLE);
         layerJson.remove(KEY_DATA_PROVIDER);
+        layerJson.remove(KEY_DATA_PROVIDER_ID);
 
         // getBaseJSON adds these but model builder isn't using them. Frontend uses DescribeLayer response
         layerJson.remove(KEY_OPTIONS);
@@ -54,6 +56,7 @@ public abstract class LayerJSONFormatterUSERDATA extends LayerJSONFormatter {
         // has only one 'default' named style
         JSONObject vectorStyleLike = JSONHelper.createJSONObject("id", "default");
         JSONHelper.putValue(vectorStyleLike, "style", wfsOpts.getDefaultStyle());
+        JSONHelper.putValue(vectorStyleLike, "type", VectorStyle.TYPE_OSKARI);
         JSONHelper.put(describeLayer, "styles", JSONHelper.createJSONArray(vectorStyleLike));
 
         JSONHelper.putValue(describeLayer, "hover", wfsOpts.getHover());
@@ -61,7 +64,7 @@ public abstract class LayerJSONFormatterUSERDATA extends LayerJSONFormatter {
         JSONArray properties = getProperties(layer, wfsAttr, lang);
         JSONHelper.put(describeLayer, "properties", properties);
 
-        JSONObject controlData = new JSONObject( getControlData(layer, wfsOpts));
+        JSONObject controlData = getControlData(layer, wfsOpts);
         JSONHelper.putValue(controlData,"styleType", getStyleType(properties));
         JSONHelper.putValue(describeLayer, "controlData", controlData);
 
@@ -82,7 +85,6 @@ public abstract class LayerJSONFormatterUSERDATA extends LayerJSONFormatter {
         JSONObject controlData = new JSONObject();
         JSONHelper.putValue(controlData, WFSLayerOptions.KEY_RENDER_MODE, wfsOpts.getRenderMode());
         JSONHelper.putValue(controlData, WFSLayerOptions.KEY_CLUSTER, wfsOpts.getClusteringDistance());
-
         return controlData;
     }
     protected String getStyleType(JSONArray properties) {

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERDATA.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERDATA.java
@@ -19,6 +19,8 @@ public abstract class LayerJSONFormatterUSERDATA extends LayerJSONFormatter {
     private static final boolean IS_SECURE = true;
     protected static final String KEY_PERMISSIONS = "permissions";
     protected static final String KEY_LOCALE = "locale";
+    protected static final JSONObject DEAULT_GEOMETRY_PROPERTY =
+            JSONHelper.createJSONObject("{\"name\":\"the_geom\", \"type\": \"geometry\", \"rawType\": \"GeometryPropertyType\"}");
 
     public JSONObject getJSON(OskariLayer baseLayer, UserDataLayer layer, String srs) {
         return this.getJSON(baseLayer, layer, srs, PropertyUtil.getDefaultLanguage());

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERDATA.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERDATA.java
@@ -27,6 +27,8 @@ public abstract class LayerJSONFormatterUSERDATA extends LayerJSONFormatter {
         return this.getJSON(baseLayer, layer, srs, PropertyUtil.getDefaultLanguage());
     }
 
+    // common parser for UserData layers
+    // override methods in subclasses if needed to highlight differences between them
     public JSONObject getJSON(OskariLayer baseLayer, UserDataLayer layer, String srs, String lang) {
         JSONObject layerJson = getBaseJSON(baseLayer, lang, IS_SECURE, srs);
         JSONHelper.putValue(layerJson, KEY_ISQUERYABLE, true);

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERDATA.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERDATA.java
@@ -11,7 +11,9 @@ import org.oskari.permissions.model.PermissionType;
 
 import java.util.Map;
 
-public abstract class LayerJSONFormatterUSERDATA extends LayerJSONFormatterWFS {
+import static fi.nls.oskari.service.capabilities.CapabilitiesConstants.KEY_ISQUERYABLE;
+
+public abstract class LayerJSONFormatterUSERDATA extends LayerJSONFormatter {
 
     private static final boolean IS_SECURE = true;
     protected static final String KEY_PERMISSIONS = "permissions";
@@ -22,7 +24,8 @@ public abstract class LayerJSONFormatterUSERDATA extends LayerJSONFormatterWFS {
     }
 
     public JSONObject getJSON(OskariLayer baseLayer, UserDataLayer layer, String srs, String lang) {
-        JSONObject layerJson = getJSON(baseLayer, lang, IS_SECURE, srs);
+        JSONObject layerJson = getBaseJSON(baseLayer, lang, IS_SECURE, srs);
+        JSONHelper.putValue(layerJson, KEY_ISQUERYABLE, true);
 
         // Override base layer values
         JSONHelper.putValue(layerJson, KEY_TYPE, layer.getType());

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERDATA.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERDATA.java
@@ -56,9 +56,12 @@ public abstract class LayerJSONFormatterUSERDATA extends LayerJSONFormatter {
 
         JSONHelper.putValue(describeLayer, "hover", wfsOpts.getHover());
 
-        JSONHelper.putValue(describeLayer, "properties", getProperties(layer, wfsAttr, lang));
+        JSONArray properties = getProperties(layer, wfsAttr, lang);
+        JSONHelper.put(describeLayer, "properties", properties);
 
-        JSONHelper.putValue(describeLayer, "controlData", getControlData(layer, wfsOpts));
+        JSONObject controlData = new JSONObject( getControlData(layer, wfsOpts));
+        JSONHelper.putValue(controlData,"styleType", getStyleType(properties));
+        JSONHelper.putValue(describeLayer, "controlData", controlData);
 
         JSONHelper.putValue(describeLayer, "coverage", getCoverage(layer, srs));
 
@@ -77,10 +80,18 @@ public abstract class LayerJSONFormatterUSERDATA extends LayerJSONFormatter {
         JSONObject controlData = new JSONObject();
         JSONHelper.putValue(controlData, WFSLayerOptions.KEY_RENDER_MODE, wfsOpts.getRenderMode());
         JSONHelper.putValue(controlData, WFSLayerOptions.KEY_CLUSTER, wfsOpts.getClusteringDistance());
-        JSONHelper.putValue(controlData, WFSLayerAttributes.KEY_GEOMETRY_TYPE, getGeometryType());
+
         return controlData;
     }
-    protected String getGeometryType() {
+    protected String getStyleType(JSONArray properties) {
+        for (int i = 0; i < properties.length(); i++) {
+            JSONObject prop = JSONHelper.getJSONObject(properties, i);
+            String type = JSONHelper.optString(prop, "type");
+            if (WFSConversionHelper.GEOMETRY.equals(type)) {
+                String raw = JSONHelper.optString(prop, "rawType");
+                return WFSConversionHelper.getStyleType(raw);
+            }
+        }
         return WFSConversionHelper.UNKNOWN;
     }
 

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERLAYER.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERLAYER.java
@@ -57,7 +57,7 @@ public class LayerJSONFormatterUSERLAYER extends LayerJSONFormatterUSERDATA {
     }
 
     // parse fields like WFSLayerAttributes
-    private static JSONObject parseAttributes(final JSONArray fields) {
+    protected static JSONObject parseAttributes(final JSONArray fields) {
         JSONObject attributes = new JSONObject();
         if (fields == null || fields.length() == 0){
             return attributes;

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWFS.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWFS.java
@@ -20,7 +20,7 @@ public class LayerJSONFormatterWFS extends LayerJSONFormatter {
         JSONHelper.putValue(layerJson, KEY_ISQUERYABLE, true);
         // getBaseJSON adds these but model builder isn't using them. Frontend uses DescribeLayer response
         layerJson.remove(KEY_OPTIONS);
-        layerJson.remove(KEY_ATTRIBUTES);
+        layerJson.optJSONObject(KEY_ATTRIBUTES).remove("data");
         return layerJson;
     }
 }

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWFS.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWFS.java
@@ -19,8 +19,8 @@ public class LayerJSONFormatterWFS extends LayerJSONFormatter {
         final JSONObject layerJson = getBaseJSON(layer, lang, isSecure, crs);
         JSONHelper.putValue(layerJson, KEY_ISQUERYABLE, true);
         // getBaseJSON adds these but model builder isn't using them. Frontend uses DescribeLayer response
-        layerJson.remove("attributes");
-        layerJson.remove("options");
+        layerJson.remove(KEY_OPTIONS);
+        layerJson.remove(KEY_ATTRIBUTES);
         return layerJson;
     }
 }

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWFS.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWFS.java
@@ -18,9 +18,8 @@ public class LayerJSONFormatterWFS extends LayerJSONFormatter {
 
         final JSONObject layerJson = getBaseJSON(layer, lang, isSecure, crs);
         JSONHelper.putValue(layerJson, KEY_ISQUERYABLE, true);
-        // getBaseJSON adds these but model builder isn't using them. Frontend uses DescribeLayer response
+        // getBaseJSON adds options but model builder isn't using it. Frontend uses DescribeLayer response
         layerJson.remove(KEY_OPTIONS);
-        layerJson.optJSONObject(KEY_ATTRIBUTES).remove("data");
         return layerJson;
     }
 }

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWFS.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterWFS.java
@@ -18,6 +18,9 @@ public class LayerJSONFormatterWFS extends LayerJSONFormatter {
 
         final JSONObject layerJson = getBaseJSON(layer, lang, isSecure, crs);
         JSONHelper.putValue(layerJson, KEY_ISQUERYABLE, true);
+        // getBaseJSON adds these but model builder isn't using them. Frontend uses DescribeLayer response
+        layerJson.remove("attributes");
+        layerJson.remove("options");
         return layerJson;
     }
 }

--- a/service-map/src/test/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterMYPLACESTest.java
+++ b/service-map/src/test/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterMYPLACESTest.java
@@ -1,0 +1,92 @@
+package fi.nls.oskari.map.layer.formatters;
+
+import fi.nls.oskari.domain.map.MyPlaceCategory;
+import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.domain.map.wfs.WFSLayerOptions;
+import fi.nls.oskari.util.JSONHelper;
+import fi.nls.oskari.util.PropertyUtil;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class LayerJSONFormatterMYPLACESTest {
+    private final static LayerJSONFormatterMYPLACES FORMATTER = new LayerJSONFormatterMYPLACES();
+    private final static String SRS = "EPSG:4326";
+    private final static String LANG = PropertyUtil.getDefaultLanguage();
+
+    // Copied from DB (select attributes from oskari_maplayer where name = 'oskari:my_places';)
+    private static final String ATTRIBUTES = "{\"data\":{\"filter\":{\"default\":[\"name\",\"place_desc\",\"image_url\",\"link\"],\"fi\":[\"name\",\"place_desc\",\"image_url\",\"link\"]},\"format\":{\"image_url\":{\"noLabel\":true,\"skipEmpty\":true,\"type\":\"image\",\"params\":{\"link\":true}},\"place_desc\":{\"noLabel\":true,\"skipEmpty\":true,\"type\":\"p\"},\"name\":{\"noLabel\":true,\"type\":\"h3\"},\"link\":{\"skipEmpty\":true,\"type\":\"link\"},\"attention_text\":{\"type\":\"hidden\"}},\"locale\":{\"fi\":{\"image_url\":\"Kuvalinkki\",\"place_desc\":\"Kuvaus\",\"name\":\"Nimi\",\"link\":\"Lisätiedot\",\"attention_text\":\"Teksti kartalla\"},\"sv\":{\"image_url\":\"Bild-URL\",\"place_desc\":\"Beskrivelse\",\"name\":\"Namn\",\"link\":\"Mera information\",\"attention_text\":\"Placera text på kartan\"},\"en\":{\"image_url\":\"Image URL\",\"place_desc\":\"Description\",\"name\":\"Name\",\"link\":\"More information\",\"attention_text\":\"Text on map\"}}},\"maxFeatures\":2000,\"namespaceURL\":\"http://www.oskari.org\"}";
+
+    private static final String NAME = "{" +
+            "\"name\": \"name\"," +
+            "\"type\": \"string\"," +
+            "\"rawType\": \"String\"," +
+            "\"label\": \"Name\"," +
+            "\"format\": {\"noLabel\": true, \"type\":\"h3\"}" +
+        "}";
+    private static final String IMAGE = "{" +
+            "\"name\": \"image_url\"," +
+            "\"type\": \"string\"," +
+            "\"rawType\": \"String\"," +
+            "\"label\": \"Image URL\"," +
+            "\"format\": {" +
+                "\"noLabel\": true," +
+                "\"skipEmpty\": true," +
+                "\"type\": \"image\"," +
+                "\"params\": {" +
+                    "\"link\": true" +
+                "}" +
+            "}" +
+        "}";
+
+    private static final String[] SE_LABELS =  {"Namn", "Beskrivelse", "Bild-URL", "Mera information","Placera text på kartan", null};
+
+    @Test
+    public void parseDescribeLayer() throws JSONException {
+        OskariLayer baseLayer = new OskariLayer();
+        baseLayer.setInternal(true);
+        baseLayer.setAttributes(new JSONObject(ATTRIBUTES));
+
+        MyPlaceCategory layer = new MyPlaceCategory();
+        JSONObject layerJson = FORMATTER.getJSON(baseLayer, layer, SRS, LANG);
+
+        JSONObject describeLayer = layerJson.getJSONObject("describeLayer");
+        JSONObject vectorStyle = describeLayer.getJSONArray("styles").getJSONObject(0);
+        JSONObject styleDef = vectorStyle.getJSONObject("style");
+        Assert.assertTrue("VectorStyle should have default feature style definitions",
+                JSONHelper.isEqual(styleDef.getJSONObject("featureStyle"), WFSLayerOptions.getDefaultOskariStyle()));
+        Assert.assertEquals("VectorStyle should have id", "default", vectorStyle.getString("id"));
+        Assert.assertEquals("VectorStyle should have type", "oskari", vectorStyle.getString("type"));
+
+        JSONArray properties = describeLayer.getJSONArray("properties");
+        Assert.assertEquals("Properties should include all (also geometry and hidden)", 6, properties.length());
+        Assert.assertTrue("Property should get parsed like DescribeLayer",
+                JSONHelper.isEqual(properties.getJSONObject(0), new JSONObject(NAME)));
+        Assert.assertTrue("Property should get parsed like DescribeLayer",
+                JSONHelper.isEqual(properties.getJSONObject(2), new JSONObject(IMAGE)));
+        Assert.assertTrue("Attention text should be hidden and after visible props",
+                properties.getJSONObject(4).getBoolean("hidden"));
+        Assert.assertEquals("Geometry is last", "geometry",
+                properties.getJSONObject(5).getString("type"));
+
+        String coverage = describeLayer.optString("coverage", null);
+        Assert.assertNull("Shouldn't have coverage WKT", coverage);
+
+        JSONObject controlData = describeLayer.getJSONObject("controlData");
+        Assert.assertEquals("Should have style type", "collection", controlData.getString("styleType"));
+        Assert.assertEquals("Should have default render mode", "vector", controlData.getString("renderMode"));
+        Assert.assertEquals("Shouldn't have clustering distance", -1, controlData.getInt("clusteringDistance"));
+
+        JSONObject seJson = FORMATTER.getJSON(baseLayer, layer, SRS, "sv");
+        List <Map<String, Object>> props = JSONHelper.getArrayAsList(seJson.getJSONObject("describeLayer").getJSONArray("properties"));
+        String[] labels = props.stream()
+                .map(m -> (String) m.getOrDefault("label", null))
+                .toArray(String[]::new);
+        Assert.assertArrayEquals("Labels should be localized", SE_LABELS, labels);
+    }
+}

--- a/service-map/src/test/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERLAYERTest.java
+++ b/service-map/src/test/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERLAYERTest.java
@@ -3,6 +3,9 @@ package fi.nls.oskari.map.layer.formatters;
 import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.domain.map.userlayer.UserLayer;
 import fi.nls.oskari.domain.map.wfs.WFSLayerAttributes;
+import fi.nls.oskari.domain.map.wfs.WFSLayerOptions;
+import fi.nls.oskari.map.geometry.WKTHelper;
+import fi.nls.oskari.util.JSONHelper;
 import fi.nls.oskari.util.PropertyUtil;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -37,16 +40,28 @@ public class LayerJSONFormatterUSERLAYERTest {
         "}" +
     "}]";
 
-    // @Test
-    public void parseFields() throws JSONException {
-        OskariLayer baseLayer = new OskariLayer();
-        baseLayer.setInternal(true);
-        baseLayer.getAttributes().put("namespaceURL", NAMESPACE);
-        UserLayer ulayer = new UserLayer();
-        ulayer.setFields(new JSONArray(FIELDS));
-        JSONObject layerJson = FORMATTER_USERLAYER.getJSON(baseLayer, ulayer, SRS, LANG);
-        WFSLayerAttributes attr = new WFSLayerAttributes(layerJson.getJSONObject("attributes"));
-        Assert.assertEquals( "parseFields shouldn't override baselayer attributes", NAMESPACE, attr.getNamespaceURL());
+    private static final String EXPECTED_1 = "{" +
+            "\"name\": \"NAME\"," +
+            "\"type\": \"string\"," +
+            "\"rawType\": \"String\"," +
+            "\"label\": \"Name\"" +
+        "}";
+    private static final String EXPECTED_2 = "{" +
+            "\"name\": \"CODE\"," +
+            "\"type\": \"number\"," +
+            "\"rawType\": \"Long\"," +
+            "\"label\": \"Code\"" +
+        "}";
+    private static final String WKT = "POLYGON ((1 2, 1 3, 1 4, 2 4, 3 4, 3 3, 3 2, 2 2, 1 2))";
+
+    @Test
+    public void parseAttributes() throws JSONException {
+        JSONArray fields = new JSONArray(FIELDS);
+        JSONObject attrJson = FORMATTER_USERLAYER.parseAttributes(fields);
+        WFSLayerAttributes attr = new WFSLayerAttributes(attrJson);
+        fields.remove(2);
+        WFSLayerAttributes anotherAttr = new WFSLayerAttributes(FORMATTER_USERLAYER.parseAttributes(fields));
+        Assert.assertEquals(1, anotherAttr.getSelectedAttributes().size());
 
         List<String> selected = attr.getSelectedAttributes();
         Assert.assertEquals("2 attributes selected", 2, selected.size());
@@ -69,23 +84,44 @@ public class LayerJSONFormatterUSERLAYERTest {
         Assert.assertEquals("MultiPolygon", data.getString("geometryType"));
     }
 
-    // @Test
-    public void parseAttributes() throws JSONException {
+    @Test
+    public void parseDescribeLayer() throws JSONException {
         OskariLayer baseLayer = new OskariLayer();
         baseLayer.setInternal(true);
-        baseLayer.getAttributes().put("namespaceURL", NAMESPACE);
+        WFSLayerOptions opts = new WFSLayerOptions(null);
+        opts.setClusteringDistance(20);
+        opts.setRenderMode("render");
+        baseLayer.setOptions(opts.getOptions());
+
         UserLayer ulayer = new UserLayer();
-        JSONArray fields = new JSONArray(FIELDS);
-        ulayer.setFields(fields);
-        JSONObject json = FORMATTER_USERLAYER.getJSON(baseLayer, ulayer, SRS, LANG);
-        fields.remove(2);
-        JSONObject anotherJson = FORMATTER_USERLAYER.getJSON(baseLayer, ulayer, SRS, LANG);
+        ulayer.setFields(new JSONArray(FIELDS));
+        //WKT is stored as WGS84
+        ulayer.setWkt(WKTHelper.getBBOX(1, 2, 3, 4));
+        JSONObject layerJson = FORMATTER_USERLAYER.getJSON(baseLayer, ulayer, SRS, LANG);
 
-        WFSLayerAttributes attr = new WFSLayerAttributes(json.getJSONObject("attributes"));
-        WFSLayerAttributes anotherAttr = new WFSLayerAttributes(anotherJson.getJSONObject("attributes"));
+        JSONObject describeLayer = layerJson.getJSONObject("describeLayer");
+        JSONObject vectorStyle = describeLayer.getJSONArray("styles").getJSONObject(0);
+        JSONObject styleDef = vectorStyle.getJSONObject("style");
+        Assert.assertTrue("VectorStyle should have default feature style definitions",
+                JSONHelper.isEqual(styleDef.getJSONObject("featureStyle"), WFSLayerOptions.getDefaultOskariStyle()));
+        Assert.assertEquals("VectorStyle should have id", "default", vectorStyle.getString("id"));
+        Assert.assertEquals("VectorStyle should have type", "oskari", vectorStyle.getString("type"));
 
-        Assert.assertEquals(attr.getNamespaceURL(), anotherAttr.getNamespaceURL());
-        Assert.assertEquals(2, attr.getSelectedAttributes().size());
-        Assert.assertEquals(1, anotherAttr.getSelectedAttributes().size());
+        JSONArray properties = describeLayer.getJSONArray("properties");
+        Assert.assertEquals("Properties should include all fields (also geometry)", 3, properties.length());
+        Assert.assertTrue("Field should get parsed like DescribeLayer",
+                JSONHelper.isEqual(properties.getJSONObject(1), new JSONObject(EXPECTED_1)));
+        Assert.assertTrue("Field should get parsed like DescribeLayer",
+                JSONHelper.isEqual(properties.getJSONObject(2), new JSONObject(EXPECTED_2)));
+
+        String coverage = describeLayer.getString("coverage");
+        // If test fails (interpolation) could be also check that WKT exists coverage.startsWith("POLYGON ((1 ")
+        Assert.assertEquals("Should have coverage WKT", WKT, coverage);
+
+        JSONObject controlData = describeLayer.getJSONObject("controlData");
+        Assert.assertEquals("Should have style type", "area", controlData.getString("styleType"));
+        Assert.assertEquals("Should have render mode", "render", controlData.getString("renderMode"));
+        Assert.assertEquals("Should have clustering distance", 20, controlData.getInt("clusteringDistance"));
     }
+
 }

--- a/service-map/src/test/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERLAYERTest.java
+++ b/service-map/src/test/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatterUSERLAYERTest.java
@@ -37,7 +37,7 @@ public class LayerJSONFormatterUSERLAYERTest {
         "}" +
     "}]";
 
-    @Test
+    // @Test
     public void parseFields() throws JSONException {
         OskariLayer baseLayer = new OskariLayer();
         baseLayer.setInternal(true);
@@ -69,7 +69,7 @@ public class LayerJSONFormatterUSERLAYERTest {
         Assert.assertEquals("MultiPolygon", data.getString("geometryType"));
     }
 
-    @Test
+    // @Test
     public void parseAttributes() throws JSONException {
         OskariLayer baseLayer = new OskariLayer();
         baseLayer.setInternal(true);


### PR DESCRIPTION
Sort and add hidden if layer has filtered/selected properties. Add format for properties. Tried list.add(index, prop) but had some problems with it so added json ignored order field for props and sorting.

Add required values from options and attributes to response and remove them from JSON formater.

For: https://github.com/oskariorg/oskari-frontend/pull/2371

![image](https://github.com/oskariorg/oskari-server/assets/22147092/ebf5ee6a-a4d3-4f38-8d8d-5c27414f119c)

UPDATED:
- `data` => `controlData`. Attributes, options, params, metadata etc. is reserved for other purposes. So hard to figure out naming
- removed wpsInputType
- Changed UserData formatters return `describeLayer` object instead of creating attributes or options objects. didn't remove parseAttributes() (maybe needed for migrations)
- describeLayer can be handled in frontend like DescribeLayerHandler response as predeined info
- update/add test for formatters
- geometryType -> styleType. actual geometryType is inside properties (type 'geometry' and rawType)

Fixes after update:
- Add attention_text and geometry (GeometryPropertyType -> styleType collection) for MyPlaces props
- Add default geometry type to Analysis props. Analysis doesn't have rawType (number -> int, double,..)
- Fix userlayer styleType, type -> rawType and add (simple) type
- Had to change WFSConversionHelper.getSimpleType to use lower case comparison as UserLayer uses upper case.

UPDATED II:
- Don't remove attributes (or data). not sure how smart it was to remove options and gather values (capa, attr, opts) to new controlData. Idea was to reduce data to be loaded on appstart and use one variable in frontend (no need to parse data from many places, no need for setters, getters only) to have all data needed for rendering layer. Forget that options doesn't have styles anymore and attributes are used elsewhere (contrib or others).
- add isDefault and localized name (wfs type) for MyPlaces
- test isDefault, locale and name


![image](https://github.com/oskariorg/oskari-server/assets/22147092/7989b0a2-b2f5-4103-ad59-084a82d02931)

![image](https://github.com/oskariorg/oskari-server/assets/22147092/37b9ae70-d1c4-4c5c-af1a-4d07062ba658)

![image](https://github.com/oskariorg/oskari-server/assets/22147092/bcc47a57-2499-47cb-8a92-d6ce4abdd72e)

![image](https://github.com/oskariorg/oskari-server/assets/22147092/87f447ee-3db4-4d33-84a7-de6bb4808686)

BTW: using underscore as separator:  `analysis_userlayer_1_13` -> analysis 13 based on userlayer_1




