### PR TITLE
Refactor permission queries to joins

### DIFF
--- a/service-permissions/src/main/java/org/oskari/permissions/PermissionServiceMybatisImpl.java
+++ b/service-permissions/src/main/java/org/oskari/permissions/PermissionServiceMybatisImpl.java
@@ -9,8 +9,10 @@ import fi.nls.oskari.domain.User;
 import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.mybatis.MyBatisHelper;
+import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 import org.oskari.permissions.model.Permission;
 import org.oskari.permissions.model.PermissionExternalType;
 import org.oskari.permissions.model.Resource;
@@ -42,9 +44,16 @@ public class PermissionServiceMybatisImpl extends PermissionService {
             LOG.warn("DataSource was null, all future calls will throw NPEs!");
             factory = null;
         } else {
-            factory = MyBatisHelper.initMyBatis(ds, MAPPER);
+            factory = initializeMyBatis(ds);
         }
         cache = CacheManager.getCache(PermissionServiceMybatisImpl.class.getName());
+    }
+
+    private SqlSessionFactory initializeMyBatis(final DataSource dataSource) {
+        final Configuration configuration = MyBatisHelper.getConfig(dataSource);
+        MyBatisHelper.addAliases(configuration, Resource.class, Permission.class);
+        MyBatisHelper.addMappers(configuration, MAPPER);
+        return new SqlSessionFactoryBuilder().build(configuration);
     }
 
     public List<Resource> findResourcesByUser(User user, ResourceType type) {

--- a/service-permissions/src/main/java/org/oskari/permissions/ResourceMapper.java
+++ b/service-permissions/src/main/java/org/oskari/permissions/ResourceMapper.java
@@ -3,6 +3,7 @@ package org.oskari.permissions;
 import java.util.List;
 import java.util.Set;
 
+import fi.nls.oskari.domain.map.userlayer.UserLayerData;
 import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Many;
@@ -19,46 +20,15 @@ import org.oskari.permissions.model.Resource;
 
 public interface ResourceMapper {
 
-    // TODO: Join tables in SQL and map the result -> improves performance by ~5x
-    @Results(id = "ResourceResult", value = {
-            @Result(property="id", column="id", id=true),
-            @Result(property="type", column="resource_type"),
-            @Result(property="mapping", column="resource_mapping"),
-            @Result(property="permissions", column="id",
-                    javaType=List.class, many=@Many(select="findPermissionsByResourceId", fetchType= FetchType.EAGER))
-    })
-    @Select("SELECT id,"
-            + "resource_type,"
-            + "resource_mapping "
-            + "FROM oskari_resource "
-            + "WHERE id = #{id}")
     Resource findById(@Param("id") int id);
 
     @Select("SELECT EXISTS (SELECT 1 FROM oskari_resource WHERE id = #{id})")
     boolean existsById(@Param("id") int id);
 
-    @ResultMap("ResourceResult")
-    @Select("SELECT id,"
-            + "resource_type,"
-            + "resource_mapping "
-            + "FROM oskari_resource")
     List<Resource> findAll();
 
-    @ResultMap("ResourceResult")
-    @Select("SELECT id,"
-            + "resource_type,"
-            + "resource_mapping "
-            + "FROM oskari_resource "
-            + "WHERE resource_type = #{type}")
-    List<Resource> findByType(String type);
+    List<Resource> findByType(@Param("type") String type);
 
-    @ResultMap("ResourceResult")
-    @Select("SELECT id,"
-            + "resource_type,"
-            + "resource_mapping "
-            + "FROM oskari_resource "
-            + "WHERE resource_type = #{type} "
-            + "AND resource_mapping = #{mapping}")
     Resource findByTypeAndMapping(@Param("type") String type, @Param("mapping") String mapping);
 
     @Select("SELECT EXISTS (SELECT 1 FROM oskari_resource WHERE resource_type = #{type} AND resource_mapping = #{mapping})")
@@ -78,20 +48,6 @@ public interface ResourceMapper {
                                           @Param("externalType") PermissionExternalType externalType,
                                           @Param("permission") String permission,
                                           @Param("external_id") String external_id);
-
-    @Results({
-        @Result(property="id", column="id", id=true),
-        @Result(property="type", column="permission"),
-        @Result(property="externalType", column="external_type"),
-        @Result(property="externalId", column="external_id")
-    })
-    @Select("SELECT id,"
-            + "external_type,"
-            + "permission,"
-            + "external_id "
-            + "FROM oskari_resource_permission "
-            + "WHERE resource_id = #{resourceId}")
-    List<Permission> findPermissionsByResourceId(@Param("resourceId") int resourceId);
 
     @Insert("INSERT INTO oskari_resource (resource_type, resource_mapping) VALUES (#{type},#{mapping})")
     @Options(useGeneratedKeys=true, keyColumn="id", keyProperty="id")

--- a/service-permissions/src/main/java/org/oskari/permissions/model/Permission.java
+++ b/service-permissions/src/main/java/org/oskari/permissions/model/Permission.java
@@ -24,7 +24,6 @@ public class Permission {
 
     public void setType(String type) {
         this.type = type;
-
     }
 
     public void setType(PermissionType type) {
@@ -36,6 +35,10 @@ public class Permission {
     }
 
     public void setExternalType(String externalType) {
+        setExternalType(PermissionExternalType.valueOf(externalType));
+    }
+
+    public void setExternalTypeMybatis(String externalType) {
         setExternalType(PermissionExternalType.valueOf(externalType));
     }
 
@@ -54,6 +57,11 @@ public class Permission {
     public void setExternalId(String externalId) {
         setExternalId(Integer.parseInt(externalId));
     }
+
+    public void setExternalIdMybatis(String externalId) {
+        setExternalId(externalId);
+    }
+
 
     public void setRoleId(int roleId) {
         setExternalType(PermissionExternalType.ROLE);

--- a/service-permissions/src/main/java/org/oskari/permissions/model/Resource.java
+++ b/service-permissions/src/main/java/org/oskari/permissions/model/Resource.java
@@ -53,7 +53,9 @@ public class Resource {
 
     public List<Permission> getPermissions() {
         if (permissions == null) {
-            return Collections.emptyList();
+            // mybatis calls get to fill in the results to
+            // -> we can't use Collections.emptyList() here
+            permissions = new ArrayList<>();
         }
         return permissions;
     }

--- a/service-permissions/src/main/resources/org/oskari/permissions/ResourceMapper.xml
+++ b/service-permissions/src/main/resources/org/oskari/permissions/ResourceMapper.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.oskari.permissions.ResourceMapper">
+
+    <resultMap id="resourceWithPermissions" type="Resource">
+        <id property="id" column="id" />
+        <result property="type" column="resource_type" javaType="String" />
+        <result property="mapping" column="resource_mapping" javaType="String" />
+        <collection property="permissions" javaType="list" ofType="Permission">
+            <result property="id" column="permission_id" javaType="int"/>
+            <result property="type" column="permission" javaType="String" />
+            <result property="externalTypeMybatis" column="external_type" javaType="String"/>
+            <result property="externalIdMybatis" column="external_id" javaType="String" />
+        </collection>
+    </resultMap>
+
+    <select id="findAll" resultMap="resourceWithPermissions" useCache="false">
+        SELECT r.id, r.resource_type, r.resource_mapping, p.id as permission_id, p.external_type, p.permission, p.external_id
+        FROM oskari_resource r
+        LEFT JOIN oskari_resource_permission p
+        ON r.id = p.resource_id
+    </select>
+
+    <select id="findById" resultMap="resourceWithPermissions" useCache="false">
+        SELECT r.id, r.resource_type, r.resource_mapping, p.id as permission_id, p.resource_id, p.external_type, p.permission, p.external_id
+        FROM oskari_resource r
+         JOIN oskari_resource_permission p
+        ON r.id = p.resource_id
+        WHERE r.id = #{id}
+    </select>
+
+    <select id="findByType" resultMap="resourceWithPermissions" useCache="false">
+        SELECT r.id, r.resource_type, r.resource_mapping, p.id as permission_id, p.external_type, p.permission, p.external_id
+        FROM oskari_resource r
+        LEFT JOIN oskari_resource_permission p
+        ON r.id = p.resource_id
+        WHERE r.resource_type = #{type}
+    </select>
+
+    <select id="findByTypeAndMapping" resultMap="resourceWithPermissions" useCache="false">
+        SELECT r.id, r.resource_type, r.resource_mapping, p.id as permission_id, p.external_type, p.permission, p.external_id
+        FROM oskari_resource r
+        LEFT JOIN oskari_resource_permission p
+        ON r.id = p.resource_id
+        WHERE r.resource_type = #{type}
+        AND r.resource_mapping = #{mapping}
+    </select>
+
+
+</mapper>


### PR DESCRIPTION
On local dev with some 3000 layers. Loading layers from db (with heavy logging so it's not properly measured):

Before:
- Amount of select queries for permissions: 6097
- Time from loading layers: 11,6s

After:
- Amount of select queries for permissions: 15
- Time from loading layers: 3,9s

Time measured from log entries between:
- from "GetAppSetupHandler - View ID: 1 created by user -1 is public, access granted for user with id -1 " 
- to "OskariLayerWorker - Returning 2712 / 2928 layers "
But with all the sql logging happening which I'm sure adds a lot to it.
