### PR TITLE
Update Maven plugins to latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -919,7 +919,7 @@ The 2.15 doesn't report any breaking changes so its backwards compatible with 2.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.13.0</version>
                 <configuration>
                     <source>${jdk.version}</source>
                     <target>${jdk.version}</target>
@@ -927,14 +927,14 @@ The 2.15 doesn't report any breaking changes so its backwards compatible with 2.
             </plugin>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.1</version>
+                <version>3.4.0</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -947,7 +947,7 @@ The 2.15 doesn't report any breaking changes so its backwards compatible with 2.
             </plugin>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.11.2</version>
                 <configuration>
                     <failOnError>false</failOnError>
                 </configuration>
@@ -963,15 +963,15 @@ The 2.15 doesn't report any breaking changes so its backwards compatible with 2.
             </plugin>
             <plugin>
                 <artifactId>maven-install-plugin</artifactId>
-                <version>2.5.2</version>
+                <version>3.1.3</version>
             </plugin>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.3.1</version>
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.1</version>
+                <version>3.5.2</version>
                 <configuration>
                     <!-- module.build.config is a workaround for test/mock libraries on Java 11 -->
                     <!-- headless=true prevents forking java process from stealing window focus on Mac OS -->
@@ -985,7 +985,7 @@ The 2.15 doesn't report any breaking changes so its backwards compatible with 2.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.1</version>
+                <version>3.5.2</version>
                 <configuration>
                     <!-- Workaround for test/mock libraries -->
                     <argLine>--add-opens java.base/java.lang=ALL-UNNAMED --illegal-access=permit</argLine>
@@ -993,7 +993,7 @@ The 2.15 doesn't report any breaking changes so its backwards compatible with 2.
             </plugin>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.4.2</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -1013,7 +1013,7 @@ The 2.15 doesn't report any breaking changes so its backwards compatible with 2.
             <plugin>
                 <!-- explicitly define maven-deploy-plugin after other to force exec order -->
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.8.2</version>
+                <version>3.1.3</version>
                 <executions>
                     <execution>
                         <id>deploy</id>
@@ -1026,9 +1026,9 @@ The 2.15 doesn't report any breaking changes so its backwards compatible with 2.
             </plugin>
             <!-- initialize git revision info -->
             <plugin>
-                <groupId>pl.project13.maven</groupId>
-                <artifactId>git-commit-id-plugin</artifactId>
-                <version>4.0.2</version>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>9.0.1</version>
                 <executions>
                     <execution>
                         <goals>
@@ -1047,7 +1047,7 @@ The 2.15 doesn't report any breaking changes so its backwards compatible with 2.
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.8.3.1</version>
+                <version>4.8.6.6</version>
                 <configuration>
                     <excludeFilterFile>spotbugs__ignore_filter.xml</excludeFilterFile>
                 </configuration>
@@ -1072,7 +1072,7 @@ The 2.15 doesn't report any breaking changes so its backwards compatible with 2.
             <plugin>
                 <groupId>org.cyclonedx</groupId>
                 <artifactId>cyclonedx-maven-plugin</artifactId>
-                <version>2.7.11</version>
+                <version>2.9.1</version>
                 <configuration>
                     <projectType>library</projectType>
                     <schemaVersion>1.4</schemaVersion>
@@ -1151,9 +1151,9 @@ The 2.15 doesn't report any breaking changes so its backwards compatible with 2.
     <profiles>
         <profile>
             <id>javamodules</id>
-            <!-- required for build/mock libraries to work on Java 11 -->
+            <!-- required for build/mock libraries to work on Java 17 -->
             <activation>
-                <jdk>[9,)</jdk>
+                <jdk>[17,)</jdk>
             </activation>
             <properties>
                 <module.build.config>
@@ -1165,7 +1165,6 @@ The 2.15 doesn't report any breaking changes so its backwards compatible with 2.
                     --add-opens java.base/java.io=ALL-UNNAMED
                     --add-opens java.base/jdk.internal.loader=ALL-UNNAMED
                     --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED
-                    --illegal-access=warn
                 </module.build.config>
             </properties>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -1176,7 +1176,7 @@ The 2.15 doesn't report any breaking changes so its backwards compatible with 2.
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>5.3.2</version>
+                        <version>11.1.1</version>
                         <configuration>
                             <format>ALL</format>
                             <failOnError>false</failOnError>
@@ -1197,7 +1197,7 @@ The 2.15 doesn't report any breaking changes so its backwards compatible with 2.
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>5.3.2</version>
+                        <version>11.1.1</version>
                         <configuration>
                             <format>ALL</format>
                             <failOnError>false</failOnError>


### PR DESCRIPTION
Removed deprecated access-warn flag: "OpenJDK 64-Bit Server VM warning: Ignoring option --illegal-access=warn; support was removed in 17.0"