### PR TITLE
Remove noise from compile time logging

### DIFF
--- a/service-base/src/main/java/fi/nls/oskari/annotation/OskariComponentAnnotationProcessor.java
+++ b/service-base/src/main/java/fi/nls/oskari/annotation/OskariComponentAnnotationProcessor.java
@@ -5,6 +5,8 @@ import fi.nls.oskari.service.OskariComponent;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
@@ -14,6 +16,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 @SupportedAnnotationTypes(OskariComponentAnnotationProcessor.ANNOTATION_TYPE)
+@SupportedSourceVersion(SourceVersion.RELEASE_17)
 public class OskariComponentAnnotationProcessor extends OskariBaseAnnotationProcessor {
     /**
      * This is the annotation we are going to process

--- a/service-base/src/main/java/fi/nls/oskari/annotation/ServiceRegistration.java
+++ b/service-base/src/main/java/fi/nls/oskari/annotation/ServiceRegistration.java
@@ -48,13 +48,13 @@ public class ServiceRegistration {
      * this {@code Set} already contains a class-name, the name
      * won't be added to the {@link #lines} {@code List}.
      */
-    private final Set<String> classes = new HashSet<String>();
+    private final Set<String> classes = new HashSet<>();
 
     /**
      * This is the raw contents of the services file, that we
      * will eventually output to the class output directory.
      */
-    private final List<String> lines = new ArrayList<String>();
+    private final List<String> lines = new ArrayList<>();
 
     /**
      * Create a new, empty {@code ServiceRegistration} object, with a
@@ -137,17 +137,14 @@ public class ServiceRegistration {
                 read(reader);
                 reader.close();
             }
-        } catch(final IOException ioe) {
+        } catch (final IOException ioe) {
+            // ignored. This happens every time with the first annotation encountered
+        } catch (final Exception error) {
             environment.getMessager().printMessage(
                     Kind.WARNING,
-                    "I/O Error: I couldn't read " + fileName +
-                            " from location " + location.getName());
-        } catch(final Exception error) {
-            environment.getMessager().printMessage(
-                    Kind.WARNING,
-                    "I couldn't read " + fileName +
-                            " from location " + location.getName() +
-                            ". Error details: " + error.toString());
+                    "Couldn't read " + fileName +
+                            " from " + location.getName() +
+                            ". Error details: " + error);
         }
     }
 

--- a/service-base/src/main/java/fi/nls/oskari/annotation/ServiceRegistration.java
+++ b/service-base/src/main/java/fi/nls/oskari/annotation/ServiceRegistration.java
@@ -89,7 +89,7 @@ public class ServiceRegistration {
 
     /**
      * This is the read implementation used by the
-     * {@link #read(JavaFileManager.Location)} to consume the
+     * {@link #read(javax.tools.JavaFileManager.Location)} to consume the
      * contents of the {@code Reader}, while ensuring we don't
      * register a particular implementation more than once.
      *
@@ -156,7 +156,7 @@ public class ServiceRegistration {
      * @param className the fully qualified name of the class to add
      */
     public void addClass(final String className) {
-        if(classes.add(className)) {
+        if (classes.add(className)) {
             lines.add(className);
         }
     }

--- a/service-control/src/main/java/fi/nls/oskari/annotation/OskariActionRouteAnnotationProcessor.java
+++ b/service-control/src/main/java/fi/nls/oskari/annotation/OskariActionRouteAnnotationProcessor.java
@@ -4,6 +4,8 @@ import fi.nls.oskari.control.ActionHandler;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
@@ -19,6 +21,7 @@ import java.util.Set;
  * The file is created if it didn't exist and duplicates aren't written.
  */
 @SupportedAnnotationTypes(OskariActionRouteAnnotationProcessor.ANNOTATION_TYPE)
+@SupportedSourceVersion(SourceVersion.RELEASE_17)
 public class OskariActionRouteAnnotationProcessor extends OskariBaseAnnotationProcessor {
     /**
      * This is the annotation we are going to process

--- a/service-control/src/main/java/fi/nls/oskari/annotation/OskariViewModifierAnnotationProcessor.java
+++ b/service-control/src/main/java/fi/nls/oskari/annotation/OskariViewModifierAnnotationProcessor.java
@@ -4,6 +4,8 @@ import fi.nls.oskari.view.modifier.ViewModifier;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
@@ -19,6 +21,7 @@ import java.util.Set;
  * The file is created if it didn't exist and duplicates aren't written.
  */
 @SupportedAnnotationTypes(OskariViewModifierAnnotationProcessor.ANNOTATION_TYPE)
+@SupportedSourceVersion(SourceVersion.RELEASE_17)
 public class OskariViewModifierAnnotationProcessor extends OskariBaseAnnotationProcessor {
     /**
      * This is the annotation we are going to process


### PR DESCRIPTION
AnnotationProcessors default to Java 6 and prints out a warning that we are using non-supported java version with Java 17.
Also two warnings were printed on compile time about not finding the files that annotation processing produces. That is unnecessary to print out so removed that as well.