### PR TITLE
Refactor SQL mappings for AppSetups

### DIFF
--- a/service-map/src/main/java/fi/nls/oskari/map/view/AppSetupMapper.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/view/AppSetupMapper.java
@@ -8,14 +8,46 @@ import java.util.List;
 import java.util.Map;
 
 public interface AppSetupMapper {
+
     @Select("SELECT MAX(id) FROM oskari_appsetup WHERE is_default = TRUE AND type = #{type}")
     Long getDefaultViewId(String type);
-    List<View> getViews(final Map<String, Object> params);
+
+    @Select("SELECT id, name, description, type, uuid, only_uuid, application, page, creator, is_public, is_default, domain, lang, metadata, created, updated" +
+            " FROM oskari_appsetup" +
+            " ORDER BY created ASC" +
+            " OFFSET ${offset} limit ${pageSize}")
+    @ResultMap("viewWithConf")
+    List<View> getViews(@Param("offset") int offset, @Param("pageSize") int pageSize);
+
+
+    @Select("SELECT id, name, description, type, uuid, only_uuid, application, page, creator, is_public, is_default, domain, lang, metadata, created, updated" +
+            " FROM oskari_appsetup" +
+            " WHERE id = #{viewId}")
+    @ResultMap("viewWithConf")
     View getViewWithConfByViewId(long viewId);
+
+    @Select("SELECT id, name, description, type, uuid, only_uuid, application, page, creator, is_public, is_default, domain, lang, metadata, created, updated" +
+            " FROM oskari_appsetup" +
+            " WHERE uuid::text = #{uuId}")
+    @ResultMap("viewWithConf")
     View getViewWithConfByUuId(String uuId);
+
+    // This doesn't have a mapping, FIXME: remove
     View getViewWithConfByOldId(long oldId);
+
+    @Select("SELECT id, name, description, type, uuid, only_uuid, application, page, creator, is_public, is_default, domain, lang, metadata, created, updated" +
+            " FROM oskari_appsetup" +
+            " WHERE name = #{name}")
+    @ResultMap("viewWithConf")
     View getViewWithConfByViewName(String viewName);
+
+    @Select("SELECT id, name, description, type, uuid, only_uuid, application, page, creator, is_public, is_default, domain, lang, metadata, created, updated" +
+            " FROM oskari_appsetup" +
+            " WHERE creator = #{userId}" +
+            " ORDER BY name ASC")
+    @ResultMap("viewWithConf")
     List<View> getViewsWithConfByUserId(long userId);
+
     List<Bundle> getBundlesByViewId(long viewId);
 
     @Insert("INSERT INTO oskari_appsetup ( name, \"description\", type, page, application, " +
@@ -38,10 +70,38 @@ public interface AppSetupMapper {
 
     @Update("UPDATE oskari_appsetup SET is_default = FALSE, updated = NOW() WHERE creator = #{userId} AND is_default = TRUE AND type = 'USER'")
     void resetUsersDefaultViews(long userId);
+
+    @Update("UPDATE oskari_appsetup SET" +
+            " name = #{name}," +
+            " description = #{description}," +
+            " application = #{application}," +
+            " page = #{page}," +
+            " domain = #{pubDomain}," +
+            " lang = #{lang}," +
+            " is_public = #{isPublic}," +
+            " is_default = #{isDefault}," +
+            " metadata = #{metadataAsString}," +
+            " updated = #{updated}" +
+            " WHERE id = #{id}")
     void update(View view);
-    void updateUsage(View view);
+
+    @Update("UPDATE oskari_appsetup SET " +
+            " used=now()," +
+            " usagecount=(SELECT usagecount+1 FROM oskari_appsetup WHERE id=#{id}) " +
+            " WHERE id=#{id}")
+    void updateUsage(long id);
+
+    @Insert("INSERT INTO oskari_appsetup_bundles (appsetup_id, bundle_id, seqno, state, config, bundleinstance)" +
+            " VALUES ( #{viewId}, #{bundleId}, #{seqNo}, #{state}, #{config}, #{bundleinstance})")
     void addBundle(Bundle bundle);
-    int updateBundleSettingsInView(final Map<String, Object> params);
+
+
+    @Update("UPDATE oskari_appsetup_bundles SET" +
+            " config = #{bundle.config}," +
+            " state = #{bundle.state}," +
+            " bundleinstance = #{bundle.bundleinstance}" +
+            " WHERE appsetup_id = #{view_id} AND bundle_id = #{bundle.bundleId}")
+    int updateBundleSettingsInView(@Param("view_id") long viewId, @Param("bundle") Bundle bundle);
 
     @Select("SELECT id FROM oskari_appsetup WHERE is_default = TRUE AND type = 'DEFAULT' AND creator = -1")
     List<Long> getDefaultViewIds();

--- a/service-map/src/main/java/fi/nls/oskari/map/view/AppSetupServiceMybatisImpl.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/view/AppSetupServiceMybatisImpl.java
@@ -133,9 +133,8 @@ public class AppSetupServiceMybatisImpl extends ViewService {
         try (final SqlSession session = factory.openSession()) {
             final AppSetupMapper mapper = session.getMapper(AppSetupMapper.class);
             final Map<String, Object> params = new HashMap<>();
-            params.put("limit", pageSize);
-            params.put("offset", (page -1) * pageSize);
-            return mapper.getViews(params);
+            int offset = (page -1) * pageSize;
+            return mapper.getViews(offset, pageSize);
         } catch (Exception e) {
             LOG.warn(e, "");
         }
@@ -300,7 +299,7 @@ public class AppSetupServiceMybatisImpl extends ViewService {
 
         try (final SqlSession session = factory.openSession()) {
             final AppSetupMapper mapper = session.getMapper(AppSetupMapper.class);
-            mapper.updateUsage(view);
+            mapper.updateUsage(view.getId());
             session.commit();
         } catch (Exception e) {
             LOG.warn(e, "Exception while updating view usage");
@@ -327,18 +326,10 @@ public class AppSetupServiceMybatisImpl extends ViewService {
 
     public void updateBundleSettingsForView(final long viewId, final Bundle bundle) throws ViewException {
         LOG.debug("Update bundle settings for view");
-        final Map<String, Object> params = new HashMap<>();
-        params.put("view_id", viewId);
-        params.put("bundle_id", bundle.getBundleId());
-
-        params.put("seqno", bundle.getSeqNo());
-        params.put("config", bundle.getConfig());
-        params.put("state", bundle.getState());
-        params.put("bundleinstance", bundle.getBundleinstance());
 
         try (final SqlSession session = factory.openSession()) {
             final AppSetupMapper mapper = session.getMapper(AppSetupMapper.class);
-            final int numUpdated = mapper.updateBundleSettingsInView(params);
+            final int numUpdated = mapper.updateBundleSettingsInView(viewId, bundle);
             if(numUpdated == 0) {
                 // not updated, bundle not found
                 throw new ViewException("Failed to update - bundle not found in view?");

--- a/service-map/src/main/resources/fi/nls/oskari/map/view/AppSetupMapper.xml
+++ b/service-map/src/main/resources/fi/nls/oskari/map/view/AppSetupMapper.xml
@@ -35,57 +35,6 @@
         <result property="bundleinstance" column="bundleinstance" />
     </resultMap>
 
-    <select id="getViews"
-            parameterType="java.util.Map"
-            resultMap="viewWithConf">
-        SELECT   id, name, description, type, uuid, only_uuid,
-        application, page, creator,
-        is_public, is_default, domain, lang, metadata, created, updated
-        FROM   oskari_appsetup
-        ORDER BY created ASC
-        OFFSET ${offset} limit ${limit}
-    </select>
-
-    <select id="getViewWithConfByViewId"
-            parameterType="java.lang.Long"
-            resultMap="viewWithConf">
-        SELECT   id, name, description, type, uuid, only_uuid,
-        application, page, creator,
-        is_public, is_default, domain, lang, metadata, created, updated
-        FROM   oskari_appsetup
-        WHERE   id = #{id}
-    </select>
-
-    <select id="getViewWithConfByUuId"
-            parameterType="java.lang.String"
-            resultMap="viewWithConf">
-        SELECT   id, name, description, type, uuid, only_uuid,
-        application, page, creator,
-        is_public, is_default, domain, lang, metadata, created, updated
-        FROM   oskari_appsetup
-        WHERE   uuid::text = #{uuId}
-    </select>
-
-    <select id="getViewWithConfByViewName"
-            parameterType="java.lang.String"
-            resultMap="viewWithConf">
-        SELECT   id, name, description, type, uuid, only_uuid,
-        application, page, creator,
-        is_public, is_default, domain, lang, metadata, created, updated
-        FROM   oskari_appsetup
-        WHERE   name = #{name}
-    </select>
-
-    <select id="getViewsWithConfByUserId"
-            resultMap="viewWithConf">
-        SELECT   id, name, description, type, uuid, only_uuid,
-        application, page, creator,
-        is_public, is_default, domain, lang, metadata, created, updated
-        FROM   oskari_appsetup
-        WHERE   creator = #{user_id}
-        ORDER BY   name ASC
-    </select>
-
     <select id="getBundlesByViewId"
             parameterType="java.lang.Long"
             resultMap="bundle">
@@ -94,37 +43,5 @@
         WHERE   appsetup_id = #{view_id} AND s.bundle_id = b.id
         ORDER BY s.seqno ASC
     </select>
-
-    <update id="update"
-               parameterType="View">
-        UPDATE oskari_appsetup
-        SET name = #{name}, description = #{description},
-        application = #{application}, page = #{page},
-        domain = #{pubDomain}, lang = #{lang}, is_public = #{isPublic}, is_default = #{isDefault}, metadata = #{metadataAsString}, updated = #{updated}
-        WHERE id = #{id}
-    </update>
-
-    <update id="updateUsage"
-               parameterType="View">
-        UPDATE oskari_appsetup
-        SET used=now(),
-        usagecount=(SELECT usagecount+1 FROM oskari_appsetup WHERE id=#{id})
-        WHERE id=#{id};
-    </update>
-
-    <insert id="addBundle"
-               parameterType="Bundle">
-        INSERT INTO oskari_appsetup_bundles (appsetup_id, bundle_id, seqno, state, config, bundleinstance)
-        VALUES ( #{viewId}, #{bundleId}, #{seqNo}, #{state}, #{config}, #{bundleinstance})
-    </insert>
-
-    <update id="updateBundleSettingsInView"
-            parameterType="java.util.Map">
-        UPDATE oskari_appsetup_bundles SET
-        config = #{config},
-        state = #{state},
-        bundleinstance = #{bundleinstance}
-        WHERE appsetup_id = #{view_id} AND bundle_id = #{bundle_id}
-    </update>
 
 </mapper>


### PR DESCRIPTION
Looks like this broke any XML-based Mybatis mapping that used Map as a way to pass multiple parameters in single option for SQL template. The JsonMapMybatisTypeHandler was called to transform the parameters when Map was only used as a convenience for passing parameter object to XML mapping.

MyBatis mapper for java.util.Map as parameter was added in: 
https://github.com/oskariorg/oskari-server/pull/1126/files#diff-be93abff1685e61a0c11dcc2441a8b913d7a1987e7554911e51377ce017514c8

This fixes the issue where for example the admin bundle to set default coordinates/layers on the default geoportal view was broken after the addition of JsonMapMybatisTypeHandler .