### PR TITLE
Add possibility to control init order of custom annotated components

### DIFF
--- a/service-base/src/main/java/fi/nls/oskari/annotation/Oskari.java
+++ b/service-base/src/main/java/fi/nls/oskari/annotation/Oskari.java
@@ -16,4 +16,5 @@ import java.lang.annotation.Target;
 public @interface Oskari {
 
     String value() default "";
+    int order() default Integer.MAX_VALUE;
 }

--- a/service-base/src/main/java/fi/nls/oskari/service/OskariComponent.java
+++ b/service-base/src/main/java/fi/nls/oskari/service/OskariComponent.java
@@ -21,6 +21,13 @@ public abstract class OskariComponent {
         }
         return getClass().getSimpleName();
     }
+    public int getOrder () {
+        if(getClass().isAnnotationPresent(Oskari.class)) {
+            Oskari r = getClass().getAnnotation(Oskari.class);
+            return r.order();
+        }
+        return Integer.MAX_VALUE;
+    }
     /**
      * Hook for setting up requirements for component
      */

--- a/service-base/src/main/java/fi/nls/oskari/service/OskariComponentManager.java
+++ b/service-base/src/main/java/fi/nls/oskari/service/OskariComponentManager.java
@@ -60,13 +60,24 @@ public class OskariComponentManager {
      * Uses ServiceLoader to find all OskariComponents in classpath.
      */
     public synchronized static void addDefaultComponents() {
-
         ServiceLoader<OskariComponent> impl = ServiceLoader.load(OskariComponent.class);
-        for (OskariComponent loadedImpl : impl) {
-            if ( loadedImpl != null ) {
-                addComponent(loadedImpl);
+        List<OskariComponent> sortedList = new ArrayList<>();
+        for (OskariComponent loadedImpl: impl) {
+            if (loadedImpl == null) {
+                continue;
             }
+            sortedList.add(loadedImpl);
         }
+        sortedList.sort(Comparator.comparingInt(OskariComponent::getOrder));
+        sortedList.forEach(loadedImpl -> addComponent(loadedImpl));
+        /*
+        // After Java 9+ we can use stream
+        impl.stream()
+                .filter( h -> h != null)
+                .map(h -> h.get())
+                .sorted(Comparator.comparingInt(OskariComponent::getOrder))
+                .forEach(loadedImpl -> addComponent(loadedImpl));
+         */
     }
     public synchronized static <MOD extends OskariComponent> MOD getComponentOfType(final Class<MOD> clazz) {
         Map<String, MOD> map = getComponentsOfType(clazz);

--- a/service-control/src/main/java/fi/nls/oskari/annotation/OskariActionRoute.java
+++ b/service-control/src/main/java/fi/nls/oskari/annotation/OskariActionRoute.java
@@ -20,4 +20,6 @@ public @interface OskariActionRoute {
      * @return
      */
     String value() default "";
+
+    int order() default Integer.MAX_VALUE;
 }

--- a/service-control/src/main/java/fi/nls/oskari/control/ActionControl.java
+++ b/service-control/src/main/java/fi/nls/oskari/control/ActionControl.java
@@ -99,14 +99,24 @@ public class ActionControl {
      * returned by getName() method.
      */
     public synchronized static void addDefaultControls() {
-
         ServiceLoader<ActionHandler> impl = ServiceLoader.load(ActionHandler.class);
-
-        for (ActionHandler loadedImpl : impl) {
-            if ( loadedImpl != null ) {
-                addAction(loadedImpl.getName(), loadedImpl);
+        List<ActionHandler> sortedList = new ArrayList<>();
+        for (ActionHandler loadedImpl: impl) {
+            if (loadedImpl == null) {
+                continue;
             }
+            sortedList.add(loadedImpl);
         }
+        sortedList.sort(Comparator.comparingInt(ActionHandler::getOrder));
+        sortedList.forEach(loadedImpl -> addAction(loadedImpl.getName(), loadedImpl));
+        /*
+        // After Java 9+ we can use stream
+        impl.stream()
+                .filter( h -> h != null)
+                .map(h -> h.get())
+                .sorted(Comparator.comparingInt(ActionHandler::getOrder))
+                .forEach(loadedImpl -> addAction(loadedImpl.getName(), loadedImpl));
+         */
     }
 
     /**

--- a/service-control/src/main/java/fi/nls/oskari/control/ActionHandler.java
+++ b/service-control/src/main/java/fi/nls/oskari/control/ActionHandler.java
@@ -21,6 +21,13 @@ public abstract class ActionHandler {
         }
         return getClass().getSimpleName();
     }
+    public int getOrder () {
+        if(getClass().isAnnotationPresent(OskariActionRoute.class)) {
+            OskariActionRoute r = getClass().getAnnotation(OskariActionRoute.class);
+            return r.order();
+        }
+        return Integer.MAX_VALUE;
+    }
 	/**
 	 * Handler method for requests
 	 * @param params


### PR DESCRIPTION
This in itself seems to fix issues of OskariComponents initializing in an order that causes errors when the code is compiled with Java 11. The problem was not at compile time but at runtime/startup. It also allows us to define the order in which the components are initialized if we need to. Like MapLayerService component might need to be initialized before some component that uses the service.

Usage (when needed, order defaults to max int and looks like everything works currently on Java 11):
```
@Oskari(order = 1000)
@OskariActionRoute(value="LayerAdmin", order=1500)
```