### PR TITLE
Allow announcements to be published without external config

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/view/AppSetupHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/view/AppSetupHandler.java
@@ -143,7 +143,8 @@ public class AppSetupHandler extends RestActionHandler {
                 ViewModifier.BUNDLE_COORDINATETOOL, ViewModifier.BUNDLE_STATSGRID,
                 ViewModifier.BUNDLE_FEEDBACKSERVICE, ViewModifier.BUNDLE_CAMERA_CONTROLS_3D,
                 ViewModifier.BUNDLE_METADATACATALOGUE, ViewModifier.BUNDLE_METADATASEARCH, ViewModifier.BUNDLE_METADATAFLYOUT,
-                ViewModifier.BUNDLE_MAPROTATOR, ViewModifier.BUNDLE_MAPLEGEND, ViewModifier.BUNDLE_LAYERSWIPE));
+                ViewModifier.BUNDLE_MAPROTATOR, ViewModifier.BUNDLE_MAPLEGEND, ViewModifier.BUNDLE_LAYERSWIPE,
+                ViewModifier.BUNDLE_ANNOUNCEMENTS));
         for(String bundleId : configBundles) {
             SIMPLE_BUNDLES.add(bundleId);
         }

--- a/service-control/src/main/java/fi/nls/oskari/view/modifier/ViewModifier.java
+++ b/service-control/src/main/java/fi/nls/oskari/view/modifier/ViewModifier.java
@@ -47,6 +47,7 @@ public abstract class ViewModifier {
     public static final String BUNDLE_BACKEND_STATUS = "backendstatus";
 
     public static final String BUNDLE_LAYERSWIPE = "layerswipe";
+    public static final String BUNDLE_ANNOUNCEMENTS = "announcements";
 
     public static final String KEY_EAST = "east";
     public static final String KEY_NORTH = "north";


### PR DESCRIPTION
Previously required configuration in oskari-ext.properties to explicitly allow publishing.