### PR TITLE
Bump commons-compress

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,15 @@ The 2.15 doesn't report any breaking changes so its backwards compatible with 2.
     <!-- Managed dependencies -->
     <dependencyManagement>
         <dependencies>
+            <!-- version 1.25.0 is transitive from org.apache.poi/poi-ooxml 5.2.5
+            It has a vulnerability that has been patched in comporess 1.26.1 -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>1.26.1</version>
+            </dependency>
+
+
             <!-- Oskari -->
             <dependency>
                 <groupId>org.oskari</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@ The 2.15 doesn't report any breaking changes so its backwards compatible with 2.
         <commons-io.version>2.15.0</commons-io.version>
         <commons-csv.version>1.10.0</commons-csv.version>
         <xmlgraphics-fop.version>2.9</xmlgraphics-fop.version>
+        <!-- Note! Check commons-compress override when updating this -->
         <poi-ooxml.version>5.2.5</poi-ooxml.version>
 
         <jsoup.version>1.17.2</jsoup.version>


### PR DESCRIPTION
org.apache.poi/poi-ooxml has this as dependency and it doesn't have a newer version but overriding this should work ok.