### PR TITLE
Userlayer geometry srid

### DIFF
--- a/content-resources/src/main/java/flyway/userlayer/V1_0_20__convert_geometry_srid.java
+++ b/content-resources/src/main/java/flyway/userlayer/V1_0_20__convert_geometry_srid.java
@@ -1,0 +1,32 @@
+package flyway.userlayer;
+
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.util.PropertyUtil;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+public class V1_0_20__convert_geometry_srid extends BaseJavaMigration {
+    private static final Logger LOG = LogFactory.getLogger(V1_0_20__convert_geometry_srid.class);
+
+    public void migrate(Context context) throws Exception {
+        Connection connection = context.getConnection();
+        String epsg = PropertyUtil.get("oskari.native.srs", "EPSG:4326");
+        String srs = epsg.substring(epsg.indexOf(':') + 1);
+        int srid = Integer.parseInt(srs);
+        convertGeometries(connection, srid);
+    }
+
+    protected void convertGeometries(Connection conn, int srid) throws SQLException {
+        final String sql = "UPDATE user_layer_data SET geometry = ST_SetSRID(geometry,?)";
+        try (PreparedStatement statement = conn.prepareStatement(sql)) {
+            statement.setInt(1, srid);
+            int updated = statement.executeUpdate();
+            LOG.info("Updated:" , updated, "user_layer_data geometry srid to:", srid);
+        }
+    }
+}

--- a/service-userlayer/src/main/java/org/oskari/map/userlayer/service/UserLayerMapper.java
+++ b/service-userlayer/src/main/java/org/oskari/map/userlayer/service/UserLayerMapper.java
@@ -19,7 +19,7 @@ public interface UserLayerMapper {
     String getUserLayerBbox (final long userLayerId);
 
     //UserLayerData related
-    void insertUserLayerData(@Param ("user_layer_data") final UserLayerData userLayerData, @Param("user_layer_id") final long userLayerId);
+    void insertUserLayerData(@Param ("user_layer_data") final UserLayerData userLayerData, @Param("user_layer_id") final long userLayerId, @Param("srid") final int srid);
     int updateUserLayerData(final UserLayerData userLayerData);
     void deleteUserLayerDataByLayerId (final long userLayerId);
     void deleteUserLayerData (final long id);

--- a/service-userlayer/src/main/resources/org/oskari/map/userlayer/service/UserLayerMapper.xml
+++ b/service-userlayer/src/main/resources/org/oskari/map/userlayer/service/UserLayerMapper.xml
@@ -127,7 +127,7 @@
             #{user_layer_data.uuid},
             #{user_layer_data.feature_id},
             CAST(#{user_layer_data.property_json} as json),
-            ST_GeomFromGeoJSON(#{user_layer_data.geometry})
+            ST_SetSRID(ST_GeomFromGeoJSON(#{user_layer_data.geometry}), #{srid})
         )
     </insert>
 


### PR DESCRIPTION
PostGIS 3+ ST_GeomFromGeoJSON defaults to SRID=4326 if not specified otherwise.  SimpleFeatureCollection -> GeoJSON contains only type  and coordinates, no crs. I think it's easier to use st_setsrid than add crs to every geojson.
https://postgis.net/docs/ST_GeomFromGeoJSON.html

Migrate existing geometries to native srid to fix mixed srid. Some spatial queries doesn't work with mixed srid. Geometries added before PostGIS 3 have srid `0` and geometries added with version 3 have `4326`. Note that coordinates were stored always in native srs/srid. So no need for transformation. Only update info/metadata.

Fixes issue where GeoServer userlayer datastore doesn't use 'loose bbox'  option and GeoServer didn't get features from  db with intersects query and exception were thrown.

Maybe we should  set srid to geometry columns to be sure that geometries doesn't get mixed srid (throws error if inserted geometry srid doesn't match  columns srid) 

![image](https://github.com/oskariorg/oskari-server/assets/22147092/186acce0-1510-47c3-ba86-6d3220f65c64)

Like: `UpdateGeometrySRID('user_layer_data','geometry',${srid});`

Didn't set for now because `vuser_layer_data` view uses `user_layer_data` table. Have to drop view before set and is view needed anymore if we are aiming to use direct queries to db (without GeoServer).