### PR TITLE
Sotkanet region sets mapping for Hyvinvointialue

### DIFF
--- a/service-statistics-sotka/src/main/java/fi/nls/oskari/control/statistics/plugins/sotka/parser/SotkaIndicatorParser.java
+++ b/service-statistics-sotka/src/main/java/fi/nls/oskari/control/statistics/plugins/sotka/parser/SotkaIndicatorParser.java
@@ -27,12 +27,7 @@ public class SotkaIndicatorParser {
 
     public StatisticalIndicator parse(JSONObject json, Map<String, Long> sotkaLayersToOskariLayers) {
         try {
-            StatisticalIndicator indicator = createIndicator(json, sotkaLayersToOskariLayers);
-            if(indicator == null) {
-                return null;
-            }
-            setupMetadata(indicator);
-            return indicator;
+            return createIndicator(json, sotkaLayersToOskariLayers);
         } catch (Exception e) {
             LOG.error("Error in mapping Sotka Indicators response to Oskari model: " + e.getMessage(), e);
         }
@@ -72,32 +67,6 @@ public class SotkaIndicatorParser {
             String indicatorId = String.valueOf(json.getInt("id"));
             ind.setId(indicatorId);
 
-            // parse layers first since if none match -> we don't need to parse the rest
-            JSONObject classificationObj = json.optJSONObject("classifications");
-            if (classificationObj == null || !classificationObj.has("region")) {
-                LOG.error("Region missing from indicator: " + indicatorId + ": " + String.valueOf(ind.getName()));
-                return null;
-            }
-            List<String> sotkaRegionsets = getDeclaredRegionsets(classificationObj);
-            if (sotkaRegionsets.isEmpty()) {
-                // if sotkanet doesn't specify any region set to have data -> assume it has data for all
-                // new indicators don't seem to have this defined anymore
-                // we can always show the user an error that we didn't get any data for the selection
-                // but if we don't do this we won't get data for "Hyvinvointialueet" as an example
-                sotkaLayersToOskariLayers.values()
-                        .forEach(oskariLayerId -> ind.addLayer(new StatisticalIndicatorLayer(oskariLayerId, indicatorId)));
-            } else {
-                sotkaRegionsets.forEach(regionType -> {
-                    Long oskariLayerId = sotkaLayersToOskariLayers.get(regionType);
-                    if (oskariLayerId != null) {
-                        ind.addLayer(new StatisticalIndicatorLayer(oskariLayerId, indicatorId));
-                    }
-                });
-            }
-            if (ind.getLayers().isEmpty()) {
-                return null;
-            }
-
             // layers ok - proceed with the rest of the data
             JSONObject nameJson = json.getJSONObject("title");
             Iterator<String> names = nameJson.keys();
@@ -107,14 +76,11 @@ public class SotkaIndicatorParser {
             }
             ind.setSource(toLocalizationMap(json.getJSONObject("organization").getJSONObject("title")));
 
-            // Note that the following will just skip the "region" part already projected into layers.
-            ind.setDataModel(createModel(json.getJSONObject("classifications")));
+            return setupMetadata(ind, sotkaLayersToOskariLayers);
         } catch (JSONException e) {
-            e.printStackTrace();
-            LOG.error("Could not read data from Sotka Indicator JSON.", e);
+            LOG.error(e, "Could not read data from Sotka Indicator JSON.");
             return null;
         }
-        return ind;
     }
     /**
      * Get values under classification.region.values:
@@ -349,7 +315,7 @@ Parsing Sotkanet metadata/JSON like this:
 	"groups": [200, 303, 730, 149, 103]
 }
  */
-    private void setupMetadata(StatisticalIndicator ind) throws APIException, JSONException {
+    private StatisticalIndicator setupMetadata(StatisticalIndicator ind, Map<String, Long> sotkaLayersToOskariLayers) throws APIException, JSONException {
 
         // fetch data
         SotkaRequest specificIndicatorRequest = SotkaRequest.getInstance(IndicatorMetadata.NAME);
@@ -358,11 +324,55 @@ Parsing Sotkanet metadata/JSON like this:
         String metadata = specificIndicatorRequest.getData();
         JSONObject json = new JSONObject(metadata);
 
+        // parse layers first since if none match -> we don't need to parse the rest
+        JSONObject classificationObj = json.optJSONObject("classifications");
+        if (classificationObj == null || !classificationObj.has("region")) {
+            LOG.error("Region missing from indicator: ", ind.getId(), ": ", ind.getName());
+            return null;
+        }
+        List<String> sotkaRegionsets = getDeclaredRegionsets(classificationObj);
+        sotkaRegionsets.forEach(regionType -> {
+            Long oskariLayerId = sotkaLayersToOskariLayers.get(regionType);
+            if (oskariLayerId != null) {
+                ind.addLayer(new StatisticalIndicatorLayer(oskariLayerId, ind.getId()));
+            }
+        });
+        if (ind.getLayers().isEmpty()) {
+            // we can't show this indicator since it doesn't link to any region set
+            // if at this point we don't have layers -> ignore the indicator by returning null
+            return null;
+        }
+
         // parse the data
         // Later on we might want to add information about the "interpretation", "limits", "legislation", and source "description" also here.
         if (json.has("description")) {
-            ind.setDescription(toLocalizationMap(json.getJSONObject("description")));
+            Map<String, String> desc = toLocalizationMap(json.optJSONObject("description"));
+            Map<String, String> interpretation = toLocalizationMap(json.optJSONObject("interpretation"));
+            Map<String, String> limits = toLocalizationMap(json.optJSONObject("limits"));
+            Map<String, String> legislation = toLocalizationMap(json.optJSONObject("legislation"));
+            desc.keySet().forEach(lang -> {
+                String langDesc = desc.get(lang);
+                String additionalDesc = interpretation.getOrDefault(lang, "");
+                if (!additionalDesc.isEmpty()) {
+                    langDesc += " \r\n\r\n" + additionalDesc;
+                }
+                additionalDesc = limits.getOrDefault(lang, "");
+                if (!additionalDesc.isEmpty()) {
+                    langDesc += " \r\n\r\n" + additionalDesc;
+                }
+                additionalDesc = legislation.getOrDefault(lang, "");
+                if (!additionalDesc.isEmpty()) {
+                    langDesc += " \r\n\r\n" + additionalDesc;
+                }
+                desc.put(lang, langDesc);
+            });
+            ind.setDescription(desc);
         }
+
+        // Parse the parameters that are used by the indicator
+        // Note that the data model will just skip the "region" part as it's the parameter for region sets/layers
+        ind.setDataModel(createModel(classificationObj));
+
         if (json.has("range")) {
             JSONObject range = json.getJSONObject("range");
             int start = range.getInt("start");
@@ -371,7 +381,8 @@ Parsing Sotkanet metadata/JSON like this:
             // TODO: Update this before the year 3000. Validating to prevent a DOS attack using insane numbers.
             if (start < 1000 || end > 3000) {
                 LOG.warn("Year range doesn't make sense, ignoring");
-                return;
+                // return it without the "year" dimension
+                return ind;
             }
             List<String> allowedYears = new ArrayList<>();
             for (int year = start; year <= end; year++) {
@@ -380,10 +391,14 @@ Parsing Sotkanet metadata/JSON like this:
             StatisticalIndicatorDataDimension yearSelector = new StatisticalIndicatorDataDimension("year", allowedYears);
             ind.getDataModel().addDimension(yearSelector);
         }
+        return ind;
     }
 
     private Map<String, String> toLocalizationMap(JSONObject json) throws JSONException {
         Map<String, String> localizationMap = new HashMap<>();
+        if (json == null) {
+            return localizationMap;
+        }
         @SuppressWarnings("unchecked")
         Iterator<String> names = json.keys();
         while (names.hasNext()) {

--- a/service-statistics-sotka/src/main/java/fi/nls/oskari/control/statistics/plugins/sotka/parser/SotkaIndicatorParser.java
+++ b/service-statistics-sotka/src/main/java/fi/nls/oskari/control/statistics/plugins/sotka/parser/SotkaIndicatorParser.java
@@ -73,11 +73,12 @@ public class SotkaIndicatorParser {
             ind.setId(indicatorId);
 
             // parse layers first since if none match -> we don't need to parse the rest
-            if (!json.getJSONObject("classifications").has("region")) {
+            JSONObject classificationObj = json.optJSONObject("classifications");
+            if (classificationObj == null || !classificationObj.has("region")) {
                 LOG.error("Region missing from indicator: " + indicatorId + ": " + String.valueOf(ind.getName()));
                 return null;
             }
-            List<String> sotkaRegionsets = getDeclaredRegionsets(json.optJSONObject("classifications"));
+            List<String> sotkaRegionsets = getDeclaredRegionsets(classificationObj);
             if (sotkaRegionsets.isEmpty()) {
                 // if sotkanet doesn't specify any region set to have data -> assume it has data for all
                 // new indicators don't seem to have this defined anymore
@@ -115,17 +116,30 @@ public class SotkaIndicatorParser {
         }
         return ind;
     }
-
     /**
      * Get values under classification.region.values:
         "classifications": {
-            "sex": {
-                "values": ["male", "female", "total"]
-            },
             "region": {
+               "title: {
+                    "fi": "Kunta, seutukunta, maakunta, hyvinvointialue, sairaanhoitopiiri, yhteistyöalue, aluehallintoviraston alue, suuralue, Manner-Suomi/Ahvenanmaa, erityisvastuualue, koko maa",
+                    ...
+                },
                "values": ["Kunta", "Maakunta", "Erva", "Aluehallintovirasto", "Sairaanhoitopiiri", "Maa", "Suuralue", "Seutukunta", "Nuts1"]
-            }
+            },
+            ...
         }
+
+     OR use title if values is empty?
+
+     "classifications": {
+        "region": {
+            "title: {
+                "fi": "Hyvinvointialue",
+                 ...
+            },
+            "values": []
+        }
+     }
      * @param indicatorClassification
      * @return
      */

--- a/service-statistics-sotka/src/main/java/fi/nls/oskari/control/statistics/plugins/sotka/parser/SotkaIndicatorParser.java
+++ b/service-statistics-sotka/src/main/java/fi/nls/oskari/control/statistics/plugins/sotka/parser/SotkaIndicatorParser.java
@@ -351,18 +351,19 @@ Parsing Sotkanet metadata/JSON like this:
             Map<String, String> limits = toLocalizationMap(json.optJSONObject("limits"));
             Map<String, String> legislation = toLocalizationMap(json.optJSONObject("legislation"));
             desc.keySet().forEach(lang -> {
+                // add as HTML as sotkanet includes HTML in description anyways
                 String langDesc = desc.get(lang);
                 String additionalDesc = interpretation.getOrDefault(lang, "");
                 if (!additionalDesc.isEmpty()) {
-                    langDesc += " \r\n\r\n" + additionalDesc;
+                    langDesc += "<p>" + additionalDesc + "</p>";
                 }
                 additionalDesc = limits.getOrDefault(lang, "");
                 if (!additionalDesc.isEmpty()) {
-                    langDesc += " \r\n\r\n" + additionalDesc;
+                    langDesc += "<p>" + additionalDesc + "</p>";
                 }
                 additionalDesc = legislation.getOrDefault(lang, "");
                 if (!additionalDesc.isEmpty()) {
-                    langDesc += " \r\n\r\n" + additionalDesc;
+                    langDesc += "<p>" + additionalDesc + "</p>";
                 }
                 desc.put(lang, langDesc);
             });

--- a/service-statistics-sotka/src/main/java/fi/nls/oskari/control/statistics/plugins/sotka/parser/SotkaIndicatorParser.java
+++ b/service-statistics-sotka/src/main/java/fi/nls/oskari/control/statistics/plugins/sotka/parser/SotkaIndicatorParser.java
@@ -164,6 +164,20 @@ public class SotkaIndicatorParser {
             }
             list.add(sotkaRegionCategory.toLowerCase());
         }
+        if (sotkaRegionsets.length() != 0) {
+            return list;
+        }
+        // empty list of declared region sets
+        // -> fallback trying to detect region set from classification.region.title.fi
+        JSONObject titleObj = regionClassification.optJSONObject("title");
+        if (titleObj == null) {
+            return list;
+        }
+        // finnish service and our regionTypes are finnish so a fair assumption
+        String finnishTitle = titleObj.optString("fi", null);
+        if (finnishTitle != null) {
+            list.add(finnishTitle.toLowerCase());
+        }
         return list;
     }
 


### PR DESCRIPTION
This allows us to show data for Hyvinvointialueet from Sotkanet. However we make an educated guess about which regionsets _can be used_ for some of the indicators (mostly the ones that do have data for hyvinvointialueet). Sotkanet has a mechanism to tell which region sets they have data for:

- Hyvinvointialue: https://sotkanet.fi/rest/1.1/indicators/3815
 
Notice the missing/empty array of classifications.region.values
```
"classifications": {
    "region": {
        "title": {
            "fi": "Hyvinvointialue",
            "en": "The wellbeing services county",
            "sv": "Välfärdsområde"
        },
        "values": []
    }
    
}
```

- Non-hyvinvointialue indicator: https://sotkanet.fi/rest/1.1/indicators/900
```
"classifications": {
    "region": {
        "title": {
            "fi": "Kunta, seutukunta, maakunta, hyvinvointialue, sairaanhoitopiiri, yhteistyöalue, aluehallintoviraston alue, suuralue, Manner-Suomi/Ahvenanmaa, erityisvastuualue, koko maa",
            "en": "Municipality, sub-region, region, the wellbeing services county, hospital district, collaborative area, area for the regional state administrative agency, major region, university hospital special responsibility area, Mainland Finland/Åland, whole country",
            "sv": "Kommun, ekonomisk region, landskap, välfärdsområde, sjukvårdsdistrikt, samarbetsområde, området för regionförvaltningsverket, storområde, specialupptagningsområde, Fastlandsfinland/Åland, hela landet"
        },
        "values": [
            "Suuralue",
            "Maa",
            "Sairaanhoitopiiri",
            "Aluehallintovirasto",
            "Nuts1",
            "Kunta",
            "Erva",
            "Seutukunta",
            "Maakunta"
        ]
    }
}
```

We rely on that values array to filter out regionsets that can't be used with the indicator, but the ones with Hyvinvointialue data seem to have the empty array. First tried assuming no region values means there's data for all the region sets. However this doesn't appear to be very user-friendly as it looks like there's no data in these indicators for any other region set that isn't Hyvinvointialue.

Next added logic to detect region values for missing values from the region title:
```
    "region": {
        "title": {
            "fi": "Hyvinvointialue",
            ...
```
This makes more sense as this (case-insensitively) seems to be the same as the category for regions in https://sotkanet.fi/rest/1.1/regions. We use the category values to match the classification region values already.
```
{
    "id": 961,
    "code": "01",
    "category": "HYVINVOINTIALUE",
    "title": {
        "fi": "Itä-Uudenmaan hyvinvointialue",
        "en": "East Uusimaa wellbeing services county",
        "sv": "Östra Nylands välfärdsområde"
    }
}
```
Needed to change the logic where the indicator parameters/region sets are parsed. It was previously parsed from the response of /indicators listing, BUT for these Hyvinvointialue indicators the values are missing from that one. So changed all indicators to parse parameters from the /indicators/[id] response since that _should_ be the correct place for these (even if it's sometimes conflicting with the /indicators response).