### PR TITLE
Support mixed geometry types when reading region sets from resources / statistical data

### DIFF
--- a/service-map/src/main/java/org/oskari/maplayer/GeoJSONStringReader.java
+++ b/service-map/src/main/java/org/oskari/maplayer/GeoJSONStringReader.java
@@ -1,0 +1,68 @@
+package org.oskari.maplayer;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.referencing.CRS;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.oskari.geojson.GeoJSONReader2;
+import org.oskari.geojson.GeoJSONSchemaDetector;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+public class GeoJSONStringReader {
+
+    private static final ObjectMapper OM = new ObjectMapper();
+    private static final TypeReference<HashMap<String, Object>> TYPE_REF = new TypeReference<HashMap<String, Object>>() {};
+
+    public static SimpleFeatureCollection readGeoJSON(InputStream in, CoordinateReferenceSystem crs) throws Exception {
+        if (in == null) {
+            throw new IllegalArgumentException("InputStream was null");
+        }
+        try (Reader utf8Reader = new InputStreamReader(in, StandardCharsets.UTF_8)) {
+            Map<String, Object> geojsonAsMap = loadJSONResource(utf8Reader);
+            boolean ignoreGeometryProperties = true;
+            SimpleFeatureType schema = GeoJSONSchemaDetector.getSchema(geojsonAsMap, crs, ignoreGeometryProperties);
+            return GeoJSONReader2.toFeatureCollection(geojsonAsMap, schema);
+        }
+    }
+
+    public static SimpleFeatureCollection readGeoJSON(String geojson, String srs) throws Exception{
+        CoordinateReferenceSystem sourceCRS = CRS.decode(srs);
+        return readGeoJSON(geojson, sourceCRS);
+    }
+
+    public static SimpleFeatureCollection readGeoJSON(String geojson, CoordinateReferenceSystem crs) throws Exception {
+        Map<String, Object> geojsonAsMap = loadJSONResource(geojson);
+        boolean ignoreGeometryProperties = true;
+        try {
+            SimpleFeatureType schema = GeoJSONSchemaDetector.getSchema(geojsonAsMap, crs, ignoreGeometryProperties);
+            return GeoJSONReader2.toFeatureCollection(geojsonAsMap, schema);
+        } catch (NullPointerException e) {
+            throw new IllegalArgumentException("Input was not GeoJSON");
+        }
+    }
+
+
+
+    private static Map<String, Object> loadJSONResource(Reader utf8Reader) throws Exception {
+        try {
+            return OM.readValue(utf8Reader, TYPE_REF);
+        } catch (MismatchedInputException e) {
+            throw new IllegalArgumentException("Input couldn't be parsed as JSON Object");
+        }
+    }
+
+    private static Map<String, Object> loadJSONResource(String geojson) throws Exception {
+        try {
+            return OM.readValue(geojson, TYPE_REF);
+        } catch (MismatchedInputException e) {
+            throw new IllegalArgumentException("Input couldn't be parsed as JSON Object");
+        }
+    }
+}

--- a/service-map/src/test/java/org/oskari/maplayer/GeoJSONStringReaderTest.java
+++ b/service-map/src/test/java/org/oskari/maplayer/GeoJSONStringReaderTest.java
@@ -1,0 +1,38 @@
+package org.oskari.maplayer;
+
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.referencing.CRS;
+import org.junit.Test;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+
+import java.io.InputStream;
+
+import static org.junit.Assert.*;
+
+public class GeoJSONStringReaderTest {
+
+    @Test (expected = IllegalArgumentException.class)
+    public void testGeoJSONasNull() throws Exception {
+        GeoJSONStringReader.readGeoJSON((String) null, "EPSG:4326");
+    }
+    @Test (expected = IllegalArgumentException.class)
+    public void testInputStreamasNull() throws Exception {
+        CoordinateReferenceSystem sourceCRS = CRS.decode("EPSG:4326");
+        GeoJSONStringReader.readGeoJSON((InputStream) null, sourceCRS);
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void testGeoJSONasEmptyString() throws Exception {
+        GeoJSONStringReader.readGeoJSON("", "EPSG:4326");
+    }
+    @Test (expected = IllegalArgumentException.class)
+    public void testGeoJSONasEmptyObject() throws Exception {
+        GeoJSONStringReader.readGeoJSON("{}", "EPSG:4326");
+    }
+    @Test (expected = IllegalArgumentException.class)
+    public void testGeoJSONWithEmptyFeatures() throws Exception {
+        SimpleFeatureCollection col = GeoJSONStringReader.readGeoJSON("{ \"type\": \"FeatureCollection\"}", "EPSG:4326");
+        assertNotNull("Parse should complete", col);
+        assertTrue("Should get an empty collection", col.isEmpty());
+    }
+}


### PR DESCRIPTION
Use the same logic to read GeoJSON in WFSClient and RegionSetHelper to workaround this: https://gis.stackexchange.com/questions/316134/reading-a-geojson-via-java-geotools-api-issue

When GeoTools is used to read the feature collection it will use the geometry type from the first feature. This results in region sets that have both Polygon and Multipolygon features look like this on the map (Multipolygons forced to Polygons if the first feature has a Polygon geometry):
![image](https://github.com/user-attachments/assets/f33f42e6-4544-4aee-8cee-f4daa016f603)

Note that there's already a GeoJSONReader on geotools-ext Maven module, but it has very little dependencies. To keep it that way I added the GeoJSONStringReader to service-map that already has Jackson-databind as dependency.