### PR TITLE
Treat proxy error as common error

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/layer/GetLayerTileHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/layer/GetLayerTileHandler.java
@@ -154,13 +154,13 @@ public class GetLayerTileHandler extends ActionHandler {
             // just throw it as is if we already handled it
             throw e;
         } catch (Exception e) {
-            LOG.info("Url in proxy error was:", url);
-            throw new ActionParamsException("Couldn't proxy request to actual service", e.getMessage(), e);
+            LOG.debug("Url in proxy error was:", url);
+            throw new ActionCommonException("Couldn't proxy request to actual service: " +  e.getMessage(), e);
         } finally {
-            if(actionTimer != null) {
+            if (actionTimer != null) {
                 actionTimer.stop();
             }
-            if(con != null) {
+            if (con != null) {
                 con.disconnect();
             }
         }


### PR DESCRIPTION
This makes errors while proxying skip audit-logging. As proxied requests for layers can spam quite a bit it's unnecessary to add the messages to audit log.