### PR TITLE
Upgrade Javax dependencies to Jakarta

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -612,11 +612,6 @@ The 2.15 doesn't report any breaking changes so its backwards compatible with 2.
                 <version>${commons-text.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.xml.stream</groupId>
-                <artifactId>stax-api</artifactId>
-                <version>${stax-api.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.jsoup</groupId>
                 <artifactId>jsoup</artifactId>
                 <version>${jsoup.version}</version>
@@ -756,13 +751,6 @@ The 2.15 doesn't report any breaking changes so its backwards compatible with 2.
                 <artifactId>gt-mif</artifactId>
                 <version>${project.version}</version>
             </dependency>
-
-            <dependency>
-                <groupId>javax.xml</groupId>
-                <artifactId>jsr173</artifactId>
-                <version>${javax.xml.version}</version>
-            </dependency>
-
 
             <dependency>
                 <groupId>javax.vecmath</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -130,14 +130,14 @@ The 2.15 doesn't report any breaking changes so its backwards compatible with 2.
     <dependencies>
         <!-- Replacements for deprecated/removed modules in JDK9/JDK11 -->
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>4.0.2</version>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
-            <version>1.2</version>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>3.0.0</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api -->

--- a/service-routing/src/main/java/fi/nls/oskari/routing/pojo/Coord.java
+++ b/service-routing/src/main/java/fi/nls/oskari/routing/pojo/Coord.java
@@ -2,7 +2,7 @@ package fi.nls.oskari.routing.pojo;
 
 import com.fasterxml.jackson.annotation.*;
 
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/service-routing/src/main/java/fi/nls/oskari/routing/pojo/DebugOutput.java
+++ b/service-routing/src/main/java/fi/nls/oskari/routing/pojo/DebugOutput.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/service-routing/src/main/java/fi/nls/oskari/routing/pojo/From.java
+++ b/service-routing/src/main/java/fi/nls/oskari/routing/pojo/From.java
@@ -3,7 +3,7 @@ package fi.nls.oskari.routing.pojo;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/service-routing/src/main/java/fi/nls/oskari/routing/pojo/From_.java
+++ b/service-routing/src/main/java/fi/nls/oskari/routing/pojo/From_.java
@@ -3,7 +3,7 @@ package fi.nls.oskari.routing.pojo;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/service-routing/src/main/java/fi/nls/oskari/routing/pojo/IntermediateStop.java
+++ b/service-routing/src/main/java/fi/nls/oskari/routing/pojo/IntermediateStop.java
@@ -2,7 +2,7 @@ package fi.nls.oskari.routing.pojo;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/service-routing/src/main/java/fi/nls/oskari/routing/pojo/Itinerary.java
+++ b/service-routing/src/main/java/fi/nls/oskari/routing/pojo/Itinerary.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/service-routing/src/main/java/fi/nls/oskari/routing/pojo/Leg.java
+++ b/service-routing/src/main/java/fi/nls/oskari/routing/pojo/Leg.java
@@ -3,7 +3,7 @@ package fi.nls.oskari.routing.pojo;
 
 import com.fasterxml.jackson.annotation.*;
 
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/service-routing/src/main/java/fi/nls/oskari/routing/pojo/LegGeometry.java
+++ b/service-routing/src/main/java/fi/nls/oskari/routing/pojo/LegGeometry.java
@@ -3,7 +3,7 @@ package fi.nls.oskari.routing.pojo;
 
 import com.fasterxml.jackson.annotation.*;
 
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/service-routing/src/main/java/fi/nls/oskari/routing/pojo/Loc.java
+++ b/service-routing/src/main/java/fi/nls/oskari/routing/pojo/Loc.java
@@ -2,7 +2,7 @@ package fi.nls.oskari.routing.pojo;
 
 import com.fasterxml.jackson.annotation.*;
 
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/service-routing/src/main/java/fi/nls/oskari/routing/pojo/Plan.java
+++ b/service-routing/src/main/java/fi/nls/oskari/routing/pojo/Plan.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/service-routing/src/main/java/fi/nls/oskari/routing/pojo/RequestParameters.java
+++ b/service-routing/src/main/java/fi/nls/oskari/routing/pojo/RequestParameters.java
@@ -3,7 +3,7 @@ package fi.nls.oskari.routing.pojo;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/service-routing/src/main/java/fi/nls/oskari/routing/pojo/Route.java
+++ b/service-routing/src/main/java/fi/nls/oskari/routing/pojo/Route.java
@@ -3,7 +3,7 @@ package fi.nls.oskari.routing.pojo;
 
 import com.fasterxml.jackson.annotation.*;
 
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/service-routing/src/main/java/fi/nls/oskari/routing/pojo/To.java
+++ b/service-routing/src/main/java/fi/nls/oskari/routing/pojo/To.java
@@ -3,7 +3,7 @@ package fi.nls.oskari.routing.pojo;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/service-routing/src/main/java/fi/nls/oskari/routing/pojo/To_.java
+++ b/service-routing/src/main/java/fi/nls/oskari/routing/pojo/To_.java
@@ -3,7 +3,7 @@ package fi.nls.oskari.routing.pojo;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/servlet-map/src/main/java/fi/nls/oskari/spring/SpringConfig.java
+++ b/servlet-map/src/main/java/fi/nls/oskari/spring/SpringConfig.java
@@ -26,8 +26,8 @@ import org.springframework.web.servlet.resource.PathResourceResolver;
 import org.springframework.web.servlet.view.InternalResourceViewResolver;
 import org.springframework.web.servlet.view.JstlView;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import jakarta.servlet.ServletContext;
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
Upgrade or delete rest of the Javax dependencies as we move to use Spring 6 with Jakarta.

! Needs to have https://github.com/oskariorg/oskari-server/pull/1118 merged first!