### PR TITLE
param for announcement api to send no-cache headers on response

### DIFF
--- a/control-announcements/pom.xml
+++ b/control-announcements/pom.xml
@@ -18,5 +18,10 @@
             <groupId>org.oskari</groupId>
             <artifactId>control-base</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/control-announcements/src/main/java/org/oskari/announcements/actions/AnnouncementsHandler.java
+++ b/control-announcements/src/main/java/org/oskari/announcements/actions/AnnouncementsHandler.java
@@ -18,16 +18,20 @@ import java.util.List;
 public class AnnouncementsHandler extends RestActionHandler {
     private AnnouncementsService service = new AnnouncementsServiceMybatisImpl();
 
+    private static final String PARAM_NO_CACHE = "no-cache";
+
     // Handle get announcements
     @Override
     public void handleGet(ActionParameters params) throws ActionException {
-
         try {
             List<Announcement> announcements;
             if (params.getUser().isAdmin()) {
                 announcements = service.getAnnouncements();
             } else {
                 announcements = service.getActiveAnnouncements();
+            }
+            if (params.getHttpParam(PARAM_NO_CACHE, false)){
+                params.getResponse().addHeader("Cache-Control", "no-cache, no-store");
             }
             ResponseHelper.writeResponse(params, AnnouncementsHelper.writeJSON(announcements));
         } catch (Exception e) {
@@ -85,7 +89,9 @@ public class AnnouncementsHandler extends RestActionHandler {
             .withParam("beginDate", announcement.getBeginDate())
             .withParam("endDate", announcement.getEndDate())
             .withParam("options", announcement.getOptions());
-
+            if (params.getHttpParam(PARAM_NO_CACHE, false)){
+                params.getResponse().addHeader("Cache-Control", "no-cache, no-store");
+            }
             ResponseHelper.writeResponse(params, result);
         } catch (Exception e) {
             throw new ActionException("Cannot save announcement", e);


### PR DESCRIPTION
ability to send parameter to announcement api to put Cache-Control, no-cache and no-store headers to response of announcement GET and POST api calls. 