### PR TITLE
JSTL upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -518,7 +518,9 @@ The 2.15 doesn't report any breaking changes so its backwards compatible with 2.
                 <version>${jakarta.servlet.jsp.version}</version>
                 <scope>provided</scope>
             </dependency>
-            <!-- JSTL API is required to prevent ClassNotFoundException at runtime with JSP -->
+            <!-- JSTL API is required to prevent jakarta.servlet.ServletException:
+            Handler processing failed: java.lang.NoClassDefFoundError: jakarta/servlet/jsp/jstl/core/Config at runtime with JSP
+            This happens immediately by just opening the geoportal page -->
             <dependency>
                 <groupId>jakarta.servlet.jsp.jstl</groupId>
                 <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,8 @@
 
         <jakarta.servlet.version>6.0.0</jakarta.servlet.version>
         <jakarta.servlet.jsp.version>3.1.0</jakarta.servlet.jsp.version>
-        <jakarta.servlet.jsp.jstl.version>2.0.0</jakarta.servlet.jsp.jstl.version>
+        <jakarta.servlet.jsp.jstl-api.version>3.0.0</jakarta.servlet.jsp.jstl-api.version>
+        <jakarta.servlet.jsp.jstl.version>3.0.1</jakarta.servlet.jsp.jstl.version>
         <javax.xml.version>1.0</javax.xml.version>
         <vecmath.version>1.5.2</vecmath.version>
 
@@ -517,6 +518,13 @@ The 2.15 doesn't report any breaking changes so its backwards compatible with 2.
                 <version>${jakarta.servlet.jsp.version}</version>
                 <scope>provided</scope>
             </dependency>
+            <!-- JSTL API is required to prevent ClassNotFoundException at runtime with JSP -->
+            <dependency>
+                <groupId>jakarta.servlet.jsp.jstl</groupId>
+                <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
+                <version>${jakarta.servlet.jsp.jstl-api.version}</version>
+            </dependency>
+            <!-- JSTL IMPL from glassfish -->
             <dependency>
                 <groupId>org.glassfish.web</groupId>
                 <artifactId>jakarta.servlet.jsp.jstl</artifactId>

--- a/servlet-map/src/main/resources/META-INF/resources/spring-map-jsp/index.jsp
+++ b/servlet-map/src/main/resources/META-INF/resources/spring-map-jsp/index.jsp
@@ -1,5 +1,5 @@
 <%@ page contentType="text/html; charset=UTF-8" isELIgnored="false" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 
 <!DOCTYPE html>


### PR DESCRIPTION
Includes commits from #1118 and updates JSTL. Looks like the JSTL-API package is also required to fix a NoClassDefFoundError: jakarta/servlet/jsp/jstl/core/Config at runtime:

![image](https://github.com/user-attachments/assets/300ac2d8-318e-4832-bcbb-51cbe1d9385e)
