### PR TITLE
Modify more json.getString() -> optString()

### DIFF
--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerPermissionHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerPermissionHandler.java
@@ -131,7 +131,7 @@ public class LayerPermissionHandler extends AbstractLayerAdminHandler {
                     throw new ActionParamsException("Resource not found: " + layerMapping);
                 }
                 Resource resource = dbResource.get();
-                final int roleId = Integer.parseInt(layerPermission.getString("roleId"));
+                final int roleId = Integer.parseInt(layerPermission.optString("roleId"));
                 JSONArray perm = layerPermission.getJSONArray("permissions");
                 final List<Permission> resourcePermissions = resource.getPermissions();
 

--- a/control-base/src/main/java/fi/nls/oskari/control/view/PublishPermissionHelper.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/view/PublishPermissionHelper.java
@@ -123,7 +123,7 @@ public class PublishPermissionHelper {
         try {
             for (int i = 0; i < selectedLayers.length(); ++i) {
                 JSONObject layer = selectedLayers.getJSONObject(i);
-                final String layerId = layer.getString("id");
+                final String layerId = layer.optString("id");
                 if (layerId.startsWith(PREFIX_MYPLACES)) {
                     // check publish right for published myplaces layer
                     if (hasRightToPublishMyPlaceLayer(layerId, userUuid, user.getScreenname())) {

--- a/control-base/src/main/java/fi/nls/oskari/control/view/modifier/bundle/MapfullHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/view/modifier/bundle/MapfullHandler.java
@@ -257,7 +257,7 @@ public class MapfullHandler extends BundleHandler {
             String layerId = null;
             try {
                 final JSONObject layer = layersArray.getJSONObject(i);
-                layerId = layer.getString(KEY_ID);
+                layerId = layer.optString(KEY_ID);
                 if (layerId == null || layerIdList.contains(layerId)) {
                     continue;
                 }
@@ -475,11 +475,11 @@ public class MapfullHandler extends BundleHandler {
             try {
                 boolean inConfigLayers = false;
                 stateLayer = mfStateLayers.getJSONObject(i);
-                stateLayerId = stateLayer.getString(KEY_ID);
+                stateLayerId = stateLayer.optString(KEY_ID);
 
                 for (int j = 0; j < mfConfigLayers.length(); j++) {
                     confLayer = mfConfigLayers.getJSONObject(j);
-                    confLayerId = confLayer.getString(KEY_ID);
+                    confLayerId = confLayer.optString(KEY_ID);
                     if (stateLayerId.equals(confLayerId)) {
                         inConfigLayers = true;
                     }
@@ -554,7 +554,7 @@ public class MapfullHandler extends BundleHandler {
                 if (!plugin.has(KEY_ID) || !plugin.has(KEY_CONFIG)) {
                     continue;
                 }
-                String id = plugin.getString(KEY_ID);
+                String id = plugin.optString(KEY_ID);
                 LOGGER.debug("[killLayerSelectionPlugin] got plugin " + id);
                 if (!id.equals(PLUGIN_LAYERSELECTION)) {
                     continue;


### PR DESCRIPTION
At least on MapfullHandler there is a problem when previously json.getString() resulted in a number value being returned as string (layer id), but now we need to use optString() to do the same thing.

Continues: https://github.com/oskariorg/oskari-server/pull/1127