### PR TITLE
Migrate featuredata and metadatasearch automatically

### DIFF
--- a/content-resources/src/main/resources/flyway/oskari/V3_0_2__migrate_bundles.sql
+++ b/content-resources/src/main/resources/flyway/oskari/V3_0_2__migrate_bundles.sql
@@ -1,0 +1,10 @@
+UPDATE oskari_appsetup_bundles
+ SET bundle_id = (select id from oskari_bundle where name='metadatasearch'),
+     bundleinstance = 'metadatasearch'
+ WHERE bundle_id = (select id from oskari_bundle where name='metadatacatalogue');
+
+UPDATE oskari_appsetup_bundles
+ SET bundle_id = (select id from oskari_bundle where name='featuredata'),
+     bundleinstance = 'featuredata'
+ WHERE bundle_id = (select id from oskari_bundle where name='featuredata2');
+ 


### PR DESCRIPTION
Old implementations were removed in 3.0.0. This is convenience so apps don't need to do db migration themselves.