### PR TITLE
Allow Redis usage with username

### DIFF
--- a/service-base/src/main/java/fi/nls/oskari/cache/JedisManager.java
+++ b/service-base/src/main/java/fi/nls/oskari/cache/JedisManager.java
@@ -36,6 +36,19 @@ public class JedisManager {
      */
     private JedisManager() {}
 
+    public static HostAndPort getHostAndPort() {
+        return new HostAndPort(JedisManager.getHost(), JedisManager.getPort());
+    }
+
+    public static JedisClientConfig getClientConfig() {
+        return DefaultJedisClientConfig.builder()
+                .connectionTimeoutMillis(getConnectionTimeoutMs())
+                .user(getUser())
+                .password(getPassword())
+                .ssl(getUseSSL())
+                .build();
+    }
+
     public static String getHost() {
         return PropertyUtil.get(KEY_REDIS_HOSTNAME, "localhost");
     }
@@ -50,6 +63,9 @@ public class JedisManager {
     }
     private static String getPassword() {
         return PropertyUtil.get("redis.password", null);
+    }
+    private static String getUser() {
+        return PropertyUtil.get("redis.user", null);
     }
     private static boolean getUseSSL() {
         return PropertyUtil.getOptional("redis.ssl", false);
@@ -80,7 +96,7 @@ public class JedisManager {
         poolConfig.setTestOnBorrow(true);
         poolConfig.setBlockWhenExhausted(getBlockWhenExhausted());
         final JedisPool oldPool = pool;
-        pool = new JedisPool(poolConfig, host, port, getConnectionTimeoutMs(), getPassword(), getUseSSL());
+        pool = new JedisPool(poolConfig, host, port, getConnectionTimeoutMs(), getUser(), getPassword(), getUseSSL());
         // Should we use the long format to have an option to pass "client name" to Redis to help debugging issues with shared Redis instances?
         // pool = new JedisPool(poolConfig, host, port, getConnectionTimeoutMs(), getSocketReadTimeoutMs(), getPassword(), Protocol.DEFAULT_DATABASE, getClientName());
 

--- a/service-base/src/main/java/org/oskari/cluster/ClusterClient.java
+++ b/service-base/src/main/java/org/oskari/cluster/ClusterClient.java
@@ -4,8 +4,7 @@ import fi.nls.oskari.cache.JedisManager;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.util.OskariRuntimeException;
-import redis.clients.jedis.Jedis;
-import redis.clients.jedis.JedisPubSub;
+import redis.clients.jedis.*;
 
 import java.util.*;
 import java.util.concurrent.ExecutorService;
@@ -153,7 +152,7 @@ public class ClusterClient extends JedisPubSub {
     // NOTE!! create a new client for subscriptions instead of using pool to make sure clients don't conflict
     private Jedis createClient() {
         if (client == null) {
-            client = new Jedis(JedisManager.getHost(), JedisManager.getPort());
+            client = new Jedis(JedisManager.getHostAndPort(), JedisManager.getClientConfig());
         }
         return client;
     }

--- a/servlet-map/src/main/java/fi/nls/oskari/spring/session/RedisSessionConfig.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/spring/session/RedisSessionConfig.java
@@ -5,10 +5,12 @@ import fi.nls.oskari.util.PropertyUtil;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.connection.RedisPassword;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+import redis.clients.jedis.JedisClientConfig;
 
 // TODO: Check if maxInactiveIntervalInSeconds can be configured
 @Configuration
@@ -22,7 +24,13 @@ public class RedisSessionConfig extends WebMvcConfigurerAdapter {
     public JedisConnectionFactory connectionFactory() {
         RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(
                 JedisManager.getHost(), JedisManager.getPort());
+        JedisClientConfig clientConfig = JedisManager.getClientConfig();
+        config.setUsername(clientConfig.getUser());
+
+        RedisPassword pw = RedisPassword.of(clientConfig.getPassword());
+        config.setPassword(pw);
         JedisConnectionFactory jedis = new JedisConnectionFactory(config);
+        jedis.afterPropertiesSet();
         return jedis;
     }
 }

--- a/servlet-map/src/main/java/fi/nls/oskari/spring/session/RedisSessionConfig.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/spring/session/RedisSessionConfig.java
@@ -30,6 +30,7 @@ public class RedisSessionConfig extends WebMvcConfigurerAdapter {
         RedisPassword pw = RedisPassword.of(clientConfig.getPassword());
         config.setPassword(pw);
         JedisConnectionFactory jedis = new JedisConnectionFactory(config);
+        // for some reason a call to afterPropertiesSet() is required for user/passwd to be used
         jedis.afterPropertiesSet();
         return jedis;
     }


### PR DESCRIPTION
Also adds credentials handling for the redis-session profile and cache syncing for clustered environments. After this it's possible to configure one or both as Redis credentials on oskari-ext.properties:
```
redis.user=user
redis.password=passwd
```
If these properties are not defined the code will work like without credentials. If you have the keys with empty values, things will probably not work.

Previously a password could be configured the basic Redis connectivity, but it wasn't used for storing/accessing session information on the redis-session profile (this didn't work at all for redis-server that requires credentials resulting in exception like `NOPERM this user has no permissions to access one of the keys used as arguments.`) or for the pub/sub functionality that the caching uses for syncing changes between servers. Password can be configured on Redis versions <6 and the user can be used on 6+.

https://redis.io/docs/latest/operate/oss_and_stack/management/security/acl/

This allows for example creating a user named `user` with password `passwd` on redis-cli:
```
ACL SETUSER user on >passwd ~* +@all
```
With `~*` meaning access to all keys and `+@all` means access to all commands. On Redis 6.2 there is also `&*` which means pub/sub for anything and it might be required for the cache syncing.
