### PR TITLE
Add param handler to toggle bundles on/off based on client

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/view/GetAppSetupHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/view/GetAppSetupHandler.java
@@ -82,14 +82,14 @@ public class GetAppSetupHandler extends ActionHandler {
        final String[] dynamicBundles = PropertyUtil.getCommaSeparatedList("actionhandler.GetAppSetup.dynamic.bundles");
 
         // Get roles for each dynamic bundle and retrieve bundles from db. Store bundles in <role,bundle> map.
-        Map <String, Bundle> requestedBundles = new HashMap<String, Bundle>();
+        Map <String, Bundle> requestedBundles = new HashMap<>();
         for(String bundleId : dynamicBundles) {
             final String[] rolesForBundle = PropertyUtil.getCommaSeparatedList("actionhandler.GetAppSetup.dynamic.bundle."
                                             + bundleId + ".roles");
 
             for(String roleName : rolesForBundle) {
                 if(!bundlesForRole.containsKey(roleName)) {
-                    bundlesForRole.put(roleName, new ArrayList<Bundle>());
+                    bundlesForRole.put(roleName, new ArrayList<>());
                 }
 
                 List<Bundle> list = bundlesForRole.get(roleName);

--- a/control-base/src/main/java/fi/nls/oskari/control/view/modifier/param/MobileParamHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/view/modifier/param/MobileParamHandler.java
@@ -1,0 +1,89 @@
+package fi.nls.oskari.control.view.modifier.param;
+
+import fi.nls.oskari.annotation.OskariViewModifier;
+import fi.nls.oskari.domain.map.view.Bundle;
+import fi.nls.oskari.domain.map.view.ViewTypes;
+import fi.nls.oskari.util.JSONHelper;
+import fi.nls.oskari.util.PropertyUtil;
+import fi.nls.oskari.view.modifier.ModifierException;
+import fi.nls.oskari.view.modifier.ModifierParams;
+import fi.nls.oskari.view.modifier.ParamHandler;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Configure bundles that should be removed from appsetup for mobile clients.
+ * Configure comma-separated bundle ids in oskari-ext.properties with:
+ *  actionhandler.GetAppSetup.desktopOnly.bundles = publisher2, analyse, statsgrid, mydata, userguide, myplaces3, printout, myplacesimport, feedbackService, coordinatetransformation
+ *  actionhandler.GetAppSetup.mobileOnly.bundles = mobileuserguide
+ */
+@OskariViewModifier("mobile")
+public class MobileParamHandler extends ParamHandler {
+
+    private String[] desktopBundles = null;
+    private String[] mobileBundles = null;
+
+
+    public void init() {
+        super.init();
+        desktopBundles = PropertyUtil.getCommaSeparatedList("actionhandler.GetAppSetup.desktopOnly.bundles");
+        mobileBundles = PropertyUtil.getCommaSeparatedList("actionhandler.GetAppSetup.mobileOnly.bundles");
+    }
+
+    public boolean handleParam(final ModifierParams params) throws ModifierException {
+        if (params.getParamValue() == null) {
+            return false;
+        }
+        if (ViewTypes.PUBLISHED.equals(params.getView().getType())) {
+            // don't modify embedded maps
+            return false;
+        }
+
+        boolean isMobile = params.getParamValue().equalsIgnoreCase("true");
+        if (!isMobile) {
+            // only modify when client requests mobile version
+            return false;
+        }
+        List<String> bundleIds = getBundleIdsAsList(params.getStartupSequence());
+        // remove bundles that are not supported in mobile mode
+        for (String bundleId : desktopBundles) {
+            int index = bundleIds.indexOf(bundleId);
+            if (index != -1) {
+                // bundle is included -> drop it for mobile users
+                // drop bundle from startup and index list
+                params.getStartupSequence().remove(index);
+                bundleIds.remove(index);
+            }
+        }
+        // add bundles for mobile client, this can be used to inject lighter replacements for desktop bundles
+        for (String bundleId : mobileBundles) {
+            if (!bundleIds.contains(bundleId)) {
+                params.getStartupSequence().put(getBundleForStartupSeq(bundleId));
+            }
+        }
+        return false;
+    }
+
+    private JSONObject getBundleForStartupSeq(String bundleid) {
+        Bundle b = new Bundle();
+        b.setName(bundleid);
+        return JSONHelper.createJSONObject(b.getStartup());
+    }
+
+    private List<String> getBundleIdsAsList(JSONArray startupSequence) {
+        List<String> list = new ArrayList<>(startupSequence.length());
+        for(int i = 0; i < startupSequence.length(); ++i) {
+            JSONObject item = startupSequence.optJSONObject(i);
+            if (item == null) {
+                list.add(null);
+            }
+            else {
+                list.add(item.optString("bundlename"));
+            }
+        }
+        return list;
+    }
+}

--- a/service-control/src/main/java/fi/nls/oskari/view/modifier/ViewModifier.java
+++ b/service-control/src/main/java/fi/nls/oskari/view/modifier/ViewModifier.java
@@ -179,14 +179,17 @@ public abstract class ViewModifier {
      * @return Set of bundles listed in the startupsequence
      */
     public Set<String> getBundleIds(final JSONArray startupSeq) {
-        final Set<String> bundles = new HashSet<String>();
+        final Set<String> bundles = new HashSet<>();
         if(startupSeq == null) {
             return bundles;
         }
         for (int i = 0; i < startupSeq.length(); i++) {
-            final JSONObject bundle = (JSONObject) startupSeq.opt(i);
-            final String startupBundleid = bundle.optString("bundlename");
-            if(startupBundleid != null) {
+            JSONObject bundle = startupSeq.optJSONObject(i);
+            if (bundle == null) {
+                continue;
+            }
+            final String startupBundleid = bundle.optString("bundlename", null);
+            if (startupBundleid != null) {
                 bundles.add(startupBundleid);
             }
         }


### PR DESCRIPTION
This allows frontend to send `mobile=true` as parameter when requesting `GetAppSetup` to activate the param handler.

The handler removes any bundles listed in oskari-ext.properties under `actionhandler.GetAppSetup.desktopOnly.bundles` from the appsetup and adds bundles listed under `actionhandler.GetAppSetup.mobileOnly.bundles` to create a more mobile friendly experience for the geoportal.

When combined with desktop-bundles being lazy-loaded when building the frontend this also decreases the size of the JS code that the frontend needs to download.