### PR TITLE
Admin: Allow searching users with their full name

### DIFF
--- a/service-users/src/main/java/fi/nls/oskari/user/UsersMapper.java
+++ b/service-users/src/main/java/fi/nls/oskari/user/UsersMapper.java
@@ -37,6 +37,8 @@ public interface UsersMapper {
             "   OR first_name ilike '%' || #{query} || '%'" +
             "   OR last_name ilike '%' || #{query} || '%'" +
             "   OR email ilike '%' || #{query} || '%' " +
+            "   OR replace(first_name || last_name, ' ', '') ilike '%' || replace(#{query}, ' ', '') || '%'" +
+            "   OR replace(last_name || first_name, ' ', '') ilike '%' || replace(#{query}, ' ', '') || '%'" +
             " ORDER BY user_name" +
             " LIMIT #{limit} OFFSET #{offset}")
     List<User> findAllPaginatedSearch(@Param("query") String query, @Param("limit") int limit, @Param("offset") int offset);


### PR DESCRIPTION
Allow Admin to find users when searching with their whole name.

```
oskaridb=# select user_name, first_name, last_name from oskari_users;
 user_name  | first_name | last_name
------------+------------+-----------
 user       | Oskari     | Demo user
 testirobot | Test       | Robot
 admin      | Oskari     | Admin
(3 rows)
```
Searching with `search=Oskari Admin`:
```
oskaridb=# SELECT first_name, last_name, user_name
FROM oskari_users
WHERE
  user_name ilike '%' || 'Oskari Admin' || '%'
  OR first_name ilike '%' || 'Oskari Admin' || '%'
  OR last_name ilike '%' || 'Oskari Admin' || '%'
  OR email ilike '%' || 'Oskari Admin' || '%';
 first_name | last_name | user_name
------------+-----------+-----------
(0 rows)
```
With the code change:
```
oskaridb=# SELECT first_name, last_name, user_name
FROM oskari_users
WHERE
  user_name ilike '%' || 'Oskari Admin' || '%'
  OR first_name ilike '%' || 'Oskari Admin' || '%'
  OR last_name ilike '%' || 'Oskari Admin' || '%'
  OR email ilike '%' || 'Oskari Admin' || '%'
  OR replace(first_name || last_name, ' ', '') ilike '%' || replace('Oskari Admin', ' ', '') || '%'
  OR replace(last_name || first_name, ' ', '') ilike '%' || replace('Oskari Admin', ' ', '') || '%';
 first_name | last_name | user_name
------------+-----------+-----------
 Oskari     | Admin     | admin
```
The second OR handles searching with `{lastName} {firstName}` order, not uncommon to do with actual human names.
