### PR TITLE
WMS Min/MaxScaleDenominator is handled wrong

### DIFF
--- a/service-admin/src/main/java/org/oskari/admin/LayerCapabilitiesHelper.java
+++ b/service-admin/src/main/java/org/oskari/admin/LayerCapabilitiesHelper.java
@@ -84,9 +84,20 @@ public class LayerCapabilitiesHelper {
         }
         if (layer instanceof LayerCapabilitiesWMS) {
             LayerCapabilitiesWMS wmsCaps = (LayerCapabilitiesWMS) layer;
-            // Check what this comment means from previous impl: "THIS IS ON PURPOSE: min -> max, max -> min"
-            ml.setMaxScale(wmsCaps.getMaxScale());
-            ml.setMinScale(wmsCaps.getMinScale());
+            // Consider scale range 1:50 000 - 1:1000
+            // WMS 1.3.0: minScaleDenominator: 1000, maxScaleDenominator: 50000
+            Double minScaleDenominator = wmsCaps.getMinScale();
+            Double maxScaleDenominator = wmsCaps.getMaxScale();
+            if (isLessThan(maxScaleDenominator, minScaleDenominator)) {
+                // Swap the values if service reported values where maxScaleDenominator < minScaleDenominator
+                double t = maxScaleDenominator;
+                maxScaleDenominator = minScaleDenominator;
+                minScaleDenominator = t;
+            }
+            // Oskari: minScale: 50000, maxScale: 1000
+            // (1:50 000 is smaller scale than 1:1000)
+            ml.setMinScale(maxScaleDenominator);
+            ml.setMaxScale(minScaleDenominator);
         }
         // default style for wms + wmts mostly
         ml.setStyle(layer.getDefaultStyle());
@@ -101,6 +112,10 @@ public class LayerCapabilitiesHelper {
         ml.setCapabilities(CapabilitiesService.toJSON(layer, systemCRSs));
         ml.setCapabilitiesLastUpdated(new Date());
         return ml;
+    }
+
+    private static boolean isLessThan(Double a, Double b) {
+        return a != null && !Double.isNaN(a) && b != null && !Double.isNaN(b) && a < b;
     }
 
     private static List<MapLayerStructure> parseStructureJson(Collection<LayerCapabilitiesWMS> caps, List<String> seen) {

--- a/service-capabilities/src/main/java/org/oskari/capabilities/ogc/wms/WMSCapsParser1_1_1.java
+++ b/service-capabilities/src/main/java/org/oskari/capabilities/ogc/wms/WMSCapsParser1_1_1.java
@@ -7,7 +7,6 @@ import org.w3c.dom.Element;
 
 import javax.xml.stream.XMLStreamException;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -70,9 +69,8 @@ public class WMSCapsParser1_1_1 extends WMSCapsParser {
         value.setBbox(latlonBox);
 
         // <ScaleHint min="1.0" max="60000.0"/>
-        Map<String, String> scaleHints = XmlHelper.getAttributesAsMap(XmlHelper.getFirstChild(layer, "ScaleHint"));
-        value.setMinScale(scaleHints.get("min"));
-        value.setMaxScale(scaleHints.get("max"));
+        // Ignore ScaleHints as they are just hints and possibly errorneusly configured
+
         // if there are other dimensions/extents than time this breaks...
         value.setTimes(parseTimes(XmlHelper.getFirstChild(layer, "Dimension"), XmlHelper.getFirstChild(layer, "Extent")));
 

--- a/service-capabilities/src/test/java/org/oskari/capabilities/ogc/WMSCapabilitiesParserTest.java
+++ b/service-capabilities/src/test/java/org/oskari/capabilities/ogc/WMSCapabilitiesParserTest.java
@@ -39,6 +39,9 @@ public class WMSCapabilitiesParserTest {
         // Note! 1.1.1 doesn't have the metadata url
         expectedJSON.remove(LayerCapabilitiesOGC.METADATA_URL);
         expectedJSON.remove(LayerCapabilitiesOGC.METADATA_UUID);
+        // 1.1.1 ScaleHint is different from 1.3.0 Min/MaxScaleDenominator and should be ignored
+        expectedJSON.remove("maxScale");
+        expectedJSON.remove("minScale");
         // System.out.println(json);
         Assertions.assertTrue(JSONHelper.isEqual(json, expectedJSON), "JSON should match");
 


### PR DESCRIPTION
In Oskari `maxScale < minScale`, for example: 
```
maxscale: 846,
minscale: 110935786
```
This makes sense as 1:110935786 is smaller scale compared to 1:846, therefore the min (the smallest) scale of the two is 1:110935786.

In WMS 1.3.0 Capabilities the logic is different. For the same range the values should appear as
```
<MinScaleDenominator>846</MinScaleDenominator>
<MaxScaleDenominator>110935786</MaxScaleDenominator>
```
This also makes sense, as 846 is the min (the smallest) scale **denominator** of the two.

Fix the mismatch when converting the values from `LayerCapabilitiesWMS` to `OskariLayer` properties. Additionally, make sure `maxScale < minScale` rule is maintained even if the WMS 1.3.0 service reported the values in non-standard order (`<MinScaleDenominator>110935786</MinScaleDenominator>
<MaxScaleDenominator>846</MaxScaleDenominator>`)


In WMS 1.1.1 `<ScaleHint min="" max="">` also uses the same order (min < max) but the units used differ from WMS 1.3.0 values. As it is not uncommon for not-totally-valid values to appear in `<ScaleHint>` the suggested change is to just ignore the whole field.



