### PR TITLE
Switch BasicDataSource to HikariCP and update MyBatis

### DIFF
--- a/control-statistics/src/test/java/fi/nls/oskari/control/statistics/GetRegionInfoHandlerIT.java
+++ b/control-statistics/src/test/java/fi/nls/oskari/control/statistics/GetRegionInfoHandlerIT.java
@@ -1,58 +1,36 @@
 package fi.nls.oskari.control.statistics;
 
-import org.apache.commons.dbcp2.BasicDataSource;
+import fi.nls.oskari.control.ActionException;
+import fi.nls.oskari.util.PropertyUtil;
+import fi.nls.test.util.TestHelper;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import fi.nls.oskari.control.ActionException;
-import fi.nls.oskari.db.DatasourceHelper;
-import fi.nls.oskari.util.PropertyUtil;
+import java.sql.SQLException;
 
-import static org.junit.Assert.*;
-
-import java.lang.reflect.Field;
-import javax.naming.NamingException;
-import javax.sql.DataSource;
+import static org.junit.Assert.assertEquals;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(DatasourceHelper.class)
-@PowerMockIgnore( {"javax.management.*"}) 
+@PowerMockIgnore({"javax.management.*"})
 public class GetRegionInfoHandlerIT {
-    public static class DatasourceHelperMock extends DatasourceHelper {
-        public DatasourceHelperMock() {
-            super();
-        }
-        @Override
-        public DataSource getDataSource(String name) {
-            BasicDataSource basicDataSource = new BasicDataSource();
-            basicDataSource.setDriverClassName("org.postgresql.Driver");
-            basicDataSource.setUrl(PropertyUtil.get("db.url"));
-            basicDataSource.setUsername(PropertyUtil.get("db.username"));
-            basicDataSource.setPassword(PropertyUtil.get("db.password"));
-            return basicDataSource;
-        }
-    }
-    
+
     @BeforeClass
-    public static void init() throws NamingException, IllegalArgumentException,
-        IllegalAccessException {
-        PropertyUtil.loadProperties("/oskari-ext.properties");
-        Field field = PowerMockito.field(DatasourceHelper.class, "INSTANCE");
-        field.set(DatasourceHelper.class, new DatasourceHelperMock());
+    public static void init() throws IllegalArgumentException, SQLException {
+        TestHelper.registerTestDataSource();
     }
+
     @AfterClass
     public static void tearDown() {
         PropertyUtil.clearProperties();
     }
-    @Test(timeout=120000)
+
+    @Test(timeout = 120000)
     public void testGettingRegionInfo() throws ActionException, JSONException {
         GetRegionsHandler handler = new GetRegionsHandler();
         handler.init();
@@ -60,7 +38,8 @@ public class GetRegionInfoHandlerIT {
         JSONObject result = handler.getRegionInfoJSON(9, "EPSG:3067");
         assertEquals("Alajärvi", result.getJSONObject("005").getString("name").toString());
     }
-    @Test(timeout=120000)
+
+    @Test(timeout = 120000)
     public void testGettingRegionInfoForErva() throws ActionException, JSONException {
         GetRegionsHandler handler = new GetRegionsHandler();
         handler.init();

--- a/pom.xml
+++ b/pom.xml
@@ -84,9 +84,11 @@
         <fi.mml.nameregister.version>1.0</fi.mml.nameregister.version>
 
         <jetty.version>9.4.51.v20230217</jetty.version>
-        <mybatis.version>3.5.11</mybatis.version>
+        <mybatis.version>3.5.13</mybatis.version>
         <flyway.version>9.12.0</flyway.version>
         <postgresql.version>42.5.1</postgresql.version>
+        <hikaricp.version>4.0.3</hikaricp.version>
+
         <!-- https://github.com/spring-projects/spring-data-redis/blob/2.7.x/pom.xml#L28 -->
         <jedis.version>3.8.0</jedis.version>
         <quartz-scheduler.version>2.3.2</quartz-scheduler.version>
@@ -440,6 +442,11 @@
                 <version>${flyway.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>com.zaxxer</groupId>
+                <artifactId>HikariCP</artifactId>
+                <version>${hikaricp.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>

--- a/service-base/pom.xml
+++ b/service-base/pom.xml
@@ -23,9 +23,8 @@
             <artifactId>commons-text</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-dbcp2</artifactId>
-            <scope>compile</scope>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-collections</groupId>

--- a/service-base/src/main/java/fi/nls/oskari/db/DatasourceHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/db/DatasourceHelper.java
@@ -5,7 +5,6 @@ import com.zaxxer.hikari.HikariDataSource;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.util.PropertyUtil;
-import org.apache.commons.dbcp2.BasicDataSource;
 
 import javax.naming.Context;
 import javax.naming.InitialContext;
@@ -228,10 +227,8 @@ public class DatasourceHelper {
         for (DataSource ds : localDataSources.values()) {
             try {
                 // try to close it
-                if (ds instanceof BasicDataSource) {
-                    ((BasicDataSource)ds).close();
-                } else if (ds instanceof Closeable) {
-                    ((AutoCloseable) ds).close();
+                if (ds instanceof Closeable) {
+                    ((Closeable) ds).close();
                 } else if (ds instanceof AutoCloseable) {
                     ((AutoCloseable) ds).close();
                 }

--- a/service-base/src/main/java/fi/nls/oskari/db/DatasourceHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/db/DatasourceHelper.java
@@ -1,5 +1,7 @@
 package fi.nls.oskari.db;
 
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.util.PropertyUtil;
@@ -138,22 +140,29 @@ public class DatasourceHelper {
     public DataSource createDataSource(final String prefix) {
         // check if we have the named connection already
         String poolName = getOskariDataSourceName(prefix);
-        BasicDataSource ds = (BasicDataSource) getDataSource(null, poolName);
+        DataSource ds = getDataSource(null, poolName);
         if (ds != null) {
             return ds;
         }
 
-        final BasicDataSource dataSource = new BasicDataSource();
         ConnectionInfo info = getPropsForDS(prefix);
 
-        dataSource.setDriverClassName(info.driver);
-        dataSource.setUrl(info.url);
-        dataSource.setUsername(info.user);
-        dataSource.setPassword(info.pass);
-        dataSource.setTimeBetweenEvictionRunsMillis(-1);
-        dataSource.setTestOnBorrow(true);
-        dataSource.setValidationQuery("SELECT 1");
-        dataSource.setValidationQueryTimeout(100);
+        HikariConfig config = new HikariConfig();
+        config.setPoolName(poolName);
+        config.setDriverClassName(info.driver);
+        config.setJdbcUrl(info.url);
+        config.setUsername(info.user);
+        config.setPassword(info.pass);
+        config.setMaximumPoolSize(10);
+        // config.addDataSourceProperty( "ApplicationName" , "should we provide one here or let users set this as part of the url?" );
+
+        // Setting this statement cache is crucial for queries using postgis geometries like on userlayers with
+        // WHERE user_layer_id = #{layerId} AND  geometry && ST_MAKEENVELOPE(#{minX}, #{minY}, #{maxX}, #{maxY}, #{srid})
+        // Otherwise calling the query repeatedly the performance crashes from 50ms to around 4 seconds or so
+        // https://stackoverflow.com/questions/64465108/spring-boot-jdbctemplate-disable-statement-cache
+        config.addDataSourceProperty( "preparedStatementCacheQueries" , "0" );
+
+        HikariDataSource dataSource = new HikariDataSource(config);
         try {
             registerDataSource(poolName, dataSource);
         } catch (SQLException e) {

--- a/service-permissions/src/test/java/org/oskari/permissions/PermissionServiceMybatisImplPerfTest.java
+++ b/service-permissions/src/test/java/org/oskari/permissions/PermissionServiceMybatisImplPerfTest.java
@@ -1,11 +1,7 @@
 package org.oskari.permissions;
 
 import fi.nls.oskari.domain.GuestUser;
-import fi.nls.oskari.domain.map.OskariLayer;
-import fi.nls.test.util.ResourceHelper;
 import fi.nls.test.util.TestHelper;
-import org.apache.commons.dbcp2.BasicDataSource;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -16,9 +12,6 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.sql.SQLException;
 import java.util.List;
-import java.util.Optional;
-
-import static org.junit.Assert.*;
 
 @Ignore
 public class PermissionServiceMybatisImplPerfTest {
@@ -27,12 +20,7 @@ public class PermissionServiceMybatisImplPerfTest {
 
     @BeforeClass
     public static void init() throws SQLException, IOException, URISyntaxException {
-        BasicDataSource dataSource = new BasicDataSource();
-
-        dataSource.setDriverClassName("org.postgresql.Driver");
-        dataSource.setUrl("jdbc:postgresql://localhost:5432/oskaridb");
-        dataSource.setUsername("oskari");
-        dataSource.setPassword("oskari");
+        DataSource dataSource = TestHelper.createMemDBforUnitTest();
         permissionService = new PermissionServiceMybatisImpl(dataSource);
     }
 

--- a/service-statistics/src/test/java/fi/nls/oskari/control/statistics/plugins/StatisticalDatasourcePluginManagerIT.java
+++ b/service-statistics/src/test/java/fi/nls/oskari/control/statistics/plugins/StatisticalDatasourcePluginManagerIT.java
@@ -2,12 +2,11 @@ package fi.nls.oskari.control.statistics.plugins;
 
 import fi.nls.oskari.control.statistics.data.*;
 import fi.nls.oskari.control.statistics.plugins.db.StatisticalDatasource;
-import org.apache.commons.dbcp2.BasicDataSource;
+import fi.nls.test.util.TestHelper;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -18,12 +17,10 @@ import fi.nls.oskari.util.PropertyUtil;
 
 import static org.junit.Assert.*;
 
-import java.lang.reflect.Field;
+import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-
-import javax.sql.DataSource;
 
 import static org.hamcrest.CoreMatchers.*;
 
@@ -33,27 +30,10 @@ import static org.hamcrest.CoreMatchers.*;
 public class StatisticalDatasourcePluginManagerIT {
 
     final private StatisticalDatasourcePluginManager manager = StatisticalDatasourcePluginManager.getInstance();
-
-    public static class DatasourceHelperMock extends DatasourceHelper {
-        public DatasourceHelperMock() {
-            super();
-        }
-        @Override
-        public DataSource getDataSource(String name) {
-            BasicDataSource basicDataSource = new BasicDataSource();
-            basicDataSource.setDriverClassName("org.postgresql.Driver");
-            basicDataSource.setUrl(PropertyUtil.get("db.url"));
-            basicDataSource.setUsername(PropertyUtil.get("db.username"));
-            basicDataSource.setPassword(PropertyUtil.get("db.password"));
-            return basicDataSource;
-        }
-    }
     
     @BeforeClass
-    public static void init() throws IllegalArgumentException, IllegalAccessException {
-        PropertyUtil.loadProperties("/oskari-ext.properties");
-        Field field = PowerMockito.field(DatasourceHelper.class, "INSTANCE");
-        field.set(DatasourceHelper.class, new DatasourceHelperMock());
+    public static void init() throws IllegalArgumentException, IllegalAccessException, SQLException {
+        TestHelper.registerTestDataSource();
     }
     @AfterClass
     public static void tearDown() {

--- a/service-statistics/src/test/java/fi/nls/oskari/control/statistics/plugins/kapa/KapaPluginIT.java
+++ b/service-statistics/src/test/java/fi/nls/oskari/control/statistics/plugins/kapa/KapaPluginIT.java
@@ -25,14 +25,12 @@ import static org.junit.Assert.*;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringBufferInputStream;
-import java.lang.reflect.Field;
 import java.net.HttpURLConnection;
 import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import javax.sql.DataSource;
 
 import static org.mockito.Mockito.*;
 


### PR DESCRIPTION
Continues solving the performance issues mentioned in https://github.com/oskariorg/oskari-server/pull/1017. The MVP change here is this:

```
        config.addDataSourceProperty( "preparedStatementCacheQueries" , "0" );
```

Finally found the same issue after debugging and profiling the running app. After 10 calls to findAllByLooseBBOX() in #1017 the performance crashed from 50ms to about 4 seconds per call. First suspected it was related to db connections running out/leaking somehow, hence changing the connection pool impl and all. But with a profiler I discovered it was actually `org.postgresql.jdbc.PgPreparedStatement.execute()` that was slow. With that knowledge I finally found this https://stackoverflow.com/questions/64465108/spring-boot-jdbctemplate-disable-statement-cache that described the issue perfectly even if it was a different tech stack.
