### PR TITLE
Add 'loose bbox' query for testing performance on user layers

### DIFF
--- a/service-userlayer/src/main/java/org/oskari/map/userlayer/service/UserLayerDbServiceMybatisImpl.java
+++ b/service-userlayer/src/main/java/org/oskari/map/userlayer/service/UserLayerDbServiceMybatisImpl.java
@@ -291,7 +291,7 @@ public class UserLayerDbServiceMybatisImpl extends UserLayerDbService {
                 .orElse(null);
 
             int nativeSrid = getSRID(nativeSrsName);
-            List<UserLayerData> features = mapper.findAllByBBOX(layerId, bbox.getMinX(), bbox.getMinY(), bbox.getMaxX(), bbox.getMaxY(), nativeSrid);
+            List<UserLayerData> features = mapper.findAllByLooseBBOX(layerId, bbox.getMinX(), bbox.getMinY(), bbox.getMaxX(), bbox.getMaxY(), nativeSrid);
 
             JSONObject featureCollection = this.toGeoJSONFeatureCollection(features, targetSrsName != null ? targetSrsName : nativeSrsName);
             return featureCollection;

--- a/service-userlayer/src/main/java/org/oskari/map/userlayer/service/UserLayerMapper.java
+++ b/service-userlayer/src/main/java/org/oskari/map/userlayer/service/UserLayerMapper.java
@@ -26,6 +26,16 @@ public interface UserLayerMapper {
     void deleteUserLayerDataByLayerId (final long userLayerId);
     void deleteUserLayerData (final long id);
 
+    /**
+     * Returns features given a bbox and layer id.
+     * @param layerId
+     * @param minX
+     * @param minY
+     * @param maxX
+     * @param maxY
+     * @param srid
+     * @return
+     */
     @ResultMap("UserLayerDataResult")
     @Select("SELECT " +
             " id, " +
@@ -50,5 +60,41 @@ public interface UserLayerMapper {
                                 @Param("maxX") double maxX,
                                 @Param("maxY") double maxY,
                                 @Param("srid") int srid);
+
+    /**
+     * Returns features given a bbox and layer id.
+     * Imitates Geoserver/geotools "loose bbox" sql query.
+     * It should be faster than intersects as it relies on _feature bounding box_ intersecting with given
+     * bbox instead of the _actual feature geometry_.
+     * @param layerId
+     * @param minX
+     * @param minY
+     * @param maxX
+     * @param maxY
+     * @param srid
+     * @return
+     */
+    @ResultMap("UserLayerDataResult")
+    @Select("SELECT " +
+            " id, " +
+            " user_layer_id, " +
+            " uuid, " +
+            " feature_id, " +
+            " property_json, " +
+            " ST_ASTEXT(geometry) as wkt, " +
+            " ST_SRID(geometry) as srid, " +
+            " created, " +
+            " updated " +
+            " FROM user_layer_data " +
+            " WHERE "+
+            " user_layer_id = #{layerId} " +
+            " AND " +
+            " geometry && ST_MAKEENVELOPE(#{minX}, #{minY}, #{maxX}, #{maxY}, #{srid})")
+    List<UserLayerData> findAllByLooseBBOX(@Param("layerId") int layerId,
+                                      @Param("minX") double minX,
+                                      @Param("minY") double minY,
+                                      @Param("maxX") double maxX,
+                                      @Param("maxY") double maxY,
+                                      @Param("srid") int srid);
 
 }


### PR DESCRIPTION
Trying out queries on prod this gives a small performance boost from 80ms to 50ms on my dataset for the query. 

However we should take a better look at the code that is run after the query. It looks like we are:
1) querying for WKT
2) transforming the coordinates and writing out geojson features
3) building a GeoTools SimpleFeatureCollection from the geojson features
4) transforming the coordinates again
5) writing out geojson.

We could return the SimpleFeatureCollection from db service directly and reduce the amount of code that needs to run and handle the features before we write it out as a geojson string for the client.