### PR TITLE
Upgrade fileupload to more recent version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ target/
 */nbproject/
 */nbactions.xml
 */nb-configuration.xml
+.vscode/
 
 .metadata
 control-base/workbook.xlsx

--- a/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java
+++ b/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java
@@ -3,7 +3,6 @@ package org.oskari.control.userlayer;
 import java.io.*;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
@@ -297,7 +296,16 @@ public class CreateUserLayerHandler extends RestActionHandler {
                 .filter(f -> f.isFormField())
                 .collect(Collectors.toMap(
                         f -> f.getFieldName(),
-                        f -> new String(f.get(), StandardCharsets.UTF_8)));
+                        f -> getFieldValue(f)));
+    }
+
+    private String getFieldValue(FileItem item) {
+        try {
+            return item.getString(StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            log.debug("Unable to read value for field", item.getFieldName());
+        }
+        return null;
     }
 
     private SimpleFeatureCollection parseFeatures(FileItem zipFile,

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <commons-text.version>1.14.0</commons-text.version>
         <commons-codec.version>1.19.0</commons-codec.version>
-        <commons-fileupload.version>2.0.0-M2</commons-fileupload.version>
+        <commons-fileupload.version>2.0.0-M4</commons-fileupload.version>
 
 <!-- This will override commons-io to be packaged with version 2.18.0, otherwise
 https://mvnrepository.com/artifact/org.apache.poi/poi-ooxml/5.4.0


### PR DESCRIPTION
Updated:
- commons-fileupload 2.0.0-M2 -> 2.0.0-M4

and handled the introduced IOException.