### PR TITLE
Bump to 2.13 and remove refs to geoserver-rest-client

### DIFF
--- a/content-resources/pom.xml
+++ b/content-resources/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
 		<artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
 	</parent>
     <artifactId>content-resources</artifactId>
     <packaging>jar</packaging>
@@ -20,11 +20,6 @@
         <dependency>
             <groupId>org.oskari</groupId>
             <artifactId>service-admin</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.oskari</groupId>
-            <artifactId>geoserver-rest-client</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/content-resources/src/main/java/org/oskari/usercontent/UserDataLayerPopulator.java
+++ b/content-resources/src/main/java/org/oskari/usercontent/UserDataLayerPopulator.java
@@ -237,24 +237,4 @@ public class UserDataLayerPopulator {
 
         return baseLayer.getId();
     }
-
-    /**
-     * Calculate and set bounds for FeatureType based on it's CRS
-     * @param featureType
-     */
-    protected static void resolveCRS(FeatureType featureType, String srs) {
-        featureType.srs = srs;
-        featureType.nativeCRS = srs;
-        try {
-            CoordinateReferenceSystem sys = CRS.decode(featureType.srs);
-            Envelope bounds = CRS.getEnvelope(sys);
-            featureType.setBounds(bounds.getLowerCorner().getOrdinate(Coordinate.X),
-                    bounds.getUpperCorner().getOrdinate(Coordinate.X),
-                    bounds.getLowerCorner().getOrdinate(Coordinate.Y),
-                    bounds.getUpperCorner().getOrdinate(Coordinate.Y));
-        } catch (Exception e) {
-            LOG.warn(e, "Unable to setup native bounds for FeatureType:", featureType);
-        }
-    }
-
 }

--- a/control-admin/pom.xml
+++ b/control-admin/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
 	</parent>
 
     <artifactId>control-admin</artifactId>

--- a/control-announcements/pom.xml
+++ b/control-announcements/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
     </parent>
 
     <artifactId>control-announcements</artifactId>

--- a/control-base/pom.xml
+++ b/control-base/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
 	</parent>
 
     <artifactId>control-base</artifactId>

--- a/control-example/pom.xml
+++ b/control-example/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
 	</parent>
 
     <artifactId>control-example</artifactId>

--- a/control-mvt/pom.xml
+++ b/control-mvt/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
     </parent>
 
     <artifactId>control-mvt</artifactId>

--- a/control-myplaces/pom.xml
+++ b/control-myplaces/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
 	</parent>
 
     <artifactId>control-myplaces</artifactId>

--- a/control-rating/pom.xml
+++ b/control-rating/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/control-routing/pom.xml
+++ b/control-routing/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
 	</parent>
 
     <artifactId>control-routing</artifactId>

--- a/control-statistics/pom.xml
+++ b/control-statistics/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
 	</parent>
 
     <artifactId>control-statistics</artifactId>

--- a/control-userlayer/pom.xml
+++ b/control-userlayer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
     </parent>
     <artifactId>control-userlayer</artifactId>
 

--- a/control-users/pom.xml
+++ b/control-users/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
 	</parent>
 
     <artifactId>control-users</artifactId>

--- a/download-basket/pom.xml
+++ b/download-basket/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.oskari</groupId>
 		<artifactId>oskari-server</artifactId>
-		<version>2.13.0-SNAPSHOT</version>
+		<version>2.13.0</version>
 	</parent>
 	<artifactId>download-basket</artifactId>
 	<name>Download Basket</name>

--- a/geotools-ext/gt-geojson/pom.xml
+++ b/geotools-ext/gt-geojson/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>gt-geojson</artifactId>

--- a/geotools-ext/gt-mif/pom.xml
+++ b/geotools-ext/gt-mif/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>gt-mif</artifactId>

--- a/geotools-ext/gt-xsd-gpx/pom.xml
+++ b/geotools-ext/gt-xsd-gpx/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/model-ogcapi/pom.xml
+++ b/model-ogcapi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
     </parent>
     <artifactId>model-ogcapi</artifactId>
     <description>Domain classes/value objects for working with OGC API services</description>

--- a/oskari-utils/pom.xml
+++ b/oskari-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
     </parent>
 
     <artifactId>oskari-utils</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.oskari</groupId>
     <artifactId>oskari-server</artifactId>
-    <version>2.13.0-SNAPSHOT</version>
+    <version>2.13.0</version>
     <packaging>pom</packaging>
 
     <name>Oskari server</name>

--- a/service-admin/pom.xml
+++ b/service-admin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
     </parent>
 
     <artifactId>service-admin</artifactId>

--- a/service-base/pom.xml
+++ b/service-base/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
 	</parent>
 
     <artifactId>service-base</artifactId>

--- a/service-capabilities-update/pom.xml
+++ b/service-capabilities-update/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
     </parent>
 
     <artifactId>service-capabilities-update</artifactId>

--- a/service-capabilities/pom.xml
+++ b/service-capabilities/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
     </parent>
 
     <artifactId>service-capabilities</artifactId>

--- a/service-control/pom.xml
+++ b/service-control/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
     </parent>
 
     <artifactId>service-control</artifactId>

--- a/service-csw/pom.xml
+++ b/service-csw/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
     </parent>
 
     <artifactId>service-csw</artifactId>

--- a/service-feedback-open311/pom.xml
+++ b/service-feedback-open311/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>service-feedback-open311</artifactId>

--- a/service-feedback/pom.xml
+++ b/service-feedback/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
     </parent>
     <artifactId>service-feedback</artifactId>
     <packaging>jar</packaging>

--- a/service-logging/pom.xml
+++ b/service-logging/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service-map/pom.xml
+++ b/service-map/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
     </parent>
 
     <artifactId>service-map</artifactId>

--- a/service-mvt/pom.xml
+++ b/service-mvt/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
     </parent>
 
     <artifactId>service-mvt</artifactId>

--- a/service-mybatis/pom.xml
+++ b/service-mybatis/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.oskari</groupId>
 		<artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
 	</parent>
 
 	<artifactId>service-mybatis</artifactId>

--- a/service-myplaces/pom.xml
+++ b/service-myplaces/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
     </parent>
 
     <artifactId>service-myplaces</artifactId>

--- a/service-permissions/pom.xml
+++ b/service-permissions/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
     </parent>
 
     <artifactId>service-permissions</artifactId>

--- a/service-print/pom.xml
+++ b/service-print/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
     </parent>
     <artifactId>service-print</artifactId>
 

--- a/service-rating/pom.xml
+++ b/service-rating/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service-routing/pom.xml
+++ b/service-routing/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
     </parent>
 
     <artifactId>service-routing</artifactId>

--- a/service-scheduler/pom.xml
+++ b/service-scheduler/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
     </parent>
 
     <artifactId>service-scheduler</artifactId>

--- a/service-search-opendata/pom.xml
+++ b/service-search-opendata/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.oskari</groupId>
 		<artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
 	</parent>
 	<artifactId>service-search-opendata</artifactId>
 	<packaging>jar</packaging>

--- a/service-search-wfs/pom.xml
+++ b/service-search-wfs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.oskari</groupId>
 		<artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
 	</parent>
 
 	<artifactId>service-search-wfs</artifactId>

--- a/service-search/pom.xml
+++ b/service-search/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.oskari</groupId>
 		<artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
 	</parent>
 
 	<artifactId>service-search</artifactId>

--- a/service-spatineo-monitor/pom.xml
+++ b/service-spatineo-monitor/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
     </parent>
 
     <artifactId>service-spatineo-monitor</artifactId>

--- a/service-statistics-common/pom.xml
+++ b/service-statistics-common/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
 	</parent>
 
     <artifactId>service-statistics-common</artifactId>

--- a/service-statistics-eurostat/pom.xml
+++ b/service-statistics-eurostat/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
 	</parent>
 
     <artifactId>service-statistics-eurostat</artifactId>

--- a/service-statistics-pxweb/pom.xml
+++ b/service-statistics-pxweb/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
     </parent>
 
     <artifactId>service-statistics-pxweb</artifactId>

--- a/service-statistics-sotka/pom.xml
+++ b/service-statistics-sotka/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
 	</parent>
 
     <artifactId>service-statistics-sotka</artifactId>

--- a/service-statistics-unsd/pom.xml
+++ b/service-statistics-unsd/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
 	</parent>
 
     <artifactId>service-statistics-unsd</artifactId>

--- a/service-statistics/pom.xml
+++ b/service-statistics/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
 	</parent>
 
     <artifactId>service-statistics</artifactId>

--- a/service-userlayer/pom.xml
+++ b/service-userlayer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
     </parent>
     <artifactId>service-userlayer</artifactId>
     <description>Everything related to UserLayers</description>

--- a/service-users/pom.xml
+++ b/service-users/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
     </parent>
 
     <artifactId>service-users</artifactId>

--- a/service-wcs/pom.xml
+++ b/service-wcs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
     </parent>
 
     <artifactId>service-wcs</artifactId>

--- a/service-webapp/pom.xml
+++ b/service-webapp/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
     </parent>
 
     <artifactId>service-webapp</artifactId>

--- a/service-wfs-client/pom.xml
+++ b/service-wfs-client/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
     </parent>
     <artifactId>service-wfs-client</artifactId>
     <description>Utilities for accessing WFS 1.1.0 services</description>

--- a/service-wfs3/pom.xml
+++ b/service-wfs3/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
     </parent>
     <artifactId>service-wfs3</artifactId>
     <description>When working with WFS 3 services</description>

--- a/servlet-map/pom.xml
+++ b/servlet-map/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
     </parent>
     <artifactId>servlet-map</artifactId>
     <packaging>jar</packaging>

--- a/shared-test-resources/pom.xml
+++ b/shared-test-resources/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>org.oskari</groupId>
         <artifactId>oskari-server</artifactId>
-        <version>2.13.0-SNAPSHOT</version>
+        <version>2.13.0</version>
 	</parent>
 
     <artifactId>shared-test-resources</artifactId>


### PR DESCRIPTION
The code compiled before since 2.13.0-SNAPSHOT still has geoserver-rest-client available, but after bumping the version to 2.13.0 it's no longer being created so the rest of the references need to be removed.