### PR TITLE
Update apache libs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,18 +73,18 @@
         <commons-fileupload.version>1.5</commons-fileupload.version>
         <commons-dbcp2.version>2.11.0</commons-dbcp2.version>
 
-<!-- This will override commons-io to be packaged with version 2.15.0, otherwise
+<!-- This will override commons-io to be packaged with version 2.16.1, otherwise
 - geotools 28.4 uses 2.10
 - fileupload 1.5 uses 2.11
-- poi-ooxml 5.2.5 uses 2.15
-The one packaged without this is 2.11, but poi-ooxml throws methodNotDefined or similar exception with it (requires 2.15).
+- poi-ooxml 5.2.5 uses 2.16.1
+The one packaged without this is 2.11, but poi-ooxml throws methodNotDefined or similar exception with it (requires 2.15+).
 The 2.15 doesn't report any breaking changes so its backwards compatible with 2.10+
   -->
-        <commons-io.version>2.15.0</commons-io.version>
+        <commons-io.version>2.16.1</commons-io.version>
         <commons-csv.version>1.10.0</commons-csv.version>
-        <xmlgraphics-fop.version>2.9</xmlgraphics-fop.version>
+        <xmlgraphics-fop.version>2.10</xmlgraphics-fop.version>
         <!-- Note! Check commons-compress override when updating this -->
-        <poi-ooxml.version>5.2.5</poi-ooxml.version>
+        <poi-ooxml.version>5.3.0</poi-ooxml.version>
 
         <jsoup.version>1.17.2</jsoup.version>
 
@@ -144,15 +144,6 @@ The 2.15 doesn't report any breaking changes so its backwards compatible with 2.
     <!-- Managed dependencies -->
     <dependencyManagement>
         <dependencies>
-            <!-- version 1.25.0 is transitive from org.apache.poi/poi-ooxml 5.2.5
-            It has a vulnerability that has been patched in comporess 1.26.1 -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>1.26.1</version>
-            </dependency>
-
-
             <!-- Oskari -->
             <dependency>
                 <groupId>org.oskari</groupId>


### PR DESCRIPTION
Updating poi-ooxml allows removal of commons-compress override.

- org.apache.xmlgraphics/fop
- org.apache.poi/poi-ooxml