### PR TITLE
Use metadata id from capabilities if there is no override

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/data/GetCSWDataHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/data/GetCSWDataHandler.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.oskari.capabilities.ogc.LayerCapabilitiesOGC;
 import org.oskari.service.util.ServiceFactory;
 
 import static fi.nls.oskari.csw.service.CSWService.PROP_SERVICE_URL;
@@ -99,7 +100,7 @@ public class GetCSWDataHandler extends ActionHandler {
         if (layerId != -1) {
             OskariLayer layer = layerService.find(layerId);
             final JSONObject attributes = layer.getAttributes();
-            uuid = layer.getMetadataId();
+            uuid = getMetadataIdForLayer(layer);
     
             try {
                 if (attributes.has(METADATA_URL_PARAM)) {
@@ -145,6 +146,16 @@ public class GetCSWDataHandler extends ActionHandler {
         }
 
         ResponseHelper.writeResponse(params, result);
+    }
+
+    private String getMetadataIdForLayer(OskariLayer layer) {
+        String uuid = layer.getMetadataId();
+        if (uuid != null && !uuid.trim().isEmpty()) {
+            // override metadataid
+            return uuid;
+        }
+        // uuid from capabilities
+        return layer.getCapabilities().optString(LayerCapabilitiesOGC.METADATA_UUID, null);
     }
     
     private void prefixImageFilenames(CSWIsoRecord record, final String uuid, final String locale) {

--- a/service-base/src/main/java/fi/nls/oskari/domain/map/OskariLayer.java
+++ b/service-base/src/main/java/fi/nls/oskari/domain/map/OskariLayer.java
@@ -321,6 +321,13 @@ public class OskariLayer extends JSONLocalizedNameAndTitle implements Comparable
         this.simplifiedUrl = null;
     }
 
+    /**
+     * Returns the override for metadata id. To get the one the service is referencing use:
+     *   getCapabilities().optString(LayerCapabilitiesOGC.METADATA_UUID, null);
+     * We can't override this to return the value from capabilities since the admin ui
+     * needs to know where the metadata id came from: capabilities or override
+     * @return
+     */
     public String getMetadataId() {
         return metadataId;
     }


### PR DESCRIPTION
Otherwise when using the layerId parameter AND the layer doesn't have an override for metadataid the metadata is not shown at all. For example the link on layer admin:
![image](https://github.com/oskariorg/oskari-server/assets/2210335/3b9738a9-fd76-4f52-8b31-74b92c36e0f8)
