### PR TITLE
Add error handling for WFS-services

### DIFF
--- a/control-base/src/main/java/org/oskari/control/layer/DescribeLayerHandler.java
+++ b/control-base/src/main/java/org/oskari/control/layer/DescribeLayerHandler.java
@@ -169,7 +169,9 @@ public class DescribeLayerHandler extends RestActionHandler {
         if (styleType == null) {
             String geomName = caps.getGeometryField();
             FeaturePropertyType fpt = caps.getFeatureProperty(geomName);
-            styleType = WFSConversionHelper.getStyleType(fpt.type);
+            if (fpt != null) {
+                styleType = WFSConversionHelper.getStyleType(fpt.type);
+            }
         }
         data.put(WFSLayerAttributes.KEY_STYLE_TYPE, styleType);
 

--- a/service-capabilities/src/main/java/org/oskari/capabilities/ogc/LayerCapabilitiesWFS.java
+++ b/service-capabilities/src/main/java/org/oskari/capabilities/ogc/LayerCapabilitiesWFS.java
@@ -55,6 +55,9 @@ public class LayerCapabilitiesWFS extends LayerCapabilitiesOGC {
 
     @JsonIgnore
     public FeaturePropertyType getFeatureProperty(String name) {
+        if (name == null) {
+            return null;
+        }
         return getFeatureProperties().stream().filter(p -> name.equals(p.name)).findFirst().orElse(null);
     }
 

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFSClient.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFSClient.java
@@ -84,6 +84,9 @@ public class OskariWFSClient {
             url = IOHelper.constructUrl(endPoint, query);
             responseHeaders = OskariWFSClient.readResponseTo(endPoint, user, pass, query, baos);
             response = baos.toByteArray();
+            if (response.length == 0) {
+                throw new ServiceRuntimeException("Empty response from " + url);
+            }
             // TODO: Select parsing algorithm based on response headers (Content-Type)
             fc = parseGeoJSON(response, crs, url);
             if (fc != null) {
@@ -105,6 +108,9 @@ public class OskariWFSClient {
         baos.reset();
         responseHeaders = OskariWFSClient.readResponseTo(endPoint, user, pass, query, baos);
         response = baos.toByteArray();
+        if (response.length == 0) {
+            throw new ServiceRuntimeException("Empty response from " + url);
+        }
         fc = parseGML(response, crs, url, user, pass, gmlDecoder);
         if (fc != null) {
             return fc;


### PR DESCRIPTION
- Handle empty responses from services to prevent unnecessary stack traces in logs
- Prevent error on DescribeLayer when capabilities are not stored on DB for some reason or another.