### PR TITLE
Upgrade java assist to allow mocking with Java 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -863,7 +863,13 @@ The 2.15 doesn't report any breaking changes so its backwards compatible with 2.
                 <artifactId>junit</artifactId>
                 <version>${junit.version}</version>
             </dependency>
-
+            <!-- Override java assist (used by mock libraries) to latest version to work with Java 21 -->
+            <dependency>
+                <groupId>org.javassist</groupId>
+                <artifactId>javassist</artifactId>
+                <version>3.30.2-GA</version>
+                <scope>test</scope>
+            </dependency>
             <dependency>
                 <groupId>org.powermock</groupId>
                 <artifactId>powermock-core</artifactId>


### PR DESCRIPTION
Solves https://github.com/oskariorg/oskari-documentation/issues/71

Without this powermock brings `3.27.0-GA`:
```
org.powermock:powermock-core:jar:2.0.9:test
\- org.javassist:javassist:jar:3.27.0-GA:test
```