### PR TITLE
correct param name for password

### DIFF
--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/UsersHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/UsersHandler.java
@@ -30,7 +30,7 @@ public class UsersHandler extends RestActionHandler {
     private static final String PARAM_FIRSTNAME = "firstName";
     private static final String PARAM_LASTNAME = "lastName";
     private static final String PARAM_SCREENNAME = "user";
-    private static final String PARAM_PASSWORD = "pass";
+    private static final String PARAM_PASSWORD = "password";
     private static final String PARAM_EMAIL = "email";
     private static final String PARAM_LIMIT = "limit";
     private static final String PARAM_OFFSET = "offset";


### PR DESCRIPTION
-adding a user failed because of the wrong param name in be