### PR TITLE
Minor Spring version bump

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,15 +49,15 @@
         <!-- Value comes from profile when needed -->
         <module.build.config></module.build.config>
 
-        <spring.version>5.3.28</spring.version>
-        <spring-security.version>5.7.9</spring-security.version>
+        <spring.version>5.3.30</spring.version>
+        <spring-security.version>5.7.11</spring-security.version>
         <!--
         session-bom 2021.2.0 uses 2.7.0 from session
-        https://github.com/spring-projects/spring-session/blob/2.7.2/gradle/dependency-management.gradle
-        which is aligned with core 5.3.28 and security 5.7.9 versions
-        https://github.com/spring-projects/spring-session/releases/tag/2.7.2
-        https://search.maven.org/artifact/org.springframework.session/spring-session-bom/2021.2.0/pom -->
-        <spring.session.version>2021.2.2</spring.session.version>
+        https://github.com/spring-projects/spring-session/blob/2.7.4/gradle/dependency-management.gradle
+        which is aligned with core 5.3.30 and security 5.7.11 versions
+        https://github.com/spring-projects/spring-session/releases/tag/2.7.4
+        https://central.sonatype.com/artifact/org.springframework.session/spring-session-bom/2021.2.3 -->
+        <spring.session.version>2021.2.3</spring.session.version>
 
         <javax.servlet.version>3.1.0</javax.servlet.version>
         <javax.servlet.jsp.version>2.3.3</javax.servlet.jsp.version>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <jetty.version>9.4.51.v20230217</jetty.version>
         <mybatis.version>3.5.13</mybatis.version>
         <flyway.version>9.12.0</flyway.version>
-        <postgresql.version>42.5.1</postgresql.version>
+        <postgresql.version>42.6.0</postgresql.version>
         <hikaricp.version>4.0.3</hikaricp.version>
 
         <!-- https://github.com/spring-projects/spring-data-redis/blob/2.7.x/pom.xml#L28 -->


### PR DESCRIPTION
Spring 5.3.28 -> 5.3.30
Spring security 5.7.9 -> 5.7.11
Spring session bom 2021.2.2 -> 2021.2.3

Also updated the Postgresql jdbc version to match the binary distribution on the Jetty package.