### PR TITLE
Cleanup threads started by the application

### DIFF
--- a/service-base/src/main/java/fi/nls/oskari/cache/JedisManager.java
+++ b/service-base/src/main/java/fi/nls/oskari/cache/JedisManager.java
@@ -118,14 +118,22 @@ public class JedisManager {
     }
 
     public static void shutdown() {
-        pool.close();
+        if (pool != null) {
+            // close calls destroy()
+            // https://github.com/redis/jedis/blob/5.3.0/src/main/java/redis/clients/jedis/util/Pool.java#L24-L25
+            pool.close();
+        }
     }
 
     /**
      * Destroys the pool
      */
     public void release() {
-        pool.destroy();
+        if (pool != null) {
+            // close calls destroy()
+            // https://github.com/redis/jedis/blob/5.3.0/src/main/java/redis/clients/jedis/util/Pool.java#L24-L25
+            pool.destroy();
+        }
     }
 
 

--- a/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
@@ -13,7 +13,6 @@ import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
 import java.util.*;
-import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -66,10 +65,15 @@ public class IOHelper {
     public static String getMyDomain() {
         return PropertyUtil.get("oskari.domain", "http://localhost:8080");
     }
+
+    public static String getManifestVersionInfo() {
+        Package pkg = IOHelper.class.getPackage();
+        return pkg.getImplementationVersion();
+    }
+
     public static String getUserAgent() {
         if (userAgent == null) {
-            Package pkg = Manifest.class.getPackage();
-            String implVersion = pkg.getImplementationVersion();
+            String implVersion = getManifestVersionInfo();
             if (implVersion == null || implVersion.isEmpty() || implVersion.contains("null")) {
                 // Some clients respond with 403 Forbidden if this includes null as string
                 // If we can't get the version, default to 0.0

--- a/service-base/src/main/java/org/oskari/cluster/ClusterManager.java
+++ b/service-base/src/main/java/org/oskari/cluster/ClusterManager.java
@@ -32,6 +32,11 @@ public class ClusterManager {
         return instance;
     }
 
+    public static void shutdown() {
+        var currentClients =getInstance().clients;
+        currentClients.values().forEach(ClusterClient::stopListening);
+        currentClients.clear();
+    }
     /**
      * Returns a shared ClusterClient for given functionality (like "cache") that can be used to send/listen to messages
      * between cluster nodes.

--- a/service-base/src/test/java/fi/nls/oskari/util/IOHelperTest.java
+++ b/service-base/src/test/java/fi/nls/oskari/util/IOHelperTest.java
@@ -151,4 +151,9 @@ public class IOHelperTest {
             }
         });
     }
+
+    @Test
+    public void testUserAgent() {
+        assertEquals("Oskari/0.0", IOHelper.getUserAgent(), "Test that the default version is returned when we don't have a MANIFEST.MF");
+    }
 }

--- a/servlet-map/src/main/java/org/oskari/spring/SpringConfig.java
+++ b/servlet-map/src/main/java/org/oskari/spring/SpringConfig.java
@@ -1,8 +1,10 @@
 package org.oskari.spring;
 
+import fi.nls.oskari.cache.JedisManager;
 import fi.nls.oskari.control.ActionControl;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
+import org.oskari.cluster.ClusterManager;
 import org.oskari.spring.extension.OskariParamMethodArgumentResolver;
 import org.oskari.spring.extension.OskariViewResolver;
 import fi.nls.oskari.util.PropertyUtil;
@@ -135,6 +137,9 @@ public class SpringConfig implements WebMvcConfigurer, ServletContextAware, Appl
     public void tearDown() {
         LOG.info("Teardown");
         ActionControl.teardown();
+        // ClusterManager leaves threads running if we don't stop them
+        ClusterManager.shutdown();
+        // OskariInitializer closes JedisManager
         OskariInitializer.teardown();
     }
 


### PR DESCRIPTION
The cluster messaging left behind threads when the redis-session profile was used. This kept for example Tomcat instance running as a zombie-process after it had been shutdown. 

The timing on when the socket needs to be closed seems to be very specific. The `Runnable` on `ClusterClient` throws an exception when we are shutting down the executor and in theory it should be enough to close the connection on the finally block. But in practice it doesn't work that way and leaves the zombie-process. So we need to `close()` the `JedisClient` in the separate `stopListening()` method to work properly.