### PR TITLE
Force targetCRS to always have longitude first on GetWfFeaturesHandler

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandler.java
@@ -53,7 +53,7 @@ public class GetWFSFeaturesHandler extends AbstractWFSFeaturesHandler {
         String targetSRS = params.getHttpParam(ActionConstants.PARAM_SRS, "EPSG:3857");
         CoordinateReferenceSystem targetCRS;
         try {
-            targetCRS = CRS.decode(targetSRS);
+            targetCRS = CRS.decode(targetSRS, true);
         } catch (Exception e) {
             throw new ActionParamsException("Invalid " + ActionConstants.PARAM_SRS);
         }


### PR DESCRIPTION
Oskari seems to internally always handle longitude first, but GetWfsFeatureHandler tries to read the coordinate order from the actual coordinatesystem. This causes lat-lon coordinate systems ( for example ETRS:3879 ) to fail while fetching user defined layers.