### PR TITLE
Remove axiom-impl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -623,12 +623,6 @@ The 2.15 doesn't report any breaking changes so its backwards compatible with 2.
                 <version>${jsoup.version}</version>
             </dependency>
             <dependency>
-                <!-- control-base powermock tests requires axiom -->
-                <groupId>org.apache.ws.commons.axiom</groupId>
-                <artifactId>axiom-impl</artifactId>
-                <version>1.2.22</version>
-            </dependency>
-            <dependency>
                 <groupId>xmlunit</groupId>
                 <artifactId>xmlunit</artifactId>
                 <version>${xmlunit.version}</version>


### PR DESCRIPTION
Axiom-impl isn't needed for junit tests after: https://github.com/oskariorg/oskari-server/pull/1104
Dependency was removed from control-base in: https://github.com/oskariorg/oskari-server/pull/1115