### PR TITLE
SotkaIndicatorParser skip faulty indicators

### DIFF
--- a/service-statistics-sotka/src/main/java/fi/nls/oskari/control/statistics/plugins/sotka/SotkaStatisticalDatasourcePlugin.java
+++ b/service-statistics-sotka/src/main/java/fi/nls/oskari/control/statistics/plugins/sotka/SotkaStatisticalDatasourcePlugin.java
@@ -45,13 +45,15 @@ public class SotkaStatisticalDatasourcePlugin extends StatisticalDatasourcePlugi
             JSONArray responseJSON = new JSONArray(data);
             SotkaIndicatorParser parser = new SotkaIndicatorParser(config);
             LOG.info("Parsing indicator response of length: " + responseJSON.length());
+            int parsedIndicators = 0;
             for (int i = 0; i < responseJSON.length(); i++) {
                 StatisticalIndicator indicator = parser.parse(responseJSON.getJSONObject(i), sotkaToLayerMappings);
                 if(indicator != null) {
+                    parsedIndicators++;
                     onIndicatorProcessed(indicator);
                 }
             }
-            LOG.info("Parsed indicator response.");
+            LOG.info("Updated datasource:", config.getUrl(), "with parsed", parsedIndicators, "of", responseJSON.length(), "indicators.");
         } catch (JSONException e) {
             LOG.error("Error in mapping Sotka Indicators response to Oskari model: " + e.getMessage(), e);
         }

--- a/service-statistics-sotka/src/main/java/fi/nls/oskari/control/statistics/plugins/sotka/parser/SotkaIndicatorParser.java
+++ b/service-statistics-sotka/src/main/java/fi/nls/oskari/control/statistics/plugins/sotka/parser/SotkaIndicatorParser.java
@@ -77,7 +77,7 @@ public class SotkaIndicatorParser {
             ind.setSource(toLocalizationMap(json.getJSONObject("organization").getJSONObject("title")));
 
             return setupMetadata(ind, sotkaLayersToOskariLayers);
-        } catch (JSONException e) {
+        } catch (Exception e) {
             LOG.error(e, "Could not read data from Sotka Indicator JSON.");
             return null;
         }
@@ -340,6 +340,7 @@ Parsing Sotkanet metadata/JSON like this:
         if (ind.getLayers().isEmpty()) {
             // we can't show this indicator since it doesn't link to any region set
             // if at this point we don't have layers -> ignore the indicator by returning null
+            LOG.debug("Indicator:", ind.getId(), "doesn't have any of regionsets linked to datasource, ignoring");
             return null;
         }
 


### PR DESCRIPTION
SotkaRequest.getData() throws APIException if failed to parse CSW response => changed to handle Exception instead of JSONException in SotkaIndicatorParser.parse(). Could also catch APIException in createIndicator's setupMetadata() where getData() is called but I think that indicator must be skipped and proceed update regardless what causes exception.

Fixes issue where invalid response for single indicator interrupts update.