### PR TITLE
Bump dependencies on dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,29 +61,28 @@
         <jakarta.servlet.jsp.version>3.1.0</jakarta.servlet.jsp.version>
         <jakarta.servlet.jsp.jstl-api.version>3.0.0</jakarta.servlet.jsp.jstl-api.version>
         <jakarta.servlet.jsp.jstl.version>3.0.1</jakarta.servlet.jsp.jstl.version>
-        <javax.xml.version>1.0</javax.xml.version>
         <vecmath.version>1.5.2</vecmath.version>
 
-        <commons-lang3.version>3.14.0</commons-lang3.version>
-        <commons-text.version>1.11.0</commons-text.version>
+        <commons-lang3.version>3.17.0</commons-lang3.version>
+        <commons-text.version>1.13.0</commons-text.version>
         <!-- could be removed? -->
         <commons-collections.version>3.2.2</commons-collections.version>
         <commons-codec.version>1.16.0</commons-codec.version>
         <commons-fileupload.version>2.0.0-M2</commons-fileupload.version>
         <commons-dbcp2.version>2.11.0</commons-dbcp2.version>
 
-<!-- This will override commons-io to be packaged with version 2.16.1, otherwise
-- geotools 28.4 uses 2.10
-- fileupload 1.5 uses 2.11
-- poi-ooxml 5.2.5 uses 2.16.1
-The one packaged without this is 2.11, but poi-ooxml throws methodNotDefined or similar exception with it (requires 2.15+).
-The 2.15 doesn't report any breaking changes so its backwards compatible with 2.10+
+<!-- This will override commons-io to be packaged with version 2.18.0, otherwise
+https://mvnrepository.com/artifact/org.apache.poi/poi-ooxml/5.4.0
+- geotools 32.1 uses 2.17.0 (https://github.com/geotools/geotools/blob/32.1/pom.xml#L942-L944)
+- fileupload 2.0.0-M2 uses 2.15.1 (https://commons.apache.org/proper/commons-fileupload/commons-fileupload2-jakarta-servlet6/dependency-management.html)
+- poi-ooxml 5.4.0 uses 2.18.0 (https://github.com/apache/poi/blob/REL_5_4_0/build.gradle#L124)
+The one packaged without this is 2.15.1
   -->
-        <commons-io.version>2.16.1</commons-io.version>
+        <commons-io.version>2.18.0</commons-io.version>
         <commons-csv.version>1.10.0</commons-csv.version>
         <xmlgraphics-fop.version>2.10</xmlgraphics-fop.version>
         <!-- Note! Check commons-compress override when updating this -->
-        <poi-ooxml.version>5.3.0</poi-ooxml.version>
+        <poi-ooxml.version>5.4.0</poi-ooxml.version>
 
         <jsoup.version>1.17.2</jsoup.version>
 
@@ -762,11 +761,11 @@ The 2.15 doesn't report any breaking changes so its backwards compatible with 2.
                 <version>${project.version}</version>
             </dependency>
 
-            <dependency>
+            <!-- dependency>
                 <groupId>javax.vecmath</groupId>
                 <artifactId>vecmath</artifactId>
                 <version>${vecmath.version}</version>
-            </dependency>
+            </dependency -->
 
             <dependency>
                 <groupId>fi.mml</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <jakarta.servlet.jsp.version>3.1.0</jakarta.servlet.jsp.version>
         <jakarta.servlet.jsp.jstl-api.version>3.0.0</jakarta.servlet.jsp.jstl-api.version>
         <jakarta.servlet.jsp.jstl.version>3.0.1</jakarta.servlet.jsp.jstl.version>
-        <vecmath.version>1.5.2</vecmath.version>
+        <!-- vecmath.version>1.5.2</vecmath.version -->
 
         <commons-lang3.version>3.17.0</commons-lang3.version>
         <commons-text.version>1.13.0</commons-text.version>
@@ -69,7 +69,6 @@
         <commons-collections.version>3.2.2</commons-collections.version>
         <commons-codec.version>1.16.0</commons-codec.version>
         <commons-fileupload.version>2.0.0-M2</commons-fileupload.version>
-        <commons-dbcp2.version>2.11.0</commons-dbcp2.version>
 
 <!-- This will override commons-io to be packaged with version 2.18.0, otherwise
 https://mvnrepository.com/artifact/org.apache.poi/poi-ooxml/5.4.0
@@ -79,22 +78,19 @@ https://mvnrepository.com/artifact/org.apache.poi/poi-ooxml/5.4.0
 The one packaged without this is 2.15.1
   -->
         <commons-io.version>2.18.0</commons-io.version>
-        <commons-csv.version>1.10.0</commons-csv.version>
+        <commons-csv.version>1.13.0</commons-csv.version>
         <xmlgraphics-fop.version>2.10</xmlgraphics-fop.version>
-        <!-- Note! Check commons-compress override when updating this -->
         <poi-ooxml.version>5.4.0</poi-ooxml.version>
 
-        <jsoup.version>1.17.2</jsoup.version>
+        <jsoup.version>1.18.3</jsoup.version>
 
-        <stax-api.version>1.0-2</stax-api.version>
-
-        <jackson.version>2.18.1</jackson.version>
-        <jackson-databind.version>2.18.1</jackson-databind.version>
+        <jackson.version>2.18.2</jackson.version>
+        <jackson-databind.version>2.18.2</jackson-databind.version>
 
         <fi.mml.nameregister.version>1.0</fi.mml.nameregister.version>
 
-        <jetty.version>9.4.56.v20240826</jetty.version>
-        <mybatis.version>3.5.16</mybatis.version>
+        <tomcat.version>10.1.34</tomcat.version>
+        <mybatis.version>3.5.19</mybatis.version>
         <flyway.version>11.1.1</flyway.version>
         <postgresql.version>42.7.4</postgresql.version>
         <hikaricp.version>6.2.1</hikaricp.version>
@@ -113,7 +109,6 @@ The one packaged without this is 2.15.1
         <pdfbox.version>3.0.3</pdfbox.version>
         <hystrix.version>1.5.18</hystrix.version>
         <!-- Test deps versions -->
-<!--        <powermock.version>2.0.9</powermock.version>-->
         <mockito.version>5.15.2</mockito.version>
         <junit.version>5.11.4</junit.version>
         <hamcrest.version>2.2</hamcrest.version>
@@ -123,8 +118,7 @@ The one packaged without this is 2.15.1
         <log4j.version>2.24.1</log4j.version>
 
         <slf4j.version>2.0.11</slf4j.version>
-        <metrics.version>4.1.0</metrics.version>
-        <xom.version>1.2.5</xom.version>
+        <metrics.version>4.2.30</metrics.version>
     </properties>
 
     <dependencies>
@@ -466,12 +460,6 @@ The one packaged without this is 2.15.1
             </dependency>
 
             <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-dbcp2</artifactId>
-                <version>${commons-dbcp2.version}</version>
-            </dependency>
-
-            <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>${commons-io.version}</version>
@@ -572,42 +560,12 @@ The one packaged without this is 2.15.1
                 <version>${metrics.version}</version>
             </dependency>
 
-            <!-- jetty -->
+            <!-- Tomcat (just for getting dependabot alerts) -->
             <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-server</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-servlet</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-webapp</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-plus</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-jsp</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-jaas</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-maven-plugin</artifactId>
-                <version>${jetty.version}</version>
+                <groupId>org.apache.tomcat</groupId>
+                <artifactId>tomcat-catalina</artifactId>
+                <version>${tomcat.version}</version>
+                <scope>provided</scope>
             </dependency>
 
             <dependency>
@@ -882,26 +840,6 @@ The one packaged without this is 2.15.1
                 <artifactId>log4j-core</artifactId>
                 <version>${log4j.version}</version>
             </dependency>
-            <dependency>
-                <groupId>xom</groupId>
-                <artifactId>xom</artifactId>
-                <version>${xom.version}</version>
-                <scope>provided</scope>
-            </dependency>
-
-            <!--
-                Bringing this back so that sample-server-application and others will continue to build.
-                This is the same version that powermock-module-junit4 uses
-
-                Get rid of this and powermock and add junit-juniper to apps
-            -->
-            <!-- dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.12</version>
-                <scope>test</scope>
-            </dependency -->
-
         </dependencies>
     </dependencyManagement>
 

--- a/service-csw/pom.xml
+++ b/service-csw/pom.xml
@@ -31,10 +31,10 @@
             <groupId>org.oskari</groupId>
             <artifactId>service-control</artifactId>
         </dependency>
-        <dependency>
+        <!--dependency>
             <groupId>javax.vecmath</groupId>
             <artifactId>vecmath</artifactId>
-        </dependency>
+        </dependency -->
 
         <dependency>
             <groupId>xmlunit</groupId>

--- a/servlet-map/pom.xml
+++ b/servlet-map/pom.xml
@@ -60,25 +60,5 @@
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
-        <!-- PowerMock can be used to mock static/private methods -->
-        <!--
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        -->
-        <!--
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        -->
     </dependencies>
 </project>


### PR DESCRIPTION
- commons-lang3: 3.14.0 -> 3.17.0
- commons-text: 1.11.0 -> 1.13.0
- commons-io: 2.16.1 -> 2.18.0
- commons-csv: 1.10.0 -> 1.13.0
- poi-ooxml: 5.3.0 -> 5.4.0
- jsoup: 1.17.2 -> 1.18.3
- jackson: 2.18.1 -> 2.18.2
- mybatis: 3.5.16 -> 3.5.19
- metrics: 4.1.0 -> 4.2.30
- removed  since it doesn't look we need these:
  - jetty dependencies (just used for getting vulnerability notifications)
  - vecmath
  - xom
  - commons-dbcp2
- added tomcat to get vulnerability notifications