### PR TITLE
Handle multiple ViewModifiers with same id

### DIFF
--- a/service-base/src/main/java/fi/nls/oskari/service/OskariComponentManager.java
+++ b/service-base/src/main/java/fi/nls/oskari/service/OskariComponentManager.java
@@ -60,29 +60,17 @@ public class OskariComponentManager {
      * Uses ServiceLoader to find all OskariComponents in classpath.
      */
     public synchronized static void addDefaultComponents() {
-        ServiceLoader<OskariComponent> impl = ServiceLoader.load(OskariComponent.class);
-        List<OskariComponent> sortedList = new ArrayList<>();
-        for (OskariComponent loadedImpl: impl) {
-            if (loadedImpl == null) {
-                continue;
-            }
-            sortedList.add(loadedImpl);
-        }
-        sortedList.sort(Comparator.comparingInt(OskariComponent::getOrder));
-        sortedList.forEach(loadedImpl -> addComponent(loadedImpl));
-        /*
-        // After Java 9+ we can use stream
-        impl.stream()
-                .filter( h -> h != null)
-                .map(h -> h.get())
+        ServiceLoader.load(OskariComponent.class).stream()
+                .filter(Objects::nonNull)
+                .map(ServiceLoader.Provider::get)
                 .sorted(Comparator.comparingInt(OskariComponent::getOrder))
-                .forEach(loadedImpl -> addComponent(loadedImpl));
-         */
+                .forEach(OskariComponentManager::addComponent);
     }
+
     public synchronized static <MOD extends OskariComponent> MOD getComponentOfType(final Class<MOD> clazz) {
         Map<String, MOD> map = getComponentsOfType(clazz);
-        if(map.isEmpty()) {
-            throw new NoSuchElementException("Coudldn't find component of type " + clazz.getName());
+        if (map.isEmpty()) {
+            throw new NoSuchElementException("Couldn't find component of type " + clazz.getName());
         }
         // just pick the first one
         // TODO: error handling (nullpointer) and possibly prioritize implementations

--- a/service-control/src/main/java/fi/nls/oskari/view/modifier/ViewModifierManager.java
+++ b/service-control/src/main/java/fi/nls/oskari/view/modifier/ViewModifierManager.java
@@ -86,10 +86,11 @@ public class ViewModifierManager {
             List<ViewModifier> modifiersList = actions.get(key);
             List<ViewModifier> typedMods = modifiersList.stream().filter(clazz::isInstance).toList();
             if (!typedMods.isEmpty()) {
-                mods.put(key, (Mod) typedMods.get(0));
+                // return the last one for backwards compatibility
+                mods.put(key, (Mod) typedMods.get(typedMods.size() - 1));
             }
             if (typedMods.size() > 1) {
-                log.warn("Multiple handlers for ViewModifier with name", key, ":", typedMods, "Using first one!");
+                log.warn("Multiple handlers for ViewModifier with name >", key, "<:", typedMods, "- Using first one!");
             }
         }
         return Collections.unmodifiableMap(mods);
@@ -109,5 +110,6 @@ public class ViewModifierManager {
                 }
             });
         });
+        actions.clear();
     }
 }

--- a/service-control/src/test/java/fi/nls/oskari/view/modifier/DummyBundleHandler.java
+++ b/service-control/src/test/java/fi/nls/oskari/view/modifier/DummyBundleHandler.java
@@ -1,0 +1,7 @@
+package fi.nls.oskari.view.modifier;
+
+/**
+ * Just for testing typing for ViewModifierManager
+ */
+public class DummyBundleHandler extends ViewModifier {
+}

--- a/service-control/src/test/java/fi/nls/oskari/view/modifier/DummyParamHandler.java
+++ b/service-control/src/test/java/fi/nls/oskari/view/modifier/DummyParamHandler.java
@@ -1,0 +1,12 @@
+package fi.nls.oskari.view.modifier;
+
+/**
+ * Just for testing typing for ViewModifierManager
+ */
+public class DummyParamHandler extends ParamHandler {
+    @Override
+    public boolean handleParam(ModifierParams params) throws ModifierException {
+        // no-op
+        return false;
+    }
+}

--- a/service-control/src/test/java/fi/nls/oskari/view/modifier/ViewModifierManagerTest.java
+++ b/service-control/src/test/java/fi/nls/oskari/view/modifier/ViewModifierManagerTest.java
@@ -1,0 +1,41 @@
+package fi.nls.oskari.view.modifier;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+public class ViewModifierManagerTest {
+
+    @AfterEach
+    public void teardown() throws Exception {
+        ViewModifierManager.teardown();
+    }
+    @Test
+    public void testBlackList()
+            throws Exception {
+        String handlerId = "testing";
+        DummyBundleHandler bundleHandler = new DummyBundleHandler();
+        Assertions.assertInstanceOf(ViewModifier.class, bundleHandler, "DummyBundleHandler should be ViewModifier");
+
+        DummyParamHandler paramHandler = new DummyParamHandler();
+        Assertions.assertInstanceOf(ViewModifier.class, paramHandler, "DummyParamHandler should be ViewModifier");
+
+        // add both with same name
+        ViewModifierManager.addModifier(handlerId, paramHandler);
+        ViewModifierManager.addModifier(handlerId, bundleHandler);
+
+        Map<String, ParamHandler> paramResult = ViewModifierManager.getModifiersOfType(ParamHandler.class);
+        Assertions.assertEquals(1, paramResult.size(), "Expect only one result for ParamHandlers");
+        Assertions.assertEquals(handlerId, paramResult.keySet().stream().findFirst().get(), "Check handler id match");
+        Assertions.assertEquals(paramHandler, paramResult.get(handlerId), "Check we got the same thing back");
+
+        Map<String, ParamHandler> bundleResult = ViewModifierManager.getModifiersOfType(ViewModifier.class);
+        Assertions.assertEquals(1, bundleResult.size(), "Expect only one result for ParamHandlers");
+        Assertions.assertEquals(handlerId, bundleResult.keySet().stream().findFirst().get(), "Check handler id match");
+        Assertions.assertEquals(bundleHandler, bundleResult.get(handlerId), "Check we get back the last ViewModifier that was added, but still just one");
+
+    }
+
+}


### PR DESCRIPTION
For example there is a BundleHandler and ParamHandler for id "statsgrid":
- https://github.com/oskariorg/oskari-server/blob/2.14.0/control-statistics/src/main/java/fi/nls/oskari/control/StatsgridHandler.java
- https://github.com/oskariorg/oskari-server/blob/2.14.0/control-base/src/main/java/fi/nls/oskari/control/view/modifier/param/StatsgridParamHandler.java

Both BundleHandler and ParamHandler share the same base class `ViewModifier`. This creates a race condition where one of these are overwritten on the ViewModifierManager.addDefaultControls() as they have the same id.

With this change they can both live happily together since they are referenced by the subclass when actually used. However this now prints a warning if we try getting a map of modifiers that would result having multiple implementations for the same key.