### PR TITLE
Bump logging libs

### DIFF
--- a/MigrationGuide.md
+++ b/MigrationGuide.md
@@ -1,5 +1,20 @@
 # Migration guide
 
+## 2.13.0
+
+Logging dependencies updated. Oskari-based applications need to update this dependency:
+
+```
+<dependency>
+    <groupId>org.apache.logging.log4j</groupId>
+    <artifactId>log4j-slf4j-impl</artifactId>
+</dependency>
+```
+to:
+```
+    <artifactId>log4j-slf4j2-impl</artifactId>
+```
+
 ## 2.11.0
 
 PostgreSQL 11 is now the minimum version supported (FlywayDB dependency).

--- a/pom.xml
+++ b/pom.xml
@@ -107,9 +107,9 @@
         <xmlunit.version>1.6</xmlunit.version>
         <h2database.version>2.2.220</h2database.version>
 
-        <log4j.version>2.20.0</log4j.version>
+        <log4j.version>2.22.1</log4j.version>
 
-        <slf4j.version>1.7.36</slf4j.version>
+        <slf4j.version>2.0.11</slf4j.version>
         <metrics.version>4.1.0</metrics.version>
         <xom.version>1.2.5</xom.version>
     </properties>
@@ -859,20 +859,21 @@
             </dependency>
 
             <dependency>
+                <!-- Includes slf4j-api and log4j-api -->
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-slf4j2-impl</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <!-- dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-slf4j-impl</artifactId>
-                <version>${log4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
                 <version>${log4j.version}</version>
-            </dependency>
+            </dependency -->
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -859,12 +859,14 @@
             </dependency>
 
             <dependency>
-                <!-- Includes slf4j-api and log4j-api -->
+                <!-- Includes slf4j-api and log4j-api,
+                 but control-admin needs log4j stuff anyway for LoggerHandler
+                 so might as well declare them here -->
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-slf4j2-impl</artifactId>
                 <version>${log4j.version}</version>
             </dependency>
-            <!-- dependency>
+            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.version}</version>
@@ -873,7 +875,7 @@
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
                 <version>${log4j.version}</version>
-            </dependency -->
+            </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-core</artifactId>

--- a/service-logging/pom.xml
+++ b/service-logging/pom.xml
@@ -16,12 +16,8 @@
             <artifactId>service-base</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/webapp-setup/pom.xml
+++ b/webapp-setup/pom.xml
@@ -36,7 +36,7 @@
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
- SLF4J 1.7.36 -> 2.0.11
- Log4J2 2.20.0 -> 2.22.1

Note! Apps will need to update the dependency as well.