### PR TITLE
Update Jackson 2.16.1 -> 2.18.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,8 +91,8 @@ The 2.15 doesn't report any breaking changes so its backwards compatible with 2.
         <axiom.version>1.2.22</axiom.version>
         <stax-api.version>1.0-2</stax-api.version>
 
-        <jackson.version>2.16.1</jackson.version>
-        <jackson-databind.version>2.16.1</jackson-databind.version>
+        <jackson.version>2.18.1</jackson.version>
+        <jackson-databind.version>2.18.1</jackson-databind.version>
 
         <fi.mml.nameregister.version>1.0</fi.mml.nameregister.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -98,8 +98,10 @@ The 2.15 doesn't report any breaking changes so its backwards compatible with 2.
 
         <jetty.version>9.4.56.v20240826</jetty.version>
         <mybatis.version>3.5.16</mybatis.version>
+        <!-- Flyway 10.x requires Java 17+ -->
         <flyway.version>9.22.3</flyway.version>
         <postgresql.version>42.7.4</postgresql.version>
+        <!-- hikaricp 5.x requires Java 11+ -->
         <hikaricp.version>4.0.3</hikaricp.version>
 
         <!-- https://github.com/spring-projects/spring-data-redis/blob/2.7.x/pom.xml#L29


### PR DESCRIPTION
Also tested updating flyway and hikariCP, but both require more recent Java version so added notes for these.