### PR TITLE
Indonesian language code changed on Java 17

### DIFF
--- a/MigrationGuide.md
+++ b/MigrationGuide.md
@@ -1,5 +1,17 @@
 # Migration guide
 
+## 3.0.0
+
+In 3.0.0 the minimum Java version for Oskari is changed from Java 8 to 17.
+
+### Language code for Indonesia changed in Java 17.
+
+Old behavior can be restored with system property `-Djava.locale.useOldISOCodes=true`
+
+See details:
+- https://stackoverflow.com/questions/55955641/correct-locale-for-indonesia-id-id-vs-in-id/55965008
+- https://bugs.openjdk.org/browse/JDK-8267069
+
 ## 2.14.0
 
 ### Frontend

--- a/service-base/src/test/java/fi/nls/oskari/util/PropertyUtilTest.java
+++ b/service-base/src/test/java/fi/nls/oskari/util/PropertyUtilTest.java
@@ -81,15 +81,14 @@ public class PropertyUtilTest {
             PropertyUtil.addProperty("oskari.locales", "id_ID, en_US", true);
             Locale loc_ID = new Locale("id");
             // https://stackoverflow.com/questions/55955641/correct-locale-for-indonesia-id-id-vs-in-id/55965008
-            assertEquals("'id' as lang should translate to 'in' with Locale", loc_ID.getLanguage(), "in");
+            assertEquals("'id' as lang should translate to 'id' with Locale on Java 17", loc_ID.getLanguage(), "id");
             assertEquals("getDefaultLanguage() doesn't use Locale", PropertyUtil.getDefaultLanguage(), "id");
-            assertFalse("The problem is locale and Props.getDefaultLanguage() don't match", loc_ID.getLanguage().equals(PropertyUtil.getDefaultLanguage()));
+            assertTrue("Locale and Props.getDefaultLanguage() match with Java 17", loc_ID.getLanguage().equals(PropertyUtil.getDefaultLanguage()));
 
             PropertyUtil.addProperty("oskari.locales", "in_ID, en_US", true);
             Locale loc_IN = new Locale("in");
-            assertEquals("'in' as lang should remain 'in' with Locale", loc_IN.getLanguage(), "in");
+            assertEquals("'in' as lang changes to 'id' with Locale", loc_IN.getLanguage(), "id");
             assertEquals("getDefaultLanguage() doesn't use Locale", PropertyUtil.getDefaultLanguage(), "in");
-            assertEquals("Using 'in_ID' for Indonesian works as expected", loc_IN.getLanguage(), PropertyUtil.getDefaultLanguage());
         } finally {
             PropertyUtil.clearProperties();
         }


### PR DESCRIPTION
See details:
- https://stackoverflow.com/questions/55955641/correct-locale-for-indonesia-id-id-vs-in-id/55965008
- https://bugs.openjdk.org/browse/JDK-8267069