### PR TITLE
Remove restricted params from urls

### DIFF
--- a/service-base/src/main/java/org/oskari/util/LayerUrlHelper.java
+++ b/service-base/src/main/java/org/oskari/util/LayerUrlHelper.java
@@ -1,0 +1,27 @@
+package org.oskari.util;
+
+import fi.nls.oskari.util.ConversionHelper;
+import fi.nls.oskari.util.IOHelper;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class LayerUrlHelper {
+
+    private static final Set<String> RESTRICTED_PARAMS = ConversionHelper.asSet("request", "service", "version");
+
+    public static String getSanitizedUrl(String pUrl) {
+        String baseUrl = IOHelper.removeQueryString(pUrl);
+        Map<String, List<String>> params = IOHelper.parseQuerystring(pUrl);
+        String url = baseUrl;
+
+        for (String key : params.keySet()) {
+            if (!RESTRICTED_PARAMS.contains(key.toLowerCase())) {
+                // not the most efficient way, but just regenerating the url without restricted params
+                url = IOHelper.addUrlParam(url, key, params.get(key).stream().toArray(String[]::new));
+            }
+        }
+        return url;
+    }
+}

--- a/service-base/src/test/java/org/oskari/util/LayerUrlHelperTest.java
+++ b/service-base/src/test/java/org/oskari/util/LayerUrlHelperTest.java
@@ -1,0 +1,15 @@
+package org.oskari.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class LayerUrlHelperTest {
+
+    @Test
+    public void getSanitizedUrl() {
+        assertEquals("https://jee.org/?apikey=woot&proxy=not", LayerUrlHelper.getSanitizedUrl("https://jee.org/?apikey=woot&request=GetWheel&proxy=not"));
+        // doesn't work:
+        // assertEquals("resources://jee.org/?apikey=woot&proxy=not", LayerUrlHelper.getSanitizedUrl("resources://jee.org/?apikey=woot&request=GetWheel&proxy=not"));
+    }
+}

--- a/service-capabilities/src/main/java/org/oskari/capabilities/ServiceConnectInfo.java
+++ b/service-capabilities/src/main/java/org/oskari/capabilities/ServiceConnectInfo.java
@@ -1,6 +1,7 @@
 package org.oskari.capabilities;
 
 import fi.nls.oskari.domain.map.OskariLayer;
+import org.oskari.util.LayerUrlHelper;
 
 import java.util.Objects;
 
@@ -13,10 +14,11 @@ public class ServiceConnectInfo {
     private String pass;
 
     public ServiceConnectInfo(String url, String type, String version) {
-        this.url = url;
+        this.url = LayerUrlHelper.getSanitizedUrl(url);
         this.type = type;
         this.version = version;
     }
+
 
     public void setCredentials(String user, String pass) {
         this.user = user;

--- a/service-map/src/main/java/org/oskari/maplayer/model/MapLayer.java
+++ b/service-map/src/main/java/org/oskari/maplayer/model/MapLayer.java
@@ -1,6 +1,7 @@
 package org.oskari.maplayer.model;
 
 import fi.nls.oskari.domain.map.style.VectorStyle;
+import org.oskari.util.LayerUrlHelper;
 
 import java.util.*;
 
@@ -83,7 +84,7 @@ public class MapLayer {
     }
 
     public void setUrl(String url) {
-        this.url = url;
+        this.url = LayerUrlHelper.getSanitizedUrl(url);
     }
 
     public String getUsername() {


### PR DESCRIPTION
If a WFS-layer is registered to the application with an URL containing request, version or service parameters some things will break for example the capabilities parser that tries to call request=DescribeFeatureType. This results in calls having something like request=GetCapabilities&request=DescribeFeatureType when fetching the featuretype documentation.

This is first attempt with what I consider the "right places" for doing this:
- MapLayer is used when inserting layers from JSON at the startup and when admin UI is used.
- ServiceConnectInfo is used for fetching capabilities and handles the issue when there are layers in the database that has the problematic parameters on the URL.

However, we might need to support resources:// protocol for urls (used in thematic maps) and regenerating the url is pretty nasty looking at this point (generating arrays and strings for each param).