### PR TITLE
Fix myplaces layers publishing

### DIFF
--- a/service-myplaces/src/main/java/fi/nls/oskari/myplaces/MyPlaceMapper.java
+++ b/service-myplaces/src/main/java/fi/nls/oskari/myplaces/MyPlaceMapper.java
@@ -104,9 +104,9 @@ public interface MyPlaceMapper {
     MyPlace findPlace(long id);
     MyPlaceCategory find(long categoryId);
     @Update("update categories set " +
-            "   publisher_name = #{publisher_name}" +
+            "   publisher_name = #{name}" +
             "   where uuid = #{uuid} and id = #{id}")
-    int updatePublisherName(Map map);
+    int updatePublisherName(@Param("name") String name, @Param("uuid") String uuid, @Param("id") long id);
     List<MyPlaceCategory> findByIds(@Param("list") List<Long> idList);
     List<MyPlaceCategory> freeFind(Map<String, Object> data);
     List<MyPlaceCategory> findAll();

--- a/service-myplaces/src/main/java/fi/nls/oskari/myplaces/MyPlaceMapper.java
+++ b/service-myplaces/src/main/java/fi/nls/oskari/myplaces/MyPlaceMapper.java
@@ -11,7 +11,6 @@ import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.Update;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * Created by SMAKINEN on 8.7.2015.
@@ -108,7 +107,6 @@ public interface MyPlaceMapper {
             "   where uuid = #{uuid} and id = #{id}")
     int updatePublisherName(@Param("name") String name, @Param("uuid") String uuid, @Param("id") long id);
     List<MyPlaceCategory> findByIds(@Param("list") List<Long> idList);
-    List<MyPlaceCategory> freeFind(Map<String, Object> data);
     List<MyPlaceCategory> findAll();
     @Delete("delete from categories where uuid = #{uid}")
     void deleteByUid(String uid);

--- a/service-myplaces/src/main/java/fi/nls/oskari/myplaces/MyPlacesServiceMybatisImpl.java
+++ b/service-myplaces/src/main/java/fi/nls/oskari/myplaces/MyPlacesServiceMybatisImpl.java
@@ -192,14 +192,9 @@ public class MyPlacesServiceMybatisImpl extends MyPlacesService {
     public int updatePublisherName(final long id, final String uuid, final String name) {
         LOG.debug("Updating publisher name", id, uuid, name);
 
-        final Map<String, Object> data = new HashMap<>();
-        data.put("publisher_name", name);
-        data.put("uuid", uuid);
-        data.put("id", id);
-
         try (final SqlSession session = factory.openSession()) {
             final MyPlaceMapper mapper = session.getMapper(MyPlaceMapper.class);
-            int rows = mapper.updatePublisherName(data);
+            int rows = mapper.updatePublisherName(name, uuid, id);
             session.commit();
             // update data in cache
             MyPlaceCategory layer = getFromCache(id);
@@ -208,7 +203,7 @@ public class MyPlacesServiceMybatisImpl extends MyPlacesService {
             }
             return rows;
         } catch (Exception e) {
-            LOG.error(e, "Failed to update publisher name", data);
+            LOG.error(e, "Failed to update publisher name", name, uuid, id);
         }
         return 0;
     }

--- a/service-myplaces/src/main/java/fi/nls/oskari/myplaces/MyPlacesServiceMybatisImpl.java
+++ b/service-myplaces/src/main/java/fi/nls/oskari/myplaces/MyPlacesServiceMybatisImpl.java
@@ -218,19 +218,6 @@ public class MyPlacesServiceMybatisImpl extends MyPlacesService {
         return Collections.emptyList();
     }
 
-    public List<MyPlaceCategory> getMyPlaceLayersBySearchKey(final String search) {
-        Map<String, Object> data = new HashMap<String, Object>();
-        data.put("searchKey", search + ":*");
-        try (final SqlSession session = factory.openSession()) {
-            final MyPlaceMapper mapper = session.getMapper(MyPlaceMapper.class);
-            return mapper.freeFind(data);
-        } catch (Exception e) {
-            LOG.error(e, "Failed searchwith", search);
-        }
-        return Collections.emptyList();
-    }
-
-
     public void deleteByUid(final String uid) {
         try (final SqlSession session = factory.openSession()) {
             final MyPlaceMapper mapper = session.getMapper(MyPlaceMapper.class);


### PR DESCRIPTION
After the Oskari 3.0 changes/upgrades a java Map as parameter to MyBatis mapper-files no longer seems to work. It's easier (for everyone) to use the typed parameters and not using a Map to pass the parameters. Map was easier when the SQL was in Mapper.xml-files, but now that the SQL is mostly in Java annotations we don't need to wrap the params into maps anymore.

Having a myplaces layer on (the openlayers) map when the user publishes a map using the UI -> changes the visibility of the myplaces layer so anonymous users can see the layer. This is because published maps are usually shared and accessed by anonymous users. This fixes an issue where the visibility could not be changed, hence the user sees the myplaces layer on map and (while logged in) also on the published map. However anonymous users wouldn't see the layer as the "publisher name" could not be updated from null (==not published) to the publishers nickname (== anonymous access allowed).

Stacktrace for the error:
```
2025-03-31 13:34:07,275 [http-nio-7701-exec-9] ERROR fi.nls.oskari.myplaces.MyPlacesServiceMybatisImpl - Failed to update publisher name Map [{publisher_name=xxx},{id=yyy},{uuid=d3a216dd-077d-44ce-b79a-adf20ca88367}]
org.apache.ibatis.exceptions.PersistenceException:
### Error updating database.  Cause: org.apache.ibatis.type.TypeException: Could not set parameters for mapping: ParameterMapping{property='publisher_name', mode=IN, javaType=interface java.util.Map, jdbcType=null, numericScale=null, resultMapId='null', jdbcTypeName='null', expression='null'}. Cause: org.apache.ibatis.type.TypeException: Error setting non null for parameter #1 with JdbcType null . Try setting a different JdbcType for this parameter or a different configuration property. Cause: java.lang.ClassCastException: class java.lang.String cannot be cast to class java.util.Map (java.lang.String and java.util.Map are in module java.base of loader 'bootstrap')
### The error may exist in fi/nls/oskari/myplaces/MyPlaceMapper.java (best guess)
### The error may involve fi.nls.oskari.myplaces.MyPlaceMapper.updatePublisherName-Inline
### The error occurred while setting parameters
### SQL: update categories set    publisher_name = ?   where uuid = ? and id = ?
### Cause: org.apache.ibatis.type.TypeException: Could not set parameters for mapping: ParameterMapping{property='publisher_name', mode=IN, javaType=interface java.util.Map, jdbcType=null, numericScale=null, resultMapId='null', jdbcTypeName='null', expression='null'}. Cause: org.apache.ibatis.type.TypeException: Error setting non null for parameter #1 with JdbcType null . Try setting a different JdbcType for this parameter or a different configuration property. Cause: java.lang.ClassCastException: class java.lang.String cannot be cast to class java.util.Map (java.lang.String and java.util.Map are in module java.base of loader 'bootstrap')
        at org.apache.ibatis.exceptions.ExceptionFactory.wrapException(ExceptionFactory.java:30) ~[mybatis-3.5.19.jar:3.5.19]
        at org.apache.ibatis.session.defaults.DefaultSqlSession.update(DefaultSqlSession.java:199) ~[mybatis-3.5.19.jar:3.5.19]
        at org.apache.ibatis.binding.MapperMethod.execute(MapperMethod.java:67) ~[mybatis-3.5.19.jar:3.5.19]
        at org.apache.ibatis.binding.MapperProxy$PlainMethodInvoker.invoke(MapperProxy.java:141) ~[mybatis-3.5.19.jar:3.5.19]
        at org.apache.ibatis.binding.MapperProxy.invoke(MapperProxy.java:86) ~[mybatis-3.5.19.jar:3.5.19]
        at jdk.proxy3/jdk.proxy3.$Proxy108.updatePublisherName(Unknown Source) ~[?:?]
        at fi.nls.oskari.myplaces.MyPlacesServiceMybatisImpl.updatePublisherName(MyPlacesServiceMybatisImpl.java:202) ~[service-myplaces-3.0.0.jar:3.0.0]
```

Also removed the "freeFind" method that allowed searching for myplaces features with free text. The SQL was removed years ago from the XML-mapper file as the functionality was removed way before the SQL was removed. But for some the methods were still included on the service-classes.