### PR TITLE
Register metadatasearch bundle

### DIFF
--- a/content-resources/src/main/java/flyway/oskari/V2_13_0__register_metadatasearch_bundle.java
+++ b/content-resources/src/main/java/flyway/oskari/V2_13_0__register_metadatasearch_bundle.java
@@ -1,0 +1,18 @@
+package flyway.oskari;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.oskari.helpers.BundleHelper;
+
+import java.sql.Connection;
+
+/**
+ * Register metadatasearch bundle (React impl) as intended replacement for metadatacatalogue bundle (jQuery impl).
+ */
+public class V2_13_0__register_metadatasearch_bundle extends BaseJavaMigration {
+
+    public void migrate(Context context) throws Exception {
+        Connection connection = context.getConnection();
+        BundleHelper.registerBundle(connection, "metadatasearch");
+    }
+}


### PR DESCRIPTION
React.js replacement for `metadatacatalogue`