### PR TITLE
Add new test-helper module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,16 +12,10 @@ target/
 /data/
 /test-output/
 /servlet-map/data/
-transport.log
 *pom.xml.versionsBackup
-/standalone-jetty/dist/public/oskari
-/standalone-jetty/dist/public/Oskari
-/standalone-jetty/dist/*.jar
-/bin/
-/service-spatineo-monitor/nbproject/
-/control-base/nbproject
+*/nbproject/
 */nbactions.xml
 */nb-configuration.xml
 
-/service-search-nls/nbproject/
 .metadata
+control-base/workbook.xlsx

--- a/content-resources/pom.xml
+++ b/content-resources/pom.xml
@@ -30,5 +30,10 @@
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.oskari</groupId>
+            <artifactId>test-helper</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/control-admin/pom.xml
+++ b/control-admin/pom.xml
@@ -104,32 +104,5 @@
             <artifactId>postgresql</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-
-        <!-- PowerMock can be used to mock static/private methods -->
-        <!--
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        -->
-        <!--
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        -->
     </dependencies>
 </project>

--- a/control-announcements/pom.xml
+++ b/control-announcements/pom.xml
@@ -23,5 +23,10 @@
             <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.oskari</groupId>
+            <artifactId>test-helper</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/control-base/pom.xml
+++ b/control-base/pom.xml
@@ -60,11 +60,6 @@
             <artifactId>service-userlayer</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.oskari</groupId>
-            <artifactId>shared-test-resources</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
         </dependency>
@@ -86,14 +81,13 @@
             <artifactId>service-wfs-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.geotools</groupId>
-            <artifactId>gt-epsg-hsql</artifactId>
+            <groupId>org.oskari</groupId>
+            <artifactId>shared-test-resources</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <!-- some powermock tests ignores xml packages and tests fails without this -->
-            <groupId>org.apache.ws.commons.axiom</groupId>
-            <artifactId>axiom-impl</artifactId>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-epsg-hsql</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/control-userlayer/pom.xml
+++ b/control-userlayer/pom.xml
@@ -30,5 +30,10 @@
             <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.oskari</groupId>
+            <artifactId>test-helper</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/geotools-ext/gt-mif/pom.xml
+++ b/geotools-ext/gt-mif/pom.xml
@@ -22,14 +22,14 @@
             <groupId>org.geotools</groupId>
             <artifactId>gt-main</artifactId>
         </dependency>
-        <!-- dependency>
-            <groupId>org.geotools</groupId>
-            <artifactId>gt-data</artifactId>
-            <version>${geotools.version}</version>
-        </dependency -->
         <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-epsg-hsql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.oskari</groupId>
+            <artifactId>test-helper</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/oskari-utils/pom.xml
+++ b/oskari-utils/pom.xml
@@ -15,6 +15,11 @@
     </description>
 
     <dependencies>
+        <dependency>
+            <groupId>org.oskari</groupId>
+            <artifactId>test-helper</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jdk.version>17</jdk.version>
         <oskari.version>${project.version}</oskari.version>
-        <!-- Value comes from profile when needed -->
-        <module.build.config></module.build.config>
 
         <spring.version>5.3.39</spring.version>
         <spring-security.version>5.7.13</spring-security.version>
@@ -143,25 +141,6 @@ The 2.15 doesn't report any breaking changes so its backwards compatible with 2.
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api -->
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-junit-jupiter</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <!-- Managed dependencies -->
     <dependencyManagement>
@@ -848,22 +827,46 @@ The 2.15 doesn't report any breaking changes so its backwards compatible with 2.
             <!-- Managed test dependencies -->
             <dependency>
                 <groupId>org.oskari</groupId>
+                <artifactId>test-helper</artifactId>
+                <version>${oskari.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.oskari</groupId>
                 <artifactId>shared-test-resources</artifactId>
                 <version>${oskari.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>${junit.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-junit-jupiter</artifactId>
+                <version>${mockito.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-params</artifactId>
+                <version>${junit.version}</version>
+            </dependency>
             <!-- Override java assist (used by mock libraries) to latest version to work with Java 21 -->
             <dependency>
                 <groupId>org.javassist</groupId>
                 <artifactId>javassist</artifactId>
                 <version>3.30.2-GA</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-library</artifactId>
                 <version>${hamcrest.version}</version>
-                <scope>test</scope>
             </dependency>
             <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
             <dependency>
@@ -896,27 +899,18 @@ The 2.15 doesn't report any breaking changes so its backwards compatible with 2.
                 <scope>provided</scope>
             </dependency>
 
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
+            <!--
+                Bringing this back so that sample-server-application and others will continue to build.
+                This is the same version that powermock-module-junit4 uses
 
-
-
-        <!--
-            Bringing this back so that sample-server-application and others will continue to build.
-            This is the same version that powermock-module-junit4 uses
-
-            Get rid of this and powermock and add junit-juniper to apps
-        -->
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
-        </dependency>
+                Get rid of this and powermock and add junit-juniper to apps
+            -->
+            <!-- dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.12</version>
+                <scope>test</scope>
+            </dependency -->
 
         </dependencies>
     </dependencyManagement>
@@ -981,7 +975,6 @@ The 2.15 doesn't report any breaking changes so its backwards compatible with 2.
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.2</version>
                 <configuration>
-                    <!-- module.build.config is a workaround for test/mock libraries on Java 11 -->
                     <!-- headless=true prevents forking java process from stealing window focus on Mac OS -->
                     <!-- syslog.level makes builds less verbose (defaults to system.out logger) -->
                     <argLine>
@@ -993,10 +986,16 @@ The 2.15 doesn't report any breaking changes so its backwards compatible with 2.
                     --add-opens java.base/java.io=ALL-UNNAMED
                     --add-opens java.base/jdk.internal.loader=ALL-UNNAMED
                     --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED
-                        ${module.build.config}
                         -Djava.awt.headless=true
                         -Doskari.syslog.level=warn</argLine>
                 </configuration>
+                <!-- dependencies>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>${junit.version}</version>
+                    </dependency>
+                </dependencies -->
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -1214,6 +1213,7 @@ The 2.15 doesn't report any breaking changes so its backwards compatible with 2.
     </profiles>
     <modules>
         <!-- basic oskari map requirements -->
+        <module>test-helper</module>
         <module>shared-test-resources</module>
         <module>model-ogcapi</module>
 

--- a/service-base/pom.xml
+++ b/service-base/pom.xml
@@ -54,5 +54,10 @@
             <groupId>org.locationtech.jts.io</groupId>
             <artifactId>jts-io-common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.oskari</groupId>
+            <artifactId>test-helper</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/service-control/pom.xml
+++ b/service-control/pom.xml
@@ -23,29 +23,14 @@
             <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
-        <!-- PowerMock can be used to mock static/private methods -->
-        <!--
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        -->
-        <!--
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        -->
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.oskari</groupId>
+            <artifactId>test-helper</artifactId>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/service-map/pom.xml
+++ b/service-map/pom.xml
@@ -39,11 +39,6 @@
             <artifactId>service-wfs3</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-wfs-ng</artifactId>
         </dependency>
@@ -62,11 +57,6 @@
         <dependency>
             <groupId>org.oskari</groupId>
             <artifactId>shared-test-resources</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>xmlunit</groupId>
-            <artifactId>xmlunit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/service-mvt/pom.xml
+++ b/service-mvt/pom.xml
@@ -36,6 +36,11 @@
             <artifactId>gt-epsg-hsql</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.oskari</groupId>
+            <artifactId>test-helper</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/service-scheduler/pom.xml
+++ b/service-scheduler/pom.xml
@@ -23,6 +23,11 @@
             <groupId>org.oskari</groupId>
             <artifactId>service-base</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.oskari</groupId>
+            <artifactId>test-helper</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/service-search/pom.xml
+++ b/service-search/pom.xml
@@ -17,5 +17,10 @@
 			<groupId>org.oskari</groupId>
 			<artifactId>service-base</artifactId>
 		</dependency>
+        <dependency>
+            <groupId>org.oskari</groupId>
+            <artifactId>test-helper</artifactId>
+            <scope>test</scope>
+        </dependency>
 	</dependencies>
 </project>

--- a/service-spatineo-monitor/pom.xml
+++ b/service-spatineo-monitor/pom.xml
@@ -23,6 +23,11 @@
             <groupId>org.oskari</groupId>
             <artifactId>service-map</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.oskari</groupId>
+            <artifactId>test-helper</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/service-userlayer/pom.xml
+++ b/service-userlayer/pom.xml
@@ -58,5 +58,10 @@
             <groupId>org.geotools</groupId>
             <artifactId>gt-geopkg</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.oskari</groupId>
+            <artifactId>test-helper</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/service-users/pom.xml
+++ b/service-users/pom.xml
@@ -30,5 +30,10 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.oskari</groupId>
+            <artifactId>test-helper</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/service-wcs/pom.xml
+++ b/service-wcs/pom.xml
@@ -15,5 +15,10 @@
             <groupId>org.oskari</groupId>
             <artifactId>oskari-utils</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.oskari</groupId>
+            <artifactId>test-helper</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/service-wfs-client/pom.xml
+++ b/service-wfs-client/pom.xml
@@ -42,6 +42,11 @@
             <groupId>com.netflix.hystrix</groupId>
             <artifactId>hystrix-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.oskari</groupId>
+            <artifactId>test-helper</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/service-wfs3/pom.xml
+++ b/service-wfs3/pom.xml
@@ -38,6 +38,11 @@
             <groupId>org.geotools</groupId>
             <artifactId>gt-epsg-hsql</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.oskari</groupId>
+            <artifactId>test-helper</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/shared-test-resources/pom.xml
+++ b/shared-test-resources/pom.xml
@@ -17,6 +17,7 @@
         <dependency>
             <groupId>org.oskari</groupId>
             <artifactId>service-control</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -31,29 +32,9 @@
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 		</dependency>
-
-        <!-- PowerMock can be used to mock static/private methods -->
-        <!--
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        -->
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit.version}</version>
+            <groupId>org.oskari</groupId>
+            <artifactId>test-helper</artifactId>
         </dependency>
     </dependencies>
 

--- a/test-helper/pom.xml
+++ b/test-helper/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+	<parent>
+        <groupId>org.oskari</groupId>
+        <artifactId>oskari-server</artifactId>
+        <version>3.0.0-SNAPSHOT</version>
+	</parent>
+
+    <artifactId>test-helper</artifactId>
+    <packaging>jar</packaging>
+    <name>Helpers for JUnit tests</name>
+    <description>
+        Helper module for importing test related dependencies.
+        Use with test-scope as dependency.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>xmlunit</groupId>
+            <artifactId>xmlunit</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>


### PR DESCRIPTION
For bundling in the junit test dependencies used by most modules so we only need to import one dependence instead of 3-4 per module.