### PR TITLE
Optional metadata url

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/data/GetCSWDataHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/data/GetCSWDataHandler.java
@@ -35,6 +35,7 @@ public class GetCSWDataHandler extends ActionHandler {
     
     private static final String LANG_PARAM = "lang";
     private static final String UUID_PARAM = "uuid";
+    private static final String METADATA_URL_PARAM = "metadataUrl";
     private final String baseUrl = PropertyUtil.getOptional(PROP_SERVICE_URL);
     private final String metadataRatingType = PropertyUtil.getOptional("service.metadata.rating");
     private final String licenseUrlPrefix = PropertyUtil.getOptional("search.channel.METADATA_CATALOGUE_CHANNEL.licenseUrlPrefix");
@@ -80,10 +81,13 @@ public class GetCSWDataHandler extends ActionHandler {
         final String uuid = params.getRequiredParam(UUID_PARAM);
         // TODO use default lang if not found?
         final String lang = params.getRequiredParam(LANG_PARAM);
+        
+        String url = params.getHttpParam(METADATA_URL_PARAM, baseUrl);
+
         CSWIsoRecord record;
         CSWService service;
         try {
-            service = new CSWService(baseUrl);
+            service = new CSWService(url);
         } catch (Exception e) {
             throw new ActionException("Failed to initialize CSWService:" + e.getMessage());
         }

--- a/control-base/src/main/java/fi/nls/oskari/control/data/GetCSWDataHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/data/GetCSWDataHandler.java
@@ -89,15 +89,15 @@ public class GetCSWDataHandler extends ActionHandler {
         }
 
         String uuid = params.getHttpParam(UUID_PARAM);
-        String layerId = params.getHttpParam(LAYER_ID_PARAM);
+        int layerId = params.getHttpParam(LAYER_ID_PARAM, -1);
 
-        if (uuid == null && layerId == null) {
-            throw new ActionException("No UUID or layer id found.");
+        if (uuid == null && layerId == -1) {
+            throw new ActionParamsException("No UUID or layer id found.");
         }
 
         String url = baseUrl;
-        if (layerId != null) {
-            OskariLayer layer = getLayer(layerId);
+        if (layerId != -1) {
+            OskariLayer layer = layerService.find(layerId);
             final JSONObject attributes = layer.getAttributes();
             uuid = layer.getMetadataId();
     
@@ -232,18 +232,5 @@ public class GetCSWDataHandler extends ActionHandler {
         } catch (Exception e) {
         }
         return null;
-    }
-
-
-    protected OskariLayer getLayer(String id) throws ActionParamsException {
-        return layerService.find(getLayerId(id));
-    }
-
-    protected int getLayerId(String layerId) throws ActionParamsException {
-        int id = ConversionHelper.getInt(layerId, -1);
-        if (id == -1) {
-            throw new ActionParamsException("Missing layer id");
-        }
-        return id;
     }
 }


### PR DESCRIPTION
Allow user to add "metadataUrl" parameter to layer attributes for optional metadata url for that layer. If no optional url is set, we default to the one set in oskari-ext.properties.

relates to: [https://github.com/oskariorg/oskari-frontend/pull/2594](url)