### PR TITLE
Make sure we don't write duplicated indicators

### DIFF
--- a/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/DataSourceUpdater.java
+++ b/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/DataSourceUpdater.java
@@ -6,13 +6,11 @@ import fi.nls.oskari.cache.JedisManager;
 import fi.nls.oskari.control.statistics.data.StatisticalIndicator;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
-import net.opengis.ows10.SectionsType;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Used to preload and -process statistical indicator data from a datasource

--- a/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/DataSourceUpdater.java
+++ b/service-statistics-common/src/main/java/fi/nls/oskari/control/statistics/plugins/DataSourceUpdater.java
@@ -6,8 +6,13 @@ import fi.nls.oskari.cache.JedisManager;
 import fi.nls.oskari.control.statistics.data.StatisticalIndicator;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
+import net.opengis.ows10.SectionsType;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Used to preload and -process statistical indicator data from a datasource
@@ -54,13 +59,28 @@ public abstract class DataSourceUpdater implements Runnable {
         if (indicators.isEmpty()) {
             return;
         }
+        // Make sure we don't store duplicates of indicators
+        // This might happen when multiple nodes in cluster processes the list at the same time.
+        // One node might be faster and store an indicator while another still has it in it's workqueue.
+        // When the slower one saves, it combines the processed from redis + workqueue on its memory
+        // where processed already might contain indicators that are in the workqueue of the node that is saving/adding it's queue
+        List<StatisticalIndicator> nonDuplicates = new ArrayList<>(indicators.size());
+        Set<String> indicatorIds = new HashSet<>(indicators.size());
+        indicators.stream().forEach(ind -> {
+            if (indicatorIds.contains(ind.getId())) {
+                return;
+            }
+            nonDuplicates.add(ind);
+            indicatorIds.add(ind.getId());
+        });
+
 
         final ObjectMapper listMapper = new ObjectMapper();
         // skip f.ex. description and source when writing list
         listMapper.addMixIn(StatisticalIndicator.class, JacksonIndicatorListMixin.class);
         // write new indicator list
         try {
-            String result = listMapper.writeValueAsString(indicators);
+            String result = listMapper.writeValueAsString(nonDuplicates);
             JedisManager.setex(plugin.getIndicatorListKey(), JedisManager.EXPIRY_TIME_DAY * 7, result);
         } catch (JsonProcessingException ex) {
             LOG.error(ex, "Error updating indicator list");


### PR DESCRIPTION
When processing indicators from a statistical datasource. It breaks the UI completely when the user scrolls to such indicator:

![aineistohaku](https://github.com/oskariorg/oskari-server/assets/2210335/937a8b39-eda6-4863-b569-9598831a92a4)

This might happen when we have multiple servers that are processing the indicator list at the same time. One server might save the indicator as processed while another still has it's on its work queue. When the other server saves it gets the processed one from redis and adds a duplicate from its work queue.

https://github.com/ant-design/ant-design/issues/33864
