### PR TITLE
Statslayer: Use layer url as default with an option to override it with attributes

### DIFF
--- a/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/db/RegionSet.java
+++ b/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/db/RegionSet.java
@@ -56,6 +56,8 @@ public class RegionSet {
 
     public void setAttributes(String attributes) {
         this.attributes = attributes;
+        // force getStatsJSON to recalculate
+        this.stats = null;
     }
 
     public JSONObject asJSON() {
@@ -71,7 +73,7 @@ public class RegionSet {
     }
 
     public String getFeaturesUrl() {
-        return getStatsJSON().optString("featuresUrl");
+        return getStatsJSON().optString("featuresUrl", getUrl());
     }
 
     private JSONObject getStatsJSON() {

--- a/service-statistics-common/src/test/java/fi/nls/oskari/control/statistics/RegionSetHelperTest.java
+++ b/service-statistics-common/src/test/java/fi/nls/oskari/control/statistics/RegionSetHelperTest.java
@@ -73,12 +73,33 @@ public class RegionSetHelperTest {
         }
     }
 
+    @Test
+    public void testFeaturesUrl() throws MismatchedDimensionException, FactoryException, TransformException, ServiceException, IOException, JSONException {
+        String endPoint = "https://my.domain";
+        String overridingEndPoint = endPoint + "/feat";
+        RegionSet kunnatJSON = new RegionSet();
+        kunnatJSON.setId(-1);
+        kunnatJSON.setUrl(endPoint);
+        kunnatJSON.setName("oskari:kunnat2013");
+        kunnatJSON.setSrs_name("EPSG:3067");
+        assertEquals("Should return url when attributes NOT defined", endPoint, kunnatJSON.getFeaturesUrl());
+
+        kunnatJSON.setAttributes(getAttributes("kuntakoodi", "kuntanimi", overridingEndPoint));
+        assertEquals("Should return features url when attributes ARE defined", overridingEndPoint, kunnatJSON.getFeaturesUrl());
+
+        overridingEndPoint = null;
+        kunnatJSON.setAttributes(getAttributes("kuntakoodi", "kuntanimi", overridingEndPoint));
+        assertEquals("Should return url when attributes ARE defined WITHOUT features url", endPoint, kunnatJSON.getFeaturesUrl());
+    }
+
     private String getAttributes(String regionIdTag, String nameIdTag, String featuresUrl) throws JSONException {
         JSONObject attributes = new JSONObject();
         JSONObject statistics = new JSONObject();
         statistics.put("regionIdTag", regionIdTag);
         statistics.put("nameIdTag", nameIdTag);
-        statistics.put("featuresUrl", featuresUrl);
+        if (featuresUrl != null) {
+            statistics.put("featuresUrl", featuresUrl);
+        }
         attributes.put("statistics", statistics);
         return attributes.toString();
     }


### PR DESCRIPTION
When layers of type `statslayer` was initially created they referred to WMS-services that were styled using SLDs. Then we migrated the region sets to use WFS-services/vector features instead but for some reason we added another URL for them (probably to support both WMS and WFS concurrently for some releases). Now we only support vector features as the region set features so it doesn't make sense anymore to have the URL duplicated on the database.

This makes having `statistics.featuresUrl` optional for `oskari_maplayer.attributes` statslayer type of layers and fallbacks to the url instead as the "main method" to provide URL for the service to fetch regions from.