### PR TITLE
Parse metadataid from path

### DIFF
--- a/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java
+++ b/control-userlayer/src/main/java/org/oskari/control/userlayer/CreateUserLayerHandler.java
@@ -281,6 +281,7 @@ public class CreateUserLayerHandler extends RestActionHandler {
         if (name == null || name.trim().isEmpty()) {
             return true;
         }
+        // https://stackoverflow.com/questions/13846000/file-separators-of-path-name-of-zipentry
         String[] parts = name.split("/");
         for (int i = 0; i < parts.length; i++) {
             if (parts[i].indexOf('.') == 0) {

--- a/service-capabilities/src/main/java/org/oskari/capabilities/MetadataHelper.java
+++ b/service-capabilities/src/main/java/org/oskari/capabilities/MetadataHelper.java
@@ -15,7 +15,8 @@ import java.util.regex.Pattern;
 
 public class MetadataHelper {
     private static final Logger LOG = LogFactory.getLogger(MetadataHelper.class);
-    private static final Pattern HEX_UPPER_GROUPED = Pattern.compile("^[0-9A-Fa-f]+(?:-[0-9A-Fa-f]+)*$");
+    // dash separated hex char sequences
+    private static final Pattern METADATA_ID_VALIDATOR = Pattern.compile("^[0-9A-Fa-f]+(?:-[0-9A-Fa-f]+)*$");
     /**
      * Helper for parsing metadata uuid from url.
      * @param url
@@ -62,13 +63,18 @@ public class MetadataHelper {
         if (url == null || !url.startsWith("http") || url.length() < 11) {
             return null;
         }
-        // remove possible protocol, we don't care if part of the domain is removed as well
-        String[] pathParts = url.substring(10).split("/");
-
-        for (String possibleId : pathParts) {
-            if(couldBeMetadataId(possibleId)) {
-                return possibleId;
+        // Parse with URI and getPath() to remove params etc
+        // the url-encoded curly braces will be decoded and saved to db as decoded
+        try {
+            String[] pathParts = new URI(url).getPath().split("/");
+            for (String possibleId : pathParts) {
+                if(couldBeMetadataId(possibleId)) {
+                    return possibleId;
+                }
             }
+
+        } catch (Exception e) {
+            LOG.debug("Unexpected error converting url-string to uri:", e);
         }
 
        return null;
@@ -79,11 +85,12 @@ public class MetadataHelper {
             // usually 30+ chars
             return false;
         }
-        if (possibleId.startsWith("%7B") && possibleId.endsWith("%7D")) {
-            possibleId = possibleId.substring(3, possibleId.length() - 3);
+        // URI decodes any URL-encoded bits so we can assume decoded chars here
+        if (possibleId.startsWith("{") && possibleId.endsWith("}")) {
+            possibleId = possibleId.substring(1, possibleId.length() - 1);
         }
 
-        return HEX_UPPER_GROUPED.matcher(possibleId).matches();
+        return METADATA_ID_VALIDATOR.matcher(possibleId).matches();
     }
 
     public static ArrayList<String> getAllowedDomainsList()  {

--- a/service-capabilities/src/main/java/org/oskari/capabilities/MetadataHelper.java
+++ b/service-capabilities/src/main/java/org/oskari/capabilities/MetadataHelper.java
@@ -11,9 +11,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 public class MetadataHelper {
     private static final Logger LOG = LogFactory.getLogger(MetadataHelper.class);
+    private static final Pattern HEX_UPPER_GROUPED = Pattern.compile("^[0-9A-Fa-f]+(?:-[0-9A-Fa-f]+)*$");
     /**
      * Helper for parsing metadata uuid from url.
      * @param url
@@ -40,7 +42,7 @@ public class MetadataHelper {
                     .orElse(null);
             if (idParam == null) {
                 // param not in url
-                return null;
+                return tryParsingIdFromPath(url);
             }
             List<String> values = params.getOrDefault(idParam, Collections.emptyList());
             if (values.isEmpty()) {
@@ -54,6 +56,34 @@ public class MetadataHelper {
         }
         LOG.debug("Couldn't parse uuid from metadata url:", url);
         return null;
+    }
+
+    private static String tryParsingIdFromPath(String url) {
+        if (url == null || !url.startsWith("http") || url.length() < 11) {
+            return null;
+        }
+        // remove possible protocol, we don't care if part of the domain is removed as well
+        String[] pathParts = url.substring(10).split("/");
+
+        for (String possibleId : pathParts) {
+            if(couldBeMetadataId(possibleId)) {
+                return possibleId;
+            }
+        }
+
+       return null;
+    }
+
+    private static boolean couldBeMetadataId(String possibleId) {
+        if (possibleId == null || possibleId.length() < 20) {
+            // usually 30+ chars
+            return false;
+        }
+        if (possibleId.startsWith("%7B") && possibleId.endsWith("%7D")) {
+            possibleId = possibleId.substring(3, possibleId.length() - 3);
+        }
+
+        return HEX_UPPER_GROUPED.matcher(possibleId).matches();
     }
 
     public static ArrayList<String> getAllowedDomainsList()  {

--- a/service-capabilities/src/test/java/org/oskari/capabilities/MetadataHelperTest.java
+++ b/service-capabilities/src/test/java/org/oskari/capabilities/MetadataHelperTest.java
@@ -37,6 +37,11 @@ public class MetadataHelperTest {
         expected.put("http://mydomain.org?test=test&uuid=key2&post=test", "key2");
         expected.put("http://mydomain.org?test=test&Id=key&post=test", "key");
         expected.put("http://mydomain.org?test=test&uuId=Key&post=test", "Key");
+        expected.put("http://mydomain.org/dataset/C73BC2C1-C2CA-4FCA-9171-B8074F2BC2A3", "C73BC2C1-C2CA-4FCA-9171-B8074F2BC2A3");
+        expected.put("http://mydomain.org/dataset/%7BC73BC2C1-C2CA-4FCA-9171-B8074F2BC2A3%7D", "%7BC73BC2C1-C2CA-4FCA-9171-B8074F2BC2A3%7D");
+        // java.net.URI breaks at {}
+        expected.put("http://mydomain.org/dataset/{C73BC2C1-C2CA-4FCA-9171-B8074F2BC2A3}", null);
+
         for (String url : expected.keySet()) {
             Assertions.assertEquals(expected.get(url), MetadataHelper.getIdFromMetadataUrl(url), "Url with id returns id value");
         }

--- a/service-capabilities/src/test/java/org/oskari/capabilities/MetadataHelperTest.java
+++ b/service-capabilities/src/test/java/org/oskari/capabilities/MetadataHelperTest.java
@@ -38,7 +38,7 @@ public class MetadataHelperTest {
         expected.put("http://mydomain.org?test=test&Id=key&post=test", "key");
         expected.put("http://mydomain.org?test=test&uuId=Key&post=test", "Key");
         expected.put("http://mydomain.org/dataset/C73BC2C1-C2CA-4FCA-9171-B8074F2BC2A3", "C73BC2C1-C2CA-4FCA-9171-B8074F2BC2A3");
-        expected.put("http://mydomain.org/dataset/%7BC73BC2C1-C2CA-4FCA-9171-B8074F2BC2A3%7D", "%7BC73BC2C1-C2CA-4FCA-9171-B8074F2BC2A3%7D");
+        expected.put("http://mydomain.org/dataset/%7BC73BC2C1-C2CA-4FCA-9171-B8074F2BC2A3%7D", "{C73BC2C1-C2CA-4FCA-9171-B8074F2BC2A3}");
         // java.net.URI breaks at {}
         expected.put("http://mydomain.org/dataset/{C73BC2C1-C2CA-4FCA-9171-B8074F2BC2A3}", null);
 


### PR DESCRIPTION
For parsing metadata id from this kind of source (service capabilities) with or without curly braces in the url:
```
<MetadataURL type="ISO19115:2003">
  <Format>text/html</Format>
  <OnlineResource xlink:type="simple" xlink:href="https://some.org/dataset/C73BC2C1-C2CA-4FCA-9171-B8074F2BC2A3"/>
</MetadataURL>
```