### PR TITLE
Bump geotools 32.2 -> 32.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@ The one packaged without this is 2.15.1
 
         <quartz-scheduler.version>2.3.2</quartz-scheduler.version>
 
-        <geotools.version>32.2</geotools.version>
+        <geotools.version>32.3</geotools.version>
         <jts.version>1.20.0</jts.version>
         <!-- https://github.com/ElectronicChartCentre/java-vector-tile -->
         <mvt.version>1.4.1</mvt.version>


### PR DESCRIPTION
Tried updating to 33.1 directly, but there's some coordinate transform test that fails. We'll need to update it later.