### PR TITLE
Add LayerProvider concept

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/view/modifier/bundle/MapfullHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/view/modifier/bundle/MapfullHandler.java
@@ -27,17 +27,24 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONTokener;
+import org.oskari.domain.map.LayerExtendedOutput;
 import org.oskari.map.myfeatures.service.MyFeaturesService;
 import org.oskari.map.userlayer.service.UserLayerDataService;
 import org.oskari.map.userlayer.service.UserLayerDbService;
+import org.oskari.service.maplayer.DescribeLayerQuery;
+import org.oskari.service.maplayer.LayerProvider;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @OskariViewModifier("mapfull")
 public class MapfullHandler extends BundleHandler {
@@ -70,31 +77,23 @@ public class MapfullHandler extends BundleHandler {
     private static final String TERRAIN_TOKEN = PropertyUtil.getOptional("oskari.map.terrain.token");
     private static final String TERRAIN_URL = PropertyUtil.getOptional("oskari.map.terrain.url");
 
-    private static final String PREFIX_MYPLACES = "myplaces_";
-    private static final String PREFIX_USERLAYERS = "userlayer_";
-    private static final String PREFIX_MYFEATURES = "myf_";
-    private static final Set<String> BUNDLES_HANDLING_MYPLACES_LAYERS = ConversionHelper.asSet(ViewModifier.BUNDLE_MYPLACES3);
-
     private static final String PLUGIN_LAYERSELECTION = "Oskari.mapframework.bundle.mapmodule.plugin.LayerSelectionPlugin";
     private static final String PLUGIN_GEOLOCATION = "Oskari.mapframework.bundle.mapmodule.plugin.GeoLocationPlugin";
     private static final String PLUGIN_MYLOCATION = "Oskari.mapframework.bundle.mapmodule.plugin.MyLocationPlugin";
 
     public static final String EPSG_PROJ4_FORMATS = "epsg_proj4_formats.json";
 
-    private static MyPlacesService myPlaceService = null;
-    private static UserLayerDbService userLayerService;
-    private static MyFeaturesService myFeaturesService;
-    private static OskariLayerService mapLayerService;
+    private Collection<LayerProvider> layerProviders;
 
     private JSONObject epsgMap = null;
     private HashMap<String, PluginHandler> pluginHandlers = null;
 
 
     public void init() {
-        myPlaceService = OskariComponentManager.getComponentOfType(MyPlacesService.class);
-        userLayerService = OskariComponentManager.getComponentOfType(UserLayerDbService.class);
-        myFeaturesService = OskariComponentManager.getComponentOfType(MyFeaturesService.class);
-        mapLayerService = OskariComponentManager.getComponentOfType(OskariLayerService.class);
+        if (layerProviders == null) {
+            Map<String, LayerProvider> components = OskariComponentManager.getComponentsOfType(LayerProvider.class);
+            layerProviders = components.values();
+        }
         epsgInit();
         pluginHandlers = new HashMap<>();
         // Note! atleast WFSVectorLayerPluginViewModifier is being registered outside this handler
@@ -139,7 +138,7 @@ public class MapfullHandler extends BundleHandler {
             LOGGER.error(e, "Unable to overwrite layers");
         }
         // init terrain profile from properties if given
-        setTerrainFromProperties (mapfullConfig);
+        setTerrainFromProperties(mapfullConfig);
 
         // dummyfix: because migration tool added layer selection to all migrated maps
         // remove it from old published maps if only one layer is selected
@@ -235,78 +234,21 @@ public class MapfullHandler extends BundleHandler {
      * @param forceProxy              false to keep urls as is, true to proxy all layers
      * @return
      */
-    public static JSONArray getFullLayerConfig(final JSONArray layersArray,
+    public List<LayerExtendedOutput> getFullLayerConfig(final JSONArray layersArray,
                                                final User user, final String lang, final long viewID,
                                                final String viewType, final Set<String> bundleIds,
                                                final boolean modifyURLs,
                                                final String mapSRS,
                                                final boolean forceProxy) {
 
-        // Create a list of layer ids
-        final List<Integer> layerIdList = new ArrayList<>();
-        final List<Long> publishedMyPlaces = new ArrayList<>();
-        final List<Long> publishedUserLayers = new ArrayList<>();
-        final List<UUID> publishedMyFeatures = new ArrayList<>();
+        Set<String> layerIds = getLayerIds(layersArray);
 
-        for (int i = 0; i < layersArray.length(); i++) {
-            String layerId = null;
-            try {
-                final JSONObject layer = layersArray.getJSONObject(i);
-                layerId = layer.optString(KEY_ID);
-                if (layerId == null || layerIdList.contains(layerId)) {
-                    continue;
-                }
-                // special handling for myplaces and userlayer layers
-                if (layerId.startsWith(PREFIX_MYPLACES)) {
-                    final long categoryId =
-                            ConversionHelper.getLong(layerId.substring(PREFIX_MYPLACES.length()), -1);
-                    if (categoryId != -1) {
-                        publishedMyPlaces.add(categoryId);
-                    } else {
-                        LOGGER.warn("Found my places layer in selected. Error parsing id with category id: ", layerId);
-                    }
-                } else if (layerId.startsWith(PREFIX_USERLAYERS)) {
-                    final long userLayerId = ConversionHelper
-                            .getLong(layerId.substring(PREFIX_USERLAYERS.length()), -1);
-                    if (userLayerId != -1) {
-                        publishedUserLayers.add(userLayerId);
-                    } else {
-                        LOGGER.warn("Found user layer in selected. Error parsing id with prefixed id: ", layerId);
-                    }
-                } else if (layerId.startsWith(PREFIX_MYFEATURES)) {
-                    try {
-                        UUID myFeaturesLayerId = MyFeaturesLayer.parseLayerId(layerId).get();
-                        publishedMyFeatures.add(myFeaturesLayerId);
-                    } catch (Exception ignore) {
-                        LOGGER.warn("Found myfeatures layer in selected. Error parsing id with prefixed id: ", layerId);
-                    }
-                } else {
-                    int id = ConversionHelper.getInt(layerId, -1);
-                    if (id != -1) {
-                        // these should all be pointing at a layer in oskari_maplayer
-                        layerIdList.add(id);
-                    }
-                }
-            } catch (JSONException je) {
-                LOGGER.error(je, "Problem handling layer id:", layerId, "skipping it!.");
-            }
-        }
-
-        final List<OskariLayer> layers = mapLayerService.findByIdList(layerIdList);
-        if (forceProxy) {
-            layers.forEach(lyr -> {
-                if (lyr.getType().equals(OskariLayer.TYPE_3DTILES)) {
-                    // Proxy is not supported for 3D layers
-                    return;
-                }
-                JSONObject attributes = lyr.getAttributes();
-                if (attributes == null) {
-                    attributes = new JSONObject();
-                }
-                JSONHelper.putValue(attributes, "forceProxy", forceProxy);
-                lyr.setAttributes(attributes);
-            });
-        }
+        List<LayerExtendedOutput> described = layerProviders.stream()
+            .flatMap(provider -> layerIds.stream()
+                .filter(provider::maybeProvides)
+                .map(layerId -> new DescribeLayerQuery(viewID, layerId, user, lang, mapSRS))
+                .map(provider::describeLayer))
+            .collect(Collectors.toList());
 
         final JSONObject struct = OskariLayerWorker.getListOfMapLayers(
                 layers, user, lang, mapSRS, ViewTypes.PUBLISHED.equals(viewType), modifyURLs);
@@ -316,7 +258,6 @@ public class MapfullHandler extends BundleHandler {
                     layerIdList);
         }
 
-        // construct layers JSON
         final JSONArray prefetch = getLayersArray(struct);
         appendMyPlacesLayers(prefetch, publishedMyPlaces, user, viewID, lang, bundleIds, mapSRS);
         appendUserLayers(prefetch, publishedUserLayers, user, viewID, lang, bundleIds, mapSRS);
@@ -324,166 +265,39 @@ public class MapfullHandler extends BundleHandler {
         return prefetch;
     }
 
-    private static boolean isMyplacesBundlePresent(Set<String> bundleIdList) {
-        for(String bundleId : BUNDLES_HANDLING_MYPLACES_LAYERS) {
-            if(bundleIdList.contains(bundleId)) {
-                return true;
-            }
-        }
-        return false;
-    }
+    private List<
 
-    private static void appendMyPlacesLayers(final JSONArray layerList,
-                                             final List<Long> publishedMyPlaces,
-                                             final User user,
-                                             final long viewID,
-                                             final String lang,
-                                             final Set<String> bundleIds,
-                                             final String mapSrs) {
-        if (publishedMyPlaces.isEmpty()) {
-            return;
-        }
-        final boolean myPlacesBundlePresent = isMyplacesBundlePresent(bundleIds);
-        // get myplaces categories from service and generate layer jsons
-        final String uuid = user.getUuid();
-        final List<MyPlaceCategory> myPlacesLayers = myPlaceService
-                .getMyPlaceLayersById(publishedMyPlaces);
-
-        for (MyPlaceCategory mpLayer : myPlacesLayers) {
-            if (!mpLayer.isPublished() && !mpLayer.isOwnedBy(uuid)) {
-                LOGGER.info("Found my places layer in selected that is no longer published. ViewID:",
-                        viewID, "Myplaces layerId:", mpLayer.getId());
-                // no longer published -> skip if isn't current users layer
-                continue;
-            }
-            if (myPlacesBundlePresent && mpLayer.isOwnedBy(uuid)) {
-                // if the layer is users own -> myplaces2 bundle handles it
-                // so if myplaces2 is present we must skip the users layers
-                continue;
-            }
-
-            JSONObject myPlaceLayer = MyPlacesService.parseLayerToJSON(mpLayer, mapSrs, lang);
-            // Get as WFS layer
-            JSONHelper.putValue(myPlaceLayer, LayerJSONFormatter.KEY_TYPE, OskariLayer.TYPE_WFS);
-            layerList.put(myPlaceLayer);
-        }
-    }
-
-    private static void appendUserLayers(final JSONArray layerList,
-                                         final List<Long> publishedUserLayers,
-                                         final User user,
-                                         final long viewID,
-                                         final String lang,
-                                         final Set<String> bundleIds,
-                                         final String mapSrs) {
-        final boolean userLayersBundlePresent = bundleIds.contains(BUNDLE_MYPLACESIMPORT);
-        for (Long id : publishedUserLayers) {
-            final UserLayer userLayer = userLayerService.getUserLayerById(id);
-
-            if (userLayer == null) {
-                LOGGER.warn("Unable to find published user layer with id", id);
-                continue;
-            }
-
-            if (userLayersBundlePresent && userLayer.isOwnedBy(user.getUuid())) {
-                // skip if it's an own layer and myplacesimport bundle is present ->
-                // will be loaded via aforementioned bundle
-                continue;
-            }
-
-            if (!userLayer.isPublished() && !userLayer.isOwnedBy(user.getUuid())) {
-                LOGGER.info("Found user layer in selected that is no longer published. ViewID:",
-                        viewID, "User layer id:", userLayer.getId());
-                // no longer published -> skip if isn't current users layer
-                continue;
-            }
-            final JSONObject json = UserLayerDataService.parseUserLayer2JSON(userLayer, mapSrs, lang);
-            if (json != null) {
-                layerList.put(json);
-            }
-        }
-    }
-
-    private static void appendMyFeaturesLayers(
-        final JSONArray layerList,
-        final List<UUID> publishedMyFeaturesLayers,
-        final User user,
-        final long viewID,
-        final String lang,
-        final Set<String> bundleIds,
-        final String mapSrs) {
-        for (UUID id : publishedMyFeaturesLayers) {
-            final MyFeaturesLayer layer = myFeaturesService.getLayer(id);
-
-            if (layer == null) {
-                LOGGER.warn("Unable to find published myfeatures layer with id", id);
-                continue;
-            }
-
-            if (!layer.isPublished() && !layer.getOwnerUuid().equals(user.getUuid())) {
-                LOGGER.info("Found myfeatures layer in selected that is no longer published. ViewID:",
-                        viewID, "myfeatures layer id:", id);
-                // no longer published -> skip if isn't owned by user
-                continue;
-            }
-
-            // Override type to wfslayer
-            MyFeaturesLayerInfo info = MyFeaturesLayerInfo.from(layer, lang, OskariLayer.TYPE_WFS);
-            try {
-                String jsonString = ObjectMapperProvider.OM.writeValueAsString(info);
-                JSONObject json = new JSONObject(jsonString);
-                if (json != null) {
-                    layerList.put(json);
+    private static Set<String> getLayerIds(final JSONArray layersArray) {
+        Set<String> layerIds = new HashSet<>();
+        for (int i = 0; i < layersArray.length(); i++) {
+            JSONObject layer = layersArray.optJSONObject(i);
+            if (layer != null) {
+                String layerId = layer.optString(KEY_ID);
+                if (layerId != null) {
+                    layerIds.add(layerId);
                 }
-            } catch (Exception e) {
-                LOGGER.warn(e, "Failed to encode/decode layer info");
             }
         }
-    }
-
-    private static JSONArray getLayersArray(final JSONObject struct) {
-        try {
-            final Object layers = struct.get(KEY_LAYERS);
-            if (layers instanceof JSONArray) {
-                return (JSONArray) layers;
-            } else if (layers instanceof JSONObject) {
-                final JSONArray list = new JSONArray();
-                list.put(layers);
-                return list;
-            } else {
-                LOGGER.error("getSelectedLayersStructure returned garbage layers.");
-            }
-        } catch (JSONException jsonex) {
-            LOGGER.error("Could not set prefetch layers.");
-        }
-        return new JSONArray();
-    }
+        return layerIds;
+    } 
 
     private void copySelectedLayersToConfigLayers(final JSONArray mfConfigLayers,
                                                   final JSONArray mfStateLayers) {
+        if (mfStateLayers.isEmpty()) {
+            return;
+        }
+        Set<String> layerIds = getLayerIds(mfConfigLayers);
         for (int i = 0; i < mfStateLayers.length(); i++) {
-            String stateLayerId = null;
-            String confLayerId = null;
-            JSONObject stateLayer = null;
-            JSONObject confLayer = null;
-            try {
-                boolean inConfigLayers = false;
-                stateLayer = mfStateLayers.getJSONObject(i);
-                stateLayerId = stateLayer.optString(KEY_ID);
-
-                for (int j = 0; j < mfConfigLayers.length(); j++) {
-                    confLayer = mfConfigLayers.getJSONObject(j);
-                    confLayerId = confLayer.optString(KEY_ID);
-                    if (stateLayerId.equals(confLayerId)) {
-                        inConfigLayers = true;
-                    }
-                }
-                if (!inConfigLayers) {
-                    mfConfigLayers.put(stateLayer);
-                }
-            } catch (JSONException je) {
-                LOGGER.error(je, "Problem comparing layers - StateLayerId:",
-                        stateLayerId, "vs confLayerId:", confLayerId);
+            JSONObject stateLayer = mfStateLayers.optJSONObject(i);
+            if (stateLayer == null) {
+                continue;
+            }
+            String stateLayerId = stateLayer.optString(KEY_ID);
+            if (stateLayerId == null) {
+                continue;
+            }
+            if (layerIds.add(stateLayerId)) {
+                mfConfigLayers.put(stateLayer);
             }
         }
     }

--- a/control-base/src/main/java/org/oskari/control/layer/DescribeLayerHandler.java
+++ b/control-base/src/main/java/org/oskari/control/layer/DescribeLayerHandler.java
@@ -2,37 +2,17 @@ package org.oskari.control.layer;
 
 import fi.nls.oskari.annotation.OskariActionRoute;
 import fi.nls.oskari.control.*;
-import fi.nls.oskari.control.layer.PermissionHelper;
-import fi.nls.oskari.domain.map.OskariLayer;
-import fi.nls.oskari.domain.map.style.VectorStyle;
-import fi.nls.oskari.domain.map.wfs.WFSLayerAttributes;
-import fi.nls.oskari.domain.map.wfs.WFSLayerOptions;
-import fi.nls.oskari.log.LogFactory;
-import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.map.geometry.WKTHelper;
-import fi.nls.oskari.map.layer.OskariLayerService;
-import fi.nls.oskari.map.layer.formatters.LayerJSONFormatter;
-import fi.nls.oskari.map.style.VectorStyleHelper;
-import fi.nls.oskari.map.style.VectorStyleService;
 import fi.nls.oskari.service.OskariComponentManager;
-import fi.nls.oskari.service.ServiceRuntimeException;
 import fi.nls.oskari.util.*;
 
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
-import org.json.JSONObject;
-import org.oskari.capabilities.CapabilitiesService;
-import org.oskari.capabilities.ogc.LayerCapabilitiesWFS;
-import org.oskari.capabilities.ogc.LayerCapabilitiesWMTS;
-import org.oskari.capabilities.ogc.wfs.FeaturePropertyType;
-import org.oskari.capabilities.ogc.wmts.TileMatrixLink;
-import org.oskari.domain.map.FeatureProperties;
 import org.oskari.domain.map.LayerExtendedOutput;
-import org.oskari.permissions.PermissionService;
-import org.oskari.service.user.UserLayerService;
+import org.oskari.service.maplayer.DescribeLayerQuery;
+import org.oskari.service.maplayer.LayerProvider;
 import org.oskari.user.User;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 import static fi.nls.oskari.control.ActionConstants.PARAM_ID;
 import static fi.nls.oskari.control.ActionConstants.PARAM_SRS;
@@ -44,36 +24,18 @@ import static fi.nls.oskari.control.ActionConstants.PARAM_SRS;
 public class DescribeLayerHandler extends RestActionHandler {
 
     private static final String ERR_INVALID_ID = "Invalid id";
+    private static final String PARAM_STYLES = "styleId";
 
-    private PermissionHelper permissionHelper;
-    private Collection<UserLayerService> userContentProcessors;
-
-    private Set<String> preferredSRS;
-    private static final Logger LOG = LogFactory.getLogger(DescribeLayerHandler.class);
+    private Collection<LayerProvider> layerProviders;
 
     @Override
     public void init() {
-        if (permissionHelper != null) {
-            return;
-        }
-        try {
-            final OskariLayerService layerService = OskariComponentManager.getComponentOfType(OskariLayerService.class);
-            final PermissionService permissionService = OskariComponentManager.getComponentOfType(PermissionService.class);
-            permissionHelper = new PermissionHelper(layerService, permissionService);
-        } catch (Exception e) {
-            throw new ServiceRuntimeException("Exception occurred while initializing map layer service", e);
-        }
-
-        Map<String, UserLayerService> components = OskariComponentManager.getComponentsOfType(UserLayerService.class);
-        this.userContentProcessors = components.values();
+        Map<String, LayerProvider> components = OskariComponentManager.getComponentsOfType(LayerProvider.class);
+        this.layerProviders = components.values();
     }
 
-    public void setPermissionHelper(PermissionHelper helper) {
-        permissionHelper = helper;
-    }
-
-    private VectorStyleService getVectorStyleService() {
-        return OskariComponentManager.getComponentOfType(VectorStyleService.class);
+    public void setLayerProviders(Collection<LayerProvider> layerProviders) {
+        this.layerProviders = layerProviders;
     }
 
     @Override
@@ -84,235 +46,28 @@ public class DescribeLayerHandler extends RestActionHandler {
         final CoordinateReferenceSystem crs = params.getHttpParam(PARAM_SRS) == null
             ? null
             : WKTHelper.getCRS(params.getHttpParam(PARAM_SRS));
+        // link params or published map could have selected style which is created by another user
+        final String styles = params.getHttpParam(PARAM_STYLES);
+        final List<String> styleIds = styles != null ? Arrays.asList(styles.split(",")) : null;
 
-        LayerExtendedOutput output = null;
+        final DescribeLayerQuery query = new DescribeLayerQuery(layerId, user, lang, crs, styleIds);
 
-        Optional<UserLayerService> processorOpt = getUserContentProsessor(layerId);
-        if (processorOpt.isPresent()) {
-            UserLayerService proc = processorOpt.get();
-            if (!proc.hasViewPermission(layerId, user)) {
-                throw new ActionDeniedException("User doesn't have permissions for requested layer");
-            }
-            output = proc.describeLayer(layerId, lang, crs);
-        } else {
-            final OskariLayer layer = findMapLayer(layerId, user);
-            output = getLayerDetails(params, layer);
-        }
+        LayerExtendedOutput output = describeLayer(query);
 
         ResponseHelper.writeJsonResponse(params, output);
     }
 
-    private Optional<UserLayerService> getUserContentProsessor(String layerId) {
-        return userContentProcessors.stream()
-                .filter(proc -> proc.isUserContentLayer(layerId))
-                .findAny();
-    }
+    private LayerExtendedOutput describeLayer(DescribeLayerQuery query) throws ActionException {
+        LayerProvider provider = layerProviders.stream()
+            .filter(p -> p.maybeProvides(query.getLayerId()))
+            .findAny()
+            .orElseThrow(() -> new ActionParamsException(ERR_INVALID_ID));
 
-    private OskariLayer findMapLayer(String layerId, User user) throws ActionException {
-        int id;
         try {
-            id = Integer.parseInt(layerId);
-        } catch (NumberFormatException e) {
-            throw new ActionParamsException(ERR_INVALID_ID);
-        }
-        return permissionHelper.getLayer(id, user);
-    }
-
-    private LayerExtendedOutput getLayerDetails(ActionParameters params, OskariLayer layer) throws ActionException {
-        final String lang = params.getLocale().getLanguage();
-        final String crs = params.getHttpParam(PARAM_SRS);
-        final int layerId = layer.getId();
-        final String layerType = layer.getType();
-
-        LayerExtendedOutput output = new LayerExtendedOutput();
-        output.id = Integer.toString(layerId);
-        output.name = layer.getName(lang);
-        JSONObject attributes = layer.getAttributes();
-        if (!attributes.optBoolean(LayerJSONFormatter.KEY_ATTRIBUTE_IGNORE_COVERAGE, false)) {
-            output.coverage = getCoverageWKT(layer.getGeometry(), crs);
-        }
-        if (VectorStyleHelper.isVectorLayer(layer)) {
-            output.styles = getVectorStyles(params, layerId);
-            output.hover = JSONHelper.getObjectAsMap(layer.getOptions().optJSONObject("hover"));
-        }
-        if (OskariLayer.TYPE_WFS.equals(layerType)) {
-            setDetailsForWFS(output, layer, lang);
-        }
-        if (OskariLayer.TYPE_WMTS.equals(layerType)) {
-            output.capabilities = getCapabilitiesJSON(layer, crs);
-        }
-        return output;
-    }
-    private void setDetailsForWFS (LayerExtendedOutput output, OskariLayer layer, String lang) {
-        // UserDataLayers are handled in frontend by WFS plugin and embedded myplaces is using WFS type
-        // so LayerJSONFormatterUSERDATA gathers values from options and attributes in same way than this
-        LayerCapabilitiesWFS caps = CapabilitiesService.fromJSON(layer.getCapabilities().toString(), layer.getType());
-        WFSLayerAttributes attr = new WFSLayerAttributes(layer.getAttributes());
-        WFSLayerOptions opts = new WFSLayerOptions(layer.getOptions());
-        output.properties = getProperties(caps, attr, lang);
-        output.controlData = getControlData(caps, attr, opts);
-    }
-
-    private List<FeatureProperties> getProperties(LayerCapabilitiesWFS caps, WFSLayerAttributes attr , String lang) {
-        List<FeatureProperties> props = new ArrayList<>();
-
-        List<String> selected = attr.getSelectedAttributes(lang);
-        JSONObject locale = attr.getLocalization(lang).orElse(new JSONObject());
-        JSONObject format = attr.getFieldFormatMetadata().orElse(new JSONObject());
-
-        caps.getFeatureProperties().stream().forEach(prop -> {
-            FeatureProperties p = new FeatureProperties();
-            p.name = prop.name;
-            p.type = WFSConversionHelper.getSimpleType(prop.type);
-            p.rawType = prop.type;
-            p.label = locale.optString(prop.name, null);
-            p.format = getPropertyFormat(format, prop.name);
-            if (!selected.isEmpty()) {
-                int index = selected.indexOf(p.name);
-                if (index == -1) {
-                    p.hidden = true;
-                    p.order = selected.size();
-                } else {
-                    p.order = index;
-                }
-            }
-            props.add(p);
-        });
-        if (!selected.isEmpty()) {
-            props.sort(Comparator.comparingInt(a -> a.order));
-        }
-        return props;
-    }
-    private Map<String, Object> getPropertyFormat (JSONObject format, String name) {
-        JSONObject propFormat = format.optJSONObject(name);
-        // return null if doesn't exist
-        return propFormat != null ? JSONHelper.getObjectAsMap(propFormat) : null;
-    }
-
-    private Map<String, Object> getControlData (LayerCapabilitiesWFS caps, WFSLayerAttributes attr, WFSLayerOptions opts) {
-        Map<String, Object> data = new HashMap<>();
-
-        JSONObject attrData = attr.getAttributesData();
-        data.put(WFSLayerAttributes.KEY_NO_DATA_VALUE, attr.getNoDataValue());
-        data.put(WFSLayerAttributes.KEY_COMMON_ID, attr.getCommonId());
-        data.put(WFSLayerAttributes.KEY_REPLACE_ID, attrData.optString(WFSLayerAttributes.KEY_REPLACE_ID, null));
-
-        String geomType = attrData.optString(WFSLayerAttributes.KEY_GEOMETRY_TYPE, null);
-        if (geomType == null) {
-            String geomName = caps.getGeometryField();
-            FeaturePropertyType fpt = caps.getFeatureProperty(geomName);
-            if (fpt != null) {
-                geomType = WFSConversionHelper.getStyleType(fpt.type);
-            }
-        }
-        data.put(WFSLayerAttributes.KEY_GEOMETRY_TYPE, geomType);
-
-        data.put(WFSLayerOptions.KEY_RENDER_MODE, opts.getRenderMode());
-        data.put(WFSLayerOptions.KEY_CLUSTER, opts.getClusteringDistance());
-        return data;
-    }
-
-    private List<VectorStyle> getVectorStyles (ActionParameters params, int layerId) {
-        VectorStyleService service = getVectorStyleService();
-        final long userId = params.getUser().getId();
-        List<VectorStyle> styles = service.getStyles(userId, layerId);
-        // link params or published map could have selected style which is created by another user
-        String styleIdList = params.getHttpParam("styleId");
-        if (styleIdList == null || styleIdList.isEmpty()) {
-            return styles;
-        }
-        // attach any styles that were specifically requested by the frontend
-        Arrays.stream(styleIdList.split(","))
-                .forEach(style -> {
-            int styleId = ConversionHelper.getInt(style, -1);
-            if (styleId == -1) {
-                // not a number, we only care about numbers as other styles are not saved in vector styles
-                return;
-            }
-            boolean isPresent = styles.stream().filter(s -> s.getId() == styleId).findFirst().isPresent();
-            if (isPresent) {
-                // already referenced in styles -> don't need to add it again
-                return;
-            }
-            VectorStyle selected = service.getStyleById(styleId);
-            if (selected == null) {
-                LOG.info("Requested selected style with id:", styleId, "which doesn't exist");
-            } else {
-                styles.add(selected);
-            }
-        });
-        return styles;
-    }
-
-    // value will be not added if transform failed, that's ok since client can't handle it if it's in unknown projection
-    private String getCoverageWKT(final String wktWGS84, final String mapSRS) {
-        if (wktWGS84 == null || wktWGS84.isEmpty() || mapSRS == null || mapSRS.isEmpty()) {
-            return null;
-        }
-        try {
-            // WTK is saved as EPSG:4326 in database
-            return WKTHelper.transformLayerCoverage(wktWGS84, mapSRS);
-        } catch (Exception ex) {
-            LOG.debug("Error transforming coverage to", mapSRS, "from", wktWGS84);
-        }
-        return null;
-    }
-
-    private Map<String, Object> getCapabilitiesJSON(OskariLayer layer, String crs) throws ActionException {
-        if (!OskariLayer.TYPE_WMTS.equals(layer.getType())) {
-            return JSONHelper.getObjectAsMap(layer.getCapabilities());
-        }
-        try {
-            String capsJSON = layer.getCapabilities().toString();
-            LayerCapabilitiesWMTS caps = CapabilitiesService.fromJSON(layer.getCapabilities().toString(), OskariLayer.TYPE_WMTS);
-            TileMatrixLink link = determineTileMatrix(caps, crs);
-
-            // Make a copy so we don't mutate layer in cache
-            JSONObject modifiedCapabilities = new JSONObject(capsJSON);
-            // remove "tileMatrixLinks" (with all matrices) that is replaced with "tileMatrixSet" (just for current projection)
-            modifiedCapabilities.remove("tileMatrixLinks");
-            modifiedCapabilities.put("tileMatrixSet", link.getTileMatrixSet().getAsJSON());
-            return JSONHelper.getObjectAsMap(modifiedCapabilities);
-        } catch (Exception e) {
-            throw new ActionParamsException("Unable to parse JSON", e);
+            return provider.describeLayer(query);
+        } catch (SecurityException e) {
+            throw new ActionDeniedException(e.getMessage());
         }
     }
 
-    private TileMatrixLink determineTileMatrix(LayerCapabilitiesWMTS caps, String crs) throws ActionException {
-        TileMatrixLink link = caps.getTileMatrixLinks().stream()
-                .filter(l -> crs.equals(l.getTileMatrixSet().getShortCrs()))
-                .findFirst()
-                .orElse(null);
-        if (link != null) {
-            // happy case, we found a matching tilematrix for projection
-            return link;
-        }
-        // set of srs that layer supports
-        Set<String> supportedSRS = caps.getTileMatrixLinks().stream()
-                .map(l -> l.getTileMatrixSet().getShortCrs())
-                .collect(Collectors.toSet());
-        // first of preferred srs that layer supports
-        Set<String> prefSRS = getPreferredSRS();
-        String matchedSRS = prefSRS.stream()
-                .filter(srs -> supportedSRS.contains(srs))
-                .findFirst()
-                .orElseThrow(() -> new ActionParamsException("None of preferred SRS (" + LOG.getAsString(prefSRS) + ") supported by layer: " + LOG.getAsString(supportedSRS)));
-
-        return caps.getTileMatrixLinks().stream()
-                .filter(l -> matchedSRS.equals(l.getTileMatrixSet().getShortCrs()))
-                .findFirst()
-                .orElseThrow(() -> new ActionParamsException("No tilematrix matching srs: " + matchedSRS));
-    }
-
-    private Set<String> getPreferredSRS() {
-        if (preferredSRS == null) {
-            preferredSRS = new HashSet<>(5);
-            String nativeCRS = PropertyUtil.get("oskari.native.srs", "EPSG:3857");
-            preferredSRS.add(nativeCRS);
-            preferredSRS.add("EPSG:3857");
-            preferredSRS.add("EPSG:4326");
-            preferredSRS.add("EPSG:900913");
-        }
-        return preferredSRS;
-    }
 }

--- a/control-base/src/main/java/org/oskari/control/layer/DescribeLayerHandler.java
+++ b/control-base/src/main/java/org/oskari/control/layer/DescribeLayerHandler.java
@@ -2,11 +2,9 @@ package org.oskari.control.layer;
 
 import fi.nls.oskari.annotation.OskariActionRoute;
 import fi.nls.oskari.control.*;
-import fi.nls.oskari.map.geometry.WKTHelper;
 import fi.nls.oskari.service.OskariComponentManager;
 import fi.nls.oskari.util.*;
 
-import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.oskari.domain.map.LayerExtendedOutput;
 import org.oskari.service.maplayer.DescribeLayerQuery;
 import org.oskari.service.maplayer.LayerProvider;
@@ -43,14 +41,12 @@ public class DescribeLayerHandler extends RestActionHandler {
         final String layerId = params.getRequiredParam(PARAM_ID);
         final User user = params.getUser();
         final String lang = params.getLocale().getLanguage();
-        final CoordinateReferenceSystem crs = params.getHttpParam(PARAM_SRS) == null
-            ? null
-            : WKTHelper.getCRS(params.getHttpParam(PARAM_SRS));
+        final String crs = params.getHttpParam(PARAM_SRS);
         // link params or published map could have selected style which is created by another user
         final String styles = params.getHttpParam(PARAM_STYLES);
         final List<String> styleIds = styles != null ? Arrays.asList(styles.split(",")) : null;
 
-        final DescribeLayerQuery query = new DescribeLayerQuery(layerId, user, lang, crs, styleIds);
+        final DescribeLayerQuery query = new DescribeLayerQuery(null, layerId, user, lang, crs, styleIds);
 
         LayerExtendedOutput output = describeLayer(query);
 

--- a/control-myfeatures/src/main/java/org/oskari/control/myfeatures/MyFeaturesWFSHelper.java
+++ b/control-myfeatures/src/main/java/org/oskari/control/myfeatures/MyFeaturesWFSHelper.java
@@ -7,36 +7,23 @@ import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.domain.map.myfeatures.MyFeaturesFeature;
 import fi.nls.oskari.domain.map.myfeatures.MyFeaturesFieldInfo;
 import fi.nls.oskari.domain.map.myfeatures.MyFeaturesLayer;
-import fi.nls.oskari.domain.map.style.VectorStyle;
 import fi.nls.oskari.domain.map.wfs.WFSLayerOptions;
-import fi.nls.oskari.map.geometry.WKTHelper;
 import fi.nls.oskari.service.OskariComponentManager;
 import fi.nls.oskari.service.ServiceException;
 
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
-import org.geotools.referencing.CRS;
 import org.json.JSONObject;
-import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.Polygon;
-import org.locationtech.jts.io.WKTWriter;
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.feature.simple.SimpleFeatureType;
-import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
-import org.oskari.domain.map.FeatureProperties;
-import org.oskari.domain.map.LayerExtendedOutput;
 import org.oskari.geojson.GeoJSONFeatureCollection;
 import org.oskari.map.myfeatures.service.MyFeaturesService;
 import org.oskari.service.user.UserLayerService;
 
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -144,93 +131,6 @@ public final class MyFeaturesWFSHelper extends UserLayerService {
         layer.setOptions(myLayer.getOptions());
         layer.setAttributes(myLayer.getAttributes());
         return layer;
-    }
-
-    @Override
-    public LayerExtendedOutput describeLayer(String layerId, String lang, CoordinateReferenceSystem crs) {
-        MyFeaturesLayer layer = getLayer(parseLayerId(layerId));
-
-        LayerExtendedOutput describe = new LayerExtendedOutput();
-        describe.id = layerId;
-        describe.type = OskariLayer.TYPE_WFS;
-        describe.name = layer.getName(lang);
-        describe.metadataUuid = null;
-        describe.dataproviderId = null;
-        describe.created = layer.getCreated() == null ? null : new Date(layer.getCreated().toEpochMilli());
-        describe.updated = layer.getUpdated() == null ? null : new Date(layer.getUpdated().toEpochMilli());
-
-        describe.coverage = getCoverageWKT(layer.getExtent(), crs);
-        describe.styles = getVectorStyles(layer);
-        describe.hover = null;
-        describe.capabilities = null;
-
-        describe.properties = getProperties(layer, lang);
-        describe.controlData = null;
-
-        return describe;
-    }
-
-    static List<VectorStyle> getVectorStyles(MyFeaturesLayer layer) {
-        JSONObject defaultStyle = layer.getLayerOptions().getDefaultStyle();
-
-        VectorStyle vectorStyle = new VectorStyle();
-        vectorStyle.setType(VectorStyle.TYPE_OSKARI);
-        vectorStyle.setName("default");
-        vectorStyle.setStyle(defaultStyle);
-
-        return Collections.singletonList(vectorStyle);
-    }
-
-    private String getCoverageWKT(Envelope extent, CoordinateReferenceSystem crs) {
-        if (extent == null || crs == null) {
-            return null;
-        }
-        try {
-            CoordinateReferenceSystem sourceCRS = getService().getNativeCRS();
-            if (CRS.equalsIgnoreMetadata(sourceCRS, crs)) {
-                return WKTHelper.getBBOX(extent.getMinX(), extent.getMinY(), extent.getMaxX(), extent.getMaxY());
-            }
-            Polygon p = toGeometry(extent);
-            Geometry transformed = WKTHelper.transform(p, sourceCRS, crs);
-            return new WKTWriter(2).write(transformed);
-        } catch (Exception ignore) {
-            // Will not report back coverage if transform failed
-            // that's ok since client can't handle it if it's in unknown projection
-            return null;
-        }
-    }
-
-    public static Polygon toGeometry(Envelope e) {
-        if (e == null) {
-            return null;
-        }
-        Coordinate[] cornerCoordinates = new Coordinate[] {
-            new Coordinate(e.getMinX(), e.getMinY()),
-            new Coordinate(e.getMinX(), e.getMaxY()),
-            new Coordinate(e.getMaxX(), e.getMaxY()),
-            new Coordinate(e.getMaxX(), e.getMinY()),
-            new Coordinate(e.getMinX(), e.getMinY()),
-        };
-        return new GeometryFactory().createPolygon(cornerCoordinates);
-    }
-
-    private List<FeatureProperties> getProperties(MyFeaturesLayer layer, String lang) {
-        List<FeatureProperties> props = new ArrayList<>();
-
-        int i = 0;
-        for (MyFeaturesFieldInfo field : layer.getLayerFields()) {
-            FeatureProperties p = new FeatureProperties();
-            p.name = field.getName();
-            p.type = field.getType().getSimpleType();
-            p.rawType = field.getType().getOutputBinding().getName();
-            p.label = field.getName();
-            p.hidden = false;
-            p.format = null;
-            p.order = i++;
-            props.add(p);
-        }
-
-        return props;
     }
 
 }

--- a/service-map/src/main/java/fi/nls/oskari/map/geometry/WKTHelper.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/geometry/WKTHelper.java
@@ -102,6 +102,21 @@ public class WKTHelper {
      *  possibly with extra interpolated points in-between of the original segments
      */
     public static String transformLayerCoverage(final String wkt, final String targetSRS) {
+        CoordinateReferenceSystem targetCrs = getCRS(targetSRS);
+        return transformLayerCoverage(wkt, targetCrs);
+    }
+
+    /**
+     * @param wkt       original geometry in EPSG:4326
+     * @param targetCrs coordinate reference system to transform to
+     * @return null if:
+     *  - geometry is null
+     *  - geometry is not a Polygon
+     *  - any of the coordinates in the exterior ring is not within [-180,-90,180,90]
+     *  otherwise return the exterior ring of the polygon projected to the targetCrs and
+     *  possibly with extra interpolated points in-between of the original segments
+     */
+    public static String transformLayerCoverage(final String wkt, final CoordinateReferenceSystem targetCrs) {
         GeometryFactory gf = new GeometryFactory();
         Geometry geom = parseWKT(wkt, gf);
         if (geom == null || !(geom instanceof Polygon)) {
@@ -119,7 +134,6 @@ public class WKTHelper {
         CoordinateSequence cs = GeometryHelper.interpolateLinear(exterior, INTERPOLATE_THRESHOLD, gf);
         polygon = gf.createPolygon(cs);
         // input axis orientation is / must be x=lon y=lat
-        CoordinateReferenceSystem targetCrs = getCRS(targetSRS);
         final Geometry transformed = transform(polygon, CRS_EPSG_4326, targetCrs);
         // output is x=lon y=lat always in every projection
         return getWKT(transformed);

--- a/service-map/src/main/java/fi/nls/oskari/map/geometry/WKTHelper.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/geometry/WKTHelper.java
@@ -102,21 +102,6 @@ public class WKTHelper {
      *  possibly with extra interpolated points in-between of the original segments
      */
     public static String transformLayerCoverage(final String wkt, final String targetSRS) {
-        CoordinateReferenceSystem targetCrs = getCRS(targetSRS);
-        return transformLayerCoverage(wkt, targetCrs);
-    }
-
-    /**
-     * @param wkt       original geometry in EPSG:4326
-     * @param targetCrs coordinate reference system to transform to
-     * @return null if:
-     *  - geometry is null
-     *  - geometry is not a Polygon
-     *  - any of the coordinates in the exterior ring is not within [-180,-90,180,90]
-     *  otherwise return the exterior ring of the polygon projected to the targetCrs and
-     *  possibly with extra interpolated points in-between of the original segments
-     */
-    public static String transformLayerCoverage(final String wkt, final CoordinateReferenceSystem targetCrs) {
         GeometryFactory gf = new GeometryFactory();
         Geometry geom = parseWKT(wkt, gf);
         if (geom == null || !(geom instanceof Polygon)) {
@@ -125,8 +110,8 @@ public class WKTHelper {
         Polygon polygon = (Polygon) geom;
         LineString exterior = polygon.getExteriorRing();
         boolean withinWGS84Bounds = GeometryHelper.isWithin(exterior.getCoordinateSequence(),
-                WGS84_LON_MIN, WGS84_LAT_MIN,
-                WGS84_LON_MAX, WGS84_LAT_MAX);
+        WGS84_LON_MIN, WGS84_LAT_MIN,
+        WGS84_LON_MAX, WGS84_LAT_MAX);
         if (!withinWGS84Bounds) {
             log.info("Layer coverage not within WGS84 bounds, not interpolating or transforming extent");
             return null;
@@ -134,6 +119,7 @@ public class WKTHelper {
         CoordinateSequence cs = GeometryHelper.interpolateLinear(exterior, INTERPOLATE_THRESHOLD, gf);
         polygon = gf.createPolygon(cs);
         // input axis orientation is / must be x=lon y=lat
+        CoordinateReferenceSystem targetCrs = getCRS(targetSRS);
         final Geometry transformed = transform(polygon, CRS_EPSG_4326, targetCrs);
         // output is x=lon y=lat always in every projection
         return getWKT(transformed);

--- a/service-map/src/main/java/org/oskari/service/maplayer/DescribeLayerQuery.java
+++ b/service-map/src/main/java/org/oskari/service/maplayer/DescribeLayerQuery.java
@@ -1,0 +1,44 @@
+package org.oskari.service.maplayer;
+
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.oskari.user.User;
+
+import java.util.List;
+
+public class DescribeLayerQuery {
+
+    private final String layerId;
+    private final User user;
+    private final String lang;
+    private final CoordinateReferenceSystem crs;
+    private final List<String> styles;
+
+    public String getLayerId() {
+        return layerId;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public String getLang() {
+        return lang;
+    }
+
+    public CoordinateReferenceSystem getCrs() {
+        return crs;
+    }
+
+    public List<String> getStyles() {
+        return styles;
+    }
+
+    public DescribeLayerQuery(String layerId, User user, String lang, CoordinateReferenceSystem crs, List<String> styles) {
+        this.layerId = layerId;
+        this.user = user;
+        this.lang = lang;
+        this.crs = crs;
+        this.styles = styles;
+    }
+
+}

--- a/service-map/src/main/java/org/oskari/service/maplayer/DescribeLayerQuery.java
+++ b/service-map/src/main/java/org/oskari/service/maplayer/DescribeLayerQuery.java
@@ -1,17 +1,21 @@
 package org.oskari.service.maplayer;
 
-import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.oskari.user.User;
 
 import java.util.List;
 
 public class DescribeLayerQuery {
 
+    private final Long viewId;
     private final String layerId;
     private final User user;
     private final String lang;
-    private final CoordinateReferenceSystem crs;
+    private final String crs;
     private final List<String> styles;
+
+    public Long getViewId() {
+        return viewId;
+    }
 
     public String getLayerId() {
         return layerId;
@@ -25,7 +29,7 @@ public class DescribeLayerQuery {
         return lang;
     }
 
-    public CoordinateReferenceSystem getCrs() {
+    public String getCrs() {
         return crs;
     }
 
@@ -33,7 +37,12 @@ public class DescribeLayerQuery {
         return styles;
     }
 
-    public DescribeLayerQuery(String layerId, User user, String lang, CoordinateReferenceSystem crs, List<String> styles) {
+    public DescribeLayerQuery(Long viewId, String layerId, User user, String lang, String crs) {
+        this(viewId, layerId, user, lang, crs, null);
+    }
+
+    public DescribeLayerQuery(Long viewId, String layerId, User user, String lang, String crs, List<String> styles) {
+        this.viewId = viewId;
         this.layerId = layerId;
         this.user = user;
         this.lang = lang;

--- a/service-map/src/main/java/org/oskari/service/maplayer/LayerProvider.java
+++ b/service-map/src/main/java/org/oskari/service/maplayer/LayerProvider.java
@@ -1,0 +1,17 @@
+package org.oskari.service.maplayer;
+
+import org.oskari.domain.map.LayerExtendedOutput;
+import org.oskari.domain.map.LayerOutput;
+import org.oskari.user.User;
+
+import java.util.List;
+
+import fi.nls.oskari.service.OskariComponent;
+
+public abstract class LayerProvider extends OskariComponent {
+
+    public abstract boolean maybeProvides(String layerId);
+    public abstract List<LayerOutput> listLayers(User user, String lang);
+    public abstract LayerExtendedOutput describeLayer(DescribeLayerQuery query) throws SecurityException;
+
+}

--- a/service-map/src/main/java/org/oskari/service/maplayer/OskariMapLayerProvider.java
+++ b/service-map/src/main/java/org/oskari/service/maplayer/OskariMapLayerProvider.java
@@ -1,0 +1,355 @@
+package org.oskari.service.maplayer;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.json.JSONObject;
+import org.oskari.capabilities.CapabilitiesService;
+import org.oskari.capabilities.MetadataHelper;
+import org.oskari.capabilities.ogc.LayerCapabilitiesOGC;
+import org.oskari.capabilities.ogc.LayerCapabilitiesWFS;
+import org.oskari.capabilities.ogc.LayerCapabilitiesWMTS;
+import org.oskari.capabilities.ogc.wfs.FeaturePropertyType;
+import org.oskari.capabilities.ogc.wmts.TileMatrixLink;
+import org.oskari.domain.map.FeatureProperties;
+import org.oskari.domain.map.LayerExtendedOutput;
+import org.oskari.domain.map.LayerOutput;
+import org.oskari.maplayer.util.OskariLayerUtil;
+import org.oskari.permissions.PermissionService;
+import org.oskari.permissions.model.PermissionType;
+import org.oskari.permissions.model.Resource;
+import org.oskari.permissions.model.ResourceType;
+import org.oskari.service.util.ServiceFactory;
+import org.oskari.user.User;
+
+import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.domain.map.style.VectorStyle;
+import fi.nls.oskari.domain.map.wfs.WFSLayerAttributes;
+import fi.nls.oskari.domain.map.wfs.WFSLayerOptions;
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.map.geometry.WKTHelper;
+import fi.nls.oskari.map.layer.OskariLayerService;
+import fi.nls.oskari.map.layer.formatters.LayerJSONFormatter;
+import fi.nls.oskari.map.style.VectorStyleHelper;
+import fi.nls.oskari.map.style.VectorStyleService;
+import fi.nls.oskari.service.OskariComponentManager;
+import fi.nls.oskari.service.capabilities.CapabilitiesConstants;
+import fi.nls.oskari.util.ConversionHelper;
+import fi.nls.oskari.util.JSONHelper;
+import fi.nls.oskari.util.PropertyUtil;
+import fi.nls.oskari.util.WFSConversionHelper;
+
+public class OskariMapLayerProvider extends LayerProvider {
+
+    private static final Logger LOG = LogFactory.getLogger(OskariMapLayerProvider.class);
+
+    // Lazy init service, doesn't work done in ctor/init()
+    private OskariLayerService layerService;
+    private PermissionService permissionService;
+    private VectorStyleService vectorStyleService;
+
+    private Set<String> preferredSRS;
+
+    private OskariLayerService getLayerService() {
+        if (layerService == null) {
+            layerService = ServiceFactory.getMapLayerService();
+        }
+        return layerService;
+    }
+
+    private PermissionService getPermissionService() {
+        if (permissionService == null) {
+            permissionService = ServiceFactory.getPermissionsService();
+        }
+        return permissionService;
+    }
+
+    private VectorStyleService getVectorStyleService() {
+        if (vectorStyleService == null) {
+            vectorStyleService = OskariComponentManager.getComponentOfType(VectorStyleService.class);
+        }
+        return vectorStyleService;
+    }
+
+    private Set<String> getPreferredSRS() {
+        if (preferredSRS == null) {
+            preferredSRS = new HashSet<>(5);
+            String nativeCRS = PropertyUtil.get("oskari.native.srs", "EPSG:3857");
+            preferredSRS.add(nativeCRS);
+            preferredSRS.add("EPSG:3857");
+            preferredSRS.add("EPSG:4326");
+            preferredSRS.add("EPSG:900913");
+        }
+        return preferredSRS;
+    }
+
+    public void setLayerService(OskariLayerService layerService) {
+        this.layerService = layerService;
+    }
+
+    public void setPermissionService(PermissionService permissionService) {
+        this.permissionService = permissionService;
+    }
+
+    @Override
+    public boolean maybeProvides(String layerId) {
+        try {
+            Integer.parseInt(layerId);
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public List<LayerOutput> listLayers(User user, String lang) {
+        OskariLayerService layerService = getLayerService();
+        PermissionService permissionService = getPermissionService();
+
+        return OskariLayerUtil.getLayersForUser(layerService, permissionService, user, false).stream()
+            .map(l -> toLayerOutput(l, lang))
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public LayerExtendedOutput describeLayer(DescribeLayerQuery query)
+            throws SecurityException {
+        int id = Integer.parseInt(query.getLayerId());
+
+        OskariLayer layer = getLayerService().find(id);
+        if (layer == null) {
+            return null;
+        }
+
+        Resource resource = getPermissionService().findResource(ResourceType.maplayer, Integer.toString(layer.getId()))
+            .orElseThrow(() -> new SecurityException("User doesn't have permissions for requested layer"));
+
+        final boolean hasPermission =
+            resource.hasPermission(query.getUser(), PermissionType.VIEW_LAYER) ||
+            resource.hasPermission(query.getUser(), PermissionType.VIEW_PUBLISHED);
+
+        if (!hasPermission) {
+            throw new SecurityException("User doesn't have permissions for requested layer");
+        }
+
+        return toExtendedLayerOutput(layer, query);
+    }
+
+    private static LayerOutput toLayerOutput(OskariLayer layer, String lang) {
+        LayerOutput out = new LayerOutput();
+        out.id = Integer.toString(layer.getId());
+        out.type = layer.getType();
+        out.name = layer.getName(lang);
+        out.metadataUuid = getMetadataUuid(layer);
+        out.dataproviderId = layer.getDataproviderId();
+        out.created = layer.getCreated();
+        out.updated = layer.getUpdated();
+        return out;
+    }
+
+    private static String getMetadataUuid(OskariLayer layer) {
+        String fixed = MetadataHelper.getIdFromMetadataUrl(layer.getMetadataId());
+        if (fixed != null) {
+            return fixed;
+        }
+        String olderMetadataCaps = layer.getCapabilities().optString(CapabilitiesConstants.KEY_METADATA, null);
+        if (olderMetadataCaps != null && !olderMetadataCaps.trim().isEmpty()) {
+            return olderMetadataCaps;
+        }
+        return layer.getCapabilities().optString(LayerCapabilitiesOGC.METADATA_UUID, null);
+    }
+
+    private LayerExtendedOutput toExtendedLayerOutput(OskariLayer layer, DescribeLayerQuery query) throws IllegalArgumentException {
+        final int layerId = layer.getId();
+        final String layerType = layer.getType();
+
+        LayerExtendedOutput output = new LayerExtendedOutput();
+        output.id = Integer.toString(layerId);
+        output.name = layer.getName(query.getLang());
+        JSONObject attributes = layer.getAttributes();
+        if (!attributes.optBoolean(LayerJSONFormatter.KEY_ATTRIBUTE_IGNORE_COVERAGE, false)) {
+            output.coverage = getCoverageWKT(layer.getGeometry(), query.getCrs());
+        }
+        if (VectorStyleHelper.isVectorLayer(layer)) {
+            output.styles = getVectorStyles(query);
+            output.hover = JSONHelper.getObjectAsMap(layer.getOptions().optJSONObject("hover"));
+        }
+        if (OskariLayer.TYPE_WFS.equals(layerType)) {
+            setDetailsForWFS(output, layer, query.getLang());
+        }
+        if (OskariLayer.TYPE_WMTS.equals(layerType)) {
+            output.capabilities = getCapabilitiesJSON(layer, query.getCrs());
+        }
+        return output;
+    }
+
+    private List<FeatureProperties> getProperties(LayerCapabilitiesWFS caps, WFSLayerAttributes attr , String lang) {
+        List<FeatureProperties> props = new ArrayList<>();
+
+        List<String> selected = attr.getSelectedAttributes(lang);
+        JSONObject locale = attr.getLocalization(lang).orElse(new JSONObject());
+        JSONObject format = attr.getFieldFormatMetadata().orElse(new JSONObject());
+
+        caps.getFeatureProperties().stream().forEach(prop -> {
+            FeatureProperties p = new FeatureProperties();
+            p.name = prop.name;
+            p.type = WFSConversionHelper.getSimpleType(prop.type);
+            p.rawType = prop.type;
+            p.label = locale.optString(prop.name, null);
+            p.format = getPropertyFormat(format, prop.name);
+            if (!selected.isEmpty()) {
+                int index = selected.indexOf(p.name);
+                if (index == -1) {
+                    p.hidden = true;
+                    p.order = selected.size();
+                } else {
+                    p.order = index;
+                }
+            }
+            props.add(p);
+        });
+        if (!selected.isEmpty()) {
+            props.sort(Comparator.comparingInt(a -> a.order));
+        }
+        return props;
+    }
+
+    private Map<String, Object> getPropertyFormat(JSONObject format, String name) {
+        JSONObject propFormat = format.optJSONObject(name);
+        // return null if doesn't exist
+        return propFormat != null ? JSONHelper.getObjectAsMap(propFormat) : null;
+    }
+
+    private Map<String, Object> getControlData(LayerCapabilitiesWFS caps, WFSLayerAttributes attr, WFSLayerOptions opts) {
+        Map<String, Object> data = new HashMap<>();
+
+        JSONObject attrData = attr.getAttributesData();
+        data.put(WFSLayerAttributes.KEY_NO_DATA_VALUE, attr.getNoDataValue());
+        data.put(WFSLayerAttributes.KEY_COMMON_ID, attr.getCommonId());
+        data.put(WFSLayerAttributes.KEY_REPLACE_ID, attrData.optString(WFSLayerAttributes.KEY_REPLACE_ID, null));
+
+        String geomType = attrData.optString(WFSLayerAttributes.KEY_GEOMETRY_TYPE, null);
+        if (geomType == null) {
+            String geomName = caps.getGeometryField();
+            FeaturePropertyType fpt = caps.getFeatureProperty(geomName);
+            if (fpt != null) {
+                geomType = WFSConversionHelper.getStyleType(fpt.type);
+            }
+        }
+        data.put(WFSLayerAttributes.KEY_GEOMETRY_TYPE, geomType);
+
+        data.put(WFSLayerOptions.KEY_RENDER_MODE, opts.getRenderMode());
+        data.put(WFSLayerOptions.KEY_CLUSTER, opts.getClusteringDistance());
+        return data;
+    }
+
+    private List<VectorStyle> getVectorStyles(DescribeLayerQuery query) {
+        VectorStyleService service = getVectorStyleService();
+        final long userId = query.getUser().getId();
+        List<VectorStyle> styles = service.getStyles(userId, Integer.parseInt(query.getLayerId()));
+
+        if (query.getStyles() == null || query.getStyles().isEmpty()) {
+            return styles;
+        }
+        // attach any styles that were specifically requested by the frontend
+        for (String style : query.getStyles()) {
+            int styleId = ConversionHelper.getInt(style, -1);
+            if (styleId == -1) {
+                // not a number, we only care about numbers as other styles are not saved in vector styles
+                continue;
+            }
+            boolean isPresent = styles.stream().filter(s -> s.getId() == styleId).findFirst().isPresent();
+            if (isPresent) {
+                // already referenced in styles -> don't need to add it again
+                continue;
+            }
+            VectorStyle selected = service.getStyleById(styleId);
+            if (selected == null) {
+                LOG.info("Requested selected style with id:", styleId, "which doesn't exist");
+            } else {
+                styles.add(selected);
+            }
+        }
+        return styles;
+    }
+
+    // value will be not added if transform failed, that's ok since client can't handle it if it's in unknown projection
+    private String getCoverageWKT(final String wktWGS84, CoordinateReferenceSystem mapCrs) {
+        if (wktWGS84 == null || wktWGS84.isEmpty() || mapCrs == null) {
+            return null;
+        }
+        try {
+            // WTK is saved as EPSG:4326 in database
+            return WKTHelper.transformLayerCoverage(wktWGS84, mapCrs);
+        } catch (Exception ex) {
+            LOG.debug("Error transforming coverage to", mapCrs.getName().toString(), "from", wktWGS84);
+        }
+        return null;
+    }
+
+    private void setDetailsForWFS(LayerExtendedOutput output, OskariLayer layer, String lang) {
+        // UserDataLayers are handled in frontend by WFS plugin and embedded myplaces is using WFS type
+        // so LayerJSONFormatterUSERDATA gathers values from options and attributes in same way than this
+        LayerCapabilitiesWFS caps = CapabilitiesService.fromJSON(layer.getCapabilities().toString(), layer.getType());
+        WFSLayerAttributes attr = new WFSLayerAttributes(layer.getAttributes());
+        WFSLayerOptions opts = new WFSLayerOptions(layer.getOptions());
+        output.properties = getProperties(caps, attr, lang);
+        output.controlData = getControlData(caps, attr, opts);
+    }
+
+    private Map<String, Object> getCapabilitiesJSON(OskariLayer layer, CoordinateReferenceSystem crs) throws IllegalArgumentException {
+        if (!OskariLayer.TYPE_WMTS.equals(layer.getType())) {
+            return JSONHelper.getObjectAsMap(layer.getCapabilities());
+        }
+        try {
+            String capsJSON = layer.getCapabilities().toString();
+            LayerCapabilitiesWMTS caps = CapabilitiesService.fromJSON(layer.getCapabilities().toString(), OskariLayer.TYPE_WMTS);
+            String crsName = CapabilitiesService.shortSyntaxEpsg(crs.getName().toString());
+            TileMatrixLink link = determineTileMatrix(caps, crsName);
+
+            // Make a copy so we don't mutate layer in cache
+            JSONObject modifiedCapabilities = new JSONObject(capsJSON);
+            // remove "tileMatrixLinks" (with all matrices) that is replaced with "tileMatrixSet" (just for current projection)
+            modifiedCapabilities.remove("tileMatrixLinks");
+            modifiedCapabilities.put("tileMatrixSet", link.getTileMatrixSet().getAsJSON());
+            return JSONHelper.getObjectAsMap(modifiedCapabilities);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Unable to parse JSON", e);
+        }
+    }
+
+    private TileMatrixLink determineTileMatrix(LayerCapabilitiesWMTS caps, String crs) throws IllegalArgumentException {
+        TileMatrixLink link = caps.getTileMatrixLinks().stream()
+                .filter(l -> crs.equals(l.getTileMatrixSet().getShortCrs()))
+                .findFirst()
+                .orElse(null);
+        if (link != null) {
+            // happy case, we found a matching tilematrix for projection
+            return link;
+        }
+        // set of srs that layer supports
+        Set<String> supportedSRS = caps.getTileMatrixLinks().stream()
+                .map(l -> l.getTileMatrixSet().getShortCrs())
+                .collect(Collectors.toSet());
+        // first of preferred srs that layer supports
+        Set<String> prefSRS = getPreferredSRS();
+        String matchedSRS = prefSRS.stream()
+                .filter(srs -> supportedSRS.contains(srs))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("None of preferred SRS (" + LOG.getAsString(prefSRS) + ") supported by layer: " + LOG.getAsString(supportedSRS)));
+
+        return caps.getTileMatrixLinks().stream()
+                .filter(l -> matchedSRS.equals(l.getTileMatrixSet().getShortCrs()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("No tilematrix matching srs: " + matchedSRS));
+    }
+
+}

--- a/service-map/src/main/java/org/oskari/service/maplayer/OskariMapLayerProvider.java
+++ b/service-map/src/main/java/org/oskari/service/maplayer/OskariMapLayerProvider.java
@@ -9,7 +9,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.json.JSONObject;
 import org.oskari.capabilities.CapabilitiesService;
 import org.oskari.capabilities.MetadataHelper;
@@ -282,7 +281,7 @@ public class OskariMapLayerProvider extends LayerProvider {
     }
 
     // value will be not added if transform failed, that's ok since client can't handle it if it's in unknown projection
-    private String getCoverageWKT(final String wktWGS84, CoordinateReferenceSystem mapCrs) {
+    private String getCoverageWKT(final String wktWGS84, String mapCrs) {
         if (wktWGS84 == null || wktWGS84.isEmpty() || mapCrs == null) {
             return null;
         }
@@ -290,7 +289,7 @@ public class OskariMapLayerProvider extends LayerProvider {
             // WTK is saved as EPSG:4326 in database
             return WKTHelper.transformLayerCoverage(wktWGS84, mapCrs);
         } catch (Exception ex) {
-            LOG.debug("Error transforming coverage to", mapCrs.getName().toString(), "from", wktWGS84);
+            LOG.debug("Error transforming coverage to", mapCrs, "from", wktWGS84);
         }
         return null;
     }
@@ -305,14 +304,14 @@ public class OskariMapLayerProvider extends LayerProvider {
         output.controlData = getControlData(caps, attr, opts);
     }
 
-    private Map<String, Object> getCapabilitiesJSON(OskariLayer layer, CoordinateReferenceSystem crs) throws IllegalArgumentException {
+    private Map<String, Object> getCapabilitiesJSON(OskariLayer layer, String crs) throws IllegalArgumentException {
         if (!OskariLayer.TYPE_WMTS.equals(layer.getType())) {
             return JSONHelper.getObjectAsMap(layer.getCapabilities());
         }
         try {
             String capsJSON = layer.getCapabilities().toString();
             LayerCapabilitiesWMTS caps = CapabilitiesService.fromJSON(layer.getCapabilities().toString(), OskariLayer.TYPE_WMTS);
-            String crsName = CapabilitiesService.shortSyntaxEpsg(crs.getName().toString());
+            String crsName = CapabilitiesService.shortSyntaxEpsg(crs);
             TileMatrixLink link = determineTileMatrix(caps, crsName);
 
             // Make a copy so we don't mutate layer in cache

--- a/service-map/src/main/java/org/oskari/service/user/UserLayerService.java
+++ b/service-map/src/main/java/org/oskari/service/user/UserLayerService.java
@@ -1,6 +1,5 @@
 package org.oskari.service.user;
 
-import org.oskari.domain.map.LayerExtendedOutput;
 import org.oskari.user.User;
 
 import fi.nls.oskari.domain.map.OskariLayer;
@@ -8,7 +7,6 @@ import fi.nls.oskari.domain.map.wfs.WFSLayerOptions;
 import fi.nls.oskari.service.OskariComponent;
 import fi.nls.oskari.service.ServiceException;
 
-import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.locationtech.jts.geom.Envelope;
 
@@ -20,7 +18,4 @@ public abstract class UserLayerService extends OskariComponent {
     public abstract WFSLayerOptions getWFSLayerOptions(String layerId);
     public abstract SimpleFeatureCollection getFeatures(String layerId, Envelope bbox) throws ServiceException;
 
-    public LayerExtendedOutput describeLayer(String layerId, String lang, CoordinateReferenceSystem crs) {
-        return null;
-    }
 }

--- a/service-myfeatures/src/main/java/org/oskari/map/myfeatures/service/MyFeaturesLayerProvider.java
+++ b/service-myfeatures/src/main/java/org/oskari/map/myfeatures/service/MyFeaturesLayerProvider.java
@@ -1,0 +1,173 @@
+package org.oskari.map.myfeatures.service;
+
+import fi.nls.oskari.annotation.Oskari;
+import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.domain.map.myfeatures.MyFeaturesFieldInfo;
+import fi.nls.oskari.domain.map.myfeatures.MyFeaturesLayer;
+import fi.nls.oskari.domain.map.style.VectorStyle;
+import fi.nls.oskari.map.geometry.WKTHelper;
+import fi.nls.oskari.service.OskariComponentManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.referencing.CRS;
+import org.json.JSONObject;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.io.WKTWriter;
+import org.oskari.domain.map.FeatureProperties;
+import org.oskari.domain.map.LayerExtendedOutput;
+import org.oskari.domain.map.LayerOutput;
+import org.oskari.service.maplayer.DescribeLayerQuery;
+import org.oskari.service.maplayer.LayerProvider;
+import org.oskari.user.User;
+
+@Oskari("myfeatures")
+public class MyFeaturesLayerProvider extends LayerProvider {
+
+    private MyFeaturesService service;
+
+    private MyFeaturesService getService() {
+        // Lazy init service, doesn't work done in ctor/init()
+        // due to some timing of components being initialized
+        if (service == null) {
+            service = OskariComponentManager.getComponentOfType(MyFeaturesService.class);
+        }
+        return service;
+    }
+
+    public void setService(MyFeaturesService service) {
+        this.service = service;
+    }
+
+    @Override
+    public boolean maybeProvides(String layerId) {
+        return layerId.startsWith(MyFeaturesLayer.PREFIX_LAYER_ID);
+    }
+
+    @Override
+    public List<LayerOutput> listLayers(User user, String lang) {
+        List<MyFeaturesLayer> layers = getService().getLayersByOwnerUuid(user.getUuid());
+        return layers.stream().map(l -> toLayerOutput(l, lang)).collect(Collectors.toList());
+    }
+
+    private static LayerOutput toLayerOutput(MyFeaturesLayer layer, String language) {
+        LayerOutput out = new LayerOutput();
+        out.id = layer.getId().toString();
+        out.type = layer.getType();
+        out.name = layer.getName(language);
+        out.metadataUuid = null;
+        out.dataproviderId = null;
+        out.created = layer.getCreated() != null ? new Date(layer.getCreated().toEpochMilli()) : null;
+        out.updated = layer.getUpdated() != null ? new Date(layer.getUpdated().toEpochMilli()) : null;
+        return out;
+    }
+
+    @Override
+    public LayerExtendedOutput describeLayer(DescribeLayerQuery query) throws SecurityException {
+        UUID layerUuid = MyFeaturesLayer.parseLayerId(query.getLayerId())
+            .orElseThrow(() -> new IllegalArgumentException("Invalid layerId"));
+
+        MyFeaturesService service = getService();
+
+        MyFeaturesLayer layer = service.getLayer(layerUuid);
+        if (layer == null) {
+            return null;
+        }
+        if (layer.getOwnerUuid().equals(query.getUser().getUuid()) || layer.isPublished()) {
+            throw new SecurityException("User doesn't have permissions for requested layer");
+        }
+
+        LayerExtendedOutput describe = new LayerExtendedOutput();
+        describe.id = query.getLayerId();
+        describe.type = OskariLayer.TYPE_WFS;
+        describe.name = layer.getName(query.getLang());
+        describe.metadataUuid = null;
+        describe.dataproviderId = null;
+        describe.created = layer.getCreated() == null ? null : new Date(layer.getCreated().toEpochMilli());
+        describe.updated = layer.getUpdated() == null ? null : new Date(layer.getUpdated().toEpochMilli());
+
+        describe.coverage = getCoverageWKT(layer.getExtent(), query.getCrs());
+        describe.styles = getVectorStyles(layer);
+        describe.hover = null;
+        describe.capabilities = null;
+
+        describe.properties = getProperties(layer, query.getLang());
+        describe.controlData = null;
+
+        return describe;
+    }
+
+    private String getCoverageWKT(Envelope extent, CoordinateReferenceSystem crs) {
+        if (extent == null || crs == null) {
+            return null;
+        }
+        try {
+            CoordinateReferenceSystem sourceCRS = getService().getNativeCRS();
+            if (CRS.equalsIgnoreMetadata(sourceCRS, crs)) {
+                return WKTHelper.getBBOX(extent.getMinX(), extent.getMinY(), extent.getMaxX(), extent.getMaxY());
+            }
+            Polygon p = toGeometry(extent);
+            Geometry transformed = WKTHelper.transform(p, sourceCRS, crs);
+            return new WKTWriter(2).write(transformed);
+        } catch (Exception ignore) {
+            // Will not report back coverage if transform failed
+            // that's ok since client can't handle it if it's in unknown projection
+            return null;
+        }
+    }
+
+    public static Polygon toGeometry(Envelope e) {
+        if (e == null) {
+            return null;
+        }
+        Coordinate[] cornerCoordinates = new Coordinate[] {
+            new Coordinate(e.getMinX(), e.getMinY()),
+            new Coordinate(e.getMinX(), e.getMaxY()),
+            new Coordinate(e.getMaxX(), e.getMaxY()),
+            new Coordinate(e.getMaxX(), e.getMinY()),
+            new Coordinate(e.getMinX(), e.getMinY()),
+        };
+        return new GeometryFactory().createPolygon(cornerCoordinates);
+    }
+
+    static List<VectorStyle> getVectorStyles(MyFeaturesLayer layer) {
+        JSONObject defaultStyle = layer.getLayerOptions().getDefaultStyle();
+
+        VectorStyle vectorStyle = new VectorStyle();
+        vectorStyle.setType(VectorStyle.TYPE_OSKARI);
+        vectorStyle.setName("default");
+        vectorStyle.setStyle(defaultStyle);
+
+        return Collections.singletonList(vectorStyle);
+    }
+
+    private List<FeatureProperties> getProperties(MyFeaturesLayer layer, String lang) {
+        List<FeatureProperties> props = new ArrayList<>();
+
+        int i = 0;
+        for (MyFeaturesFieldInfo field : layer.getLayerFields()) {
+            FeatureProperties p = new FeatureProperties();
+            p.name = field.getName();
+            p.type = field.getType().getSimpleType();
+            p.rawType = field.getType().getOutputBinding().getName();
+            p.label = field.getName();
+            p.hidden = false;
+            p.format = null;
+            p.order = i++;
+            props.add(p);
+        }
+
+        return props;
+    }
+
+}

--- a/service-myfeatures/src/main/java/org/oskari/map/myfeatures/service/MyFeaturesLayerProvider.java
+++ b/service-myfeatures/src/main/java/org/oskari/map/myfeatures/service/MyFeaturesLayerProvider.java
@@ -15,8 +15,6 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
-import org.geotools.referencing.CRS;
 import org.json.JSONObject;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
@@ -107,13 +105,13 @@ public class MyFeaturesLayerProvider extends LayerProvider {
         return describe;
     }
 
-    private String getCoverageWKT(Envelope extent, CoordinateReferenceSystem crs) {
+    private String getCoverageWKT(Envelope extent, String crs) {
         if (extent == null || crs == null) {
             return null;
         }
         try {
-            CoordinateReferenceSystem sourceCRS = getService().getNativeCRS();
-            if (CRS.equalsIgnoreMetadata(sourceCRS, crs)) {
+            String sourceCRS = getService().getNativeCRS();
+            if (sourceCRS.equals(crs)) {
                 return WKTHelper.getBBOX(extent.getMinX(), extent.getMinY(), extent.getMaxX(), extent.getMaxY());
             }
             Polygon p = toGeometry(extent);

--- a/service-myfeatures/src/main/java/org/oskari/map/myfeatures/service/MyFeaturesService.java
+++ b/service-myfeatures/src/main/java/org/oskari/map/myfeatures/service/MyFeaturesService.java
@@ -3,8 +3,6 @@ package org.oskari.map.myfeatures.service;
 import java.util.List;
 import java.util.UUID;
 
-import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
-
 import fi.nls.oskari.domain.map.myfeatures.MyFeaturesFeature;
 import fi.nls.oskari.domain.map.myfeatures.MyFeaturesLayer;
 import fi.nls.oskari.service.OskariComponent;
@@ -15,7 +13,7 @@ import fi.nls.oskari.service.OskariComponent;
  */
 public abstract class MyFeaturesService extends OskariComponent {
 
-    public abstract CoordinateReferenceSystem getNativeCRS();
+    public abstract String getNativeCRS();
 
     public abstract MyFeaturesLayer getLayer(UUID layerId);
     public abstract void createLayer(MyFeaturesLayer layer);

--- a/service-myfeatures/src/main/java/org/oskari/map/myfeatures/service/MyFeaturesServiceMybatisImpl.java
+++ b/service-myfeatures/src/main/java/org/oskari/map/myfeatures/service/MyFeaturesServiceMybatisImpl.java
@@ -12,8 +12,6 @@ import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
-import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
-import org.geotools.referencing.CRS;
 
 import fi.nls.oskari.annotation.Oskari;
 import fi.nls.oskari.db.DatasourceHelper;
@@ -34,7 +32,7 @@ public class MyFeaturesServiceMybatisImpl extends MyFeaturesService {
     private static final String NATIVE_SRS = "oskari.native.srs";
     private static final String FALLBACK_NATIVE_SRS = "EPSG:3857";
 
-    private final CoordinateReferenceSystem nativeCRS;
+    private final String nativeCRS;
     private final int batchSize;
     private final SqlSessionFactory factory;
 
@@ -61,7 +59,7 @@ public class MyFeaturesServiceMybatisImpl extends MyFeaturesService {
     }
 
     @Override
-    public CoordinateReferenceSystem getNativeCRS() {
+    public String getNativeCRS() {
         return nativeCRS;
     }
 
@@ -264,14 +262,8 @@ public class MyFeaturesServiceMybatisImpl extends MyFeaturesService {
         }
     }
 
-    private static CoordinateReferenceSystem createNativeCRS() {
-        try {
-            String epsg = PropertyUtil.get(NATIVE_SRS, FALLBACK_NATIVE_SRS);
-            return CRS.decode(epsg, true);
-        } catch (Exception e) {
-            LOG.error(e, "Failed to create nativeCRS!");
-            return null;
-        }
+    private static String createNativeCRS() {
+        return PropertyUtil.get(NATIVE_SRS, FALLBACK_NATIVE_SRS);
     }
 
     private MyFeaturesMapper getMapper(SqlSession session) {


### PR DESCRIPTION
Add new concept: `LayerProvider`
- `LayerProvider` provides information about available Layers in unifrom way
- Add two implementations of `LayerProvider`
  - `OskariMapLayerProvider` provides information about "default" layers `~OskariLayer`
  - `MyFeaturesLayerProvider` provides information about "MyFeatures" layers
- Refactor LayerList and DescribeLayer to use available `LayerProvider`s.

