### PR TITLE
Update Layer extent/coverage from CSW metadata when saving layer

### DIFF
--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerAdminHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerAdminHandler.java
@@ -6,7 +6,14 @@ import fi.nls.oskari.control.ActionDeniedException;
 import fi.nls.oskari.control.ActionException;
 import fi.nls.oskari.control.ActionParameters;
 import fi.nls.oskari.control.ActionParamsException;
+import fi.nls.oskari.control.data.GetCSWDataHandler;
 import fi.nls.oskari.control.layer.GetMapLayerGroupsHandler;
+import fi.nls.oskari.csw.dao.OskariLayerMetadataDao;
+import fi.nls.oskari.csw.domain.CSWIsoRecord;
+import fi.nls.oskari.csw.dto.OskariLayerMetadataDto;
+import fi.nls.oskari.csw.service.CSWService;
+import fi.nls.oskari.db.DatasourceHelper;
+
 import org.oskari.user.User;
 import fi.nls.oskari.domain.map.DataProvider;
 import fi.nls.oskari.domain.map.OskariLayer;
@@ -47,9 +54,11 @@ public class LayerAdminHandler extends AbstractLayerAdminHandler {
     // Response from service
     private static final String KEY_UPDATE_CAPA_FAIL = "updateCapabilitiesFail";
     private static final String KEY_PERMISSIONS_FAIL = "insertPermissionsFail";
+    private static final String KEY_UPDATE_METADATA_FAIL = "updateMetadataFail";
     private static final String ERROR_NO_LAYER_WITH_ID = "layer_not_found";
     private OskariLayerService mapLayerService;
     private DataProviderService dataProviderService;
+    private OskariLayerMetadataDao metadataDao;
 
     @Override
     public void init() {
@@ -62,6 +71,11 @@ public class LayerAdminHandler extends AbstractLayerAdminHandler {
             dataProviderService = OskariComponentManager.getComponentOfType(DataProviderService.class);
         } catch (Exception e) {
             throw new ServiceRuntimeException("Exception occured while initializing data provider service", e);
+        }
+        try {
+            metadataDao = new OskariLayerMetadataDao(DatasourceHelper.getInstance().getDataSource());
+        } catch (Exception e) {
+            throw new ServiceRuntimeException("Exception occured while initializing metadata data access object", e);
         }
         super.init();
     }
@@ -104,6 +118,8 @@ public class LayerAdminHandler extends AbstractLayerAdminHandler {
         MapLayerPermissionsHelper.setLayerPermissions(result.id, layer.getRole_permissions());
         MapLayerGroupsHelper.setGroupsForLayer(result.id, layer.getGroup_ids());
 
+        boolean metadataUpdateOK = refreshLayerMetadata(layer.getMetadataid(), layer.getAttributes());
+
         OskariLayer ml = mapLayerService.find(result.id);
         if (ml == null) {
             throw new ActionParamsException("Couldn't get the saved layer from DB - id:" + result.id, ERROR_NO_LAYER_WITH_ID);
@@ -126,9 +142,16 @@ public class LayerAdminHandler extends AbstractLayerAdminHandler {
             // NOTE! only tell if permissions failed, this probably needs some refactoring to be useful
             output.setWarn(KEY_PERMISSIONS_FAIL);
         }
+
+        if (!metadataUpdateOK && output.getWarn() == null) {
+            // Currently only single warning is supported, don't override previous warning (of higher priority)
+            output.setWarn(KEY_UPDATE_METADATA_FAIL);
+        }
+
         flushLayerListCache();
         writeResponse(params, output);
     }
+
 
     @Override
     public void handleDelete(ActionParameters params) throws ActionException {
@@ -410,11 +433,48 @@ public class LayerAdminHandler extends AbstractLayerAdminHandler {
         }
     }
 
+    /**
+     * @return true if ok, false if not
+     */
+    private boolean refreshLayerMetadata(String metadataid, Map<String, Object> attributes) {
+        if (metadataid == null || metadataid.trim().isBlank()) {
+            return true;
+        }
+
+        String defaultBaseURL = PropertyUtil.getOptional(CSWService.PROP_SERVICE_URL);
+        String baseURLOverrideAttribute = GetCSWDataHandler.LAYER_ATTRIBUTE_METADATA_URL;
+
+        String baseURL = attributes.get(baseURLOverrideAttribute) != null
+            ? attributes.get(baseURLOverrideAttribute).toString()
+            : defaultBaseURL;
+        if (baseURL == null || baseURL.trim().isBlank()) {
+            return true;
+        }
+
+        String lang = PropertyUtil.getDefaultLanguage();
+        try {
+            CSWService csw = new CSWService(baseURL);
+            CSWIsoRecord rec = csw.getRecordById(metadataid, lang);
+
+            OskariLayerMetadataDto dto = new OskariLayerMetadataDto();
+            dto.metadataId = metadataid;
+            dto.json = rec.toJSON().toString();
+            dto.wkt = rec.getIdentifications().stream().findAny()
+                .map(x -> x.getExtents().getEnvelope().toText())
+                .orElse(null);
+
+            metadataDao.saveMetadata(dto);
+            return true;
+        } catch (Exception e) {
+            LOG.warn(e, "CSW metadata handling failed, baseURL", baseURL, "id", metadataid);
+            return false;
+        }
+    }
+
     private class Result {
         int id;
         boolean permissions = true;
         boolean keywords = true;
     }
-
 
 }

--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerAdminHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerAdminHandler.java
@@ -72,12 +72,18 @@ public class LayerAdminHandler extends AbstractLayerAdminHandler {
         } catch (Exception e) {
             throw new ServiceRuntimeException("Exception occured while initializing data provider service", e);
         }
-        try {
-            metadataDao = new OskariLayerMetadataDao(DatasourceHelper.getInstance().getDataSource());
-        } catch (Exception e) {
-            throw new ServiceRuntimeException("Exception occured while initializing metadata data access object", e);
+        if (metadataDao == null) {
+            try {
+                metadataDao = new OskariLayerMetadataDao(DatasourceHelper.getInstance().getDataSource());
+            } catch (Exception e) {
+                throw new ServiceRuntimeException("Exception occured while initializing metadata data access object", e);
+            }
         }
         super.init();
+    }
+
+    public void setMetadataDao(OskariLayerMetadataDao metadataDao) {
+        this.metadataDao = metadataDao;
     }
 
     private void flushLayerListCache() {

--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerAdminHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerAdminHandler.java
@@ -6,12 +6,10 @@ import fi.nls.oskari.control.ActionDeniedException;
 import fi.nls.oskari.control.ActionException;
 import fi.nls.oskari.control.ActionParameters;
 import fi.nls.oskari.control.ActionParamsException;
-import fi.nls.oskari.control.data.GetCSWDataHandler;
 import fi.nls.oskari.control.layer.GetMapLayerGroupsHandler;
 import fi.nls.oskari.csw.dao.OskariLayerMetadataDao;
-import fi.nls.oskari.csw.domain.CSWIsoRecord;
-import fi.nls.oskari.csw.dto.OskariLayerMetadataDto;
-import fi.nls.oskari.csw.service.CSWService;
+import fi.nls.oskari.csw.helper.CSW;
+import fi.nls.oskari.csw.helper.CSW.RefreshResult;
 import fi.nls.oskari.db.DatasourceHelper;
 
 import org.oskari.user.User;
@@ -54,6 +52,8 @@ public class LayerAdminHandler extends AbstractLayerAdminHandler {
     // Response from service
     private static final String KEY_UPDATE_CAPA_FAIL = "updateCapabilitiesFail";
     private static final String KEY_PERMISSIONS_FAIL = "insertPermissionsFail";
+    private static final String KEY_UPDATE_METADATA_NO_REC = "updateMetadataNoRec";
+    private static final String KEY_UPDATE_METADATA_NO_GEOM = "updateMetadataNoGeom";
     private static final String KEY_UPDATE_METADATA_FAIL = "updateMetadataFail";
     private static final String ERROR_NO_LAYER_WITH_ID = "layer_not_found";
     private OskariLayerService mapLayerService;
@@ -108,6 +108,7 @@ public class LayerAdminHandler extends AbstractLayerAdminHandler {
     @Override
     public void handlePost(ActionParameters params) throws ActionException {
         MapLayerAdminInput layer = LayerAdminJSONHelper.inputFromJSON(params.getPayLoad());
+
         boolean isExisting = layer.getId() != null && layer.getId() > 0;
         Result result;
         if (isExisting) {
@@ -115,14 +116,15 @@ public class LayerAdminHandler extends AbstractLayerAdminHandler {
         } else {
             result = insertLayer(params, layer);
         }
-        MapLayerPermissionsHelper.setLayerPermissions(result.id, layer.getRole_permissions());
-        MapLayerGroupsHelper.setGroupsForLayer(result.id, layer.getGroup_ids());
+        MapLayerPermissionsHelper.setLayerPermissions(result.layer.getId(), layer.getRole_permissions());
+        MapLayerGroupsHelper.setGroupsForLayer(result.layer.getId(), layer.getGroup_ids());
 
-        boolean metadataUpdateOK = refreshLayerMetadata(layer.getMetadataid(), layer.getAttributes());
+        RefreshResult metadataUpdate = CSW.refreshLayerMetadata(metadataDao, result.layer);
 
-        OskariLayer ml = mapLayerService.find(result.id);
+        // Fetch a clean copy of the layer after all "side-updates"
+        OskariLayer ml = mapLayerService.find(result.layer.getId());
         if (ml == null) {
-            throw new ActionParamsException("Couldn't get the saved layer from DB - id:" + result.id, ERROR_NO_LAYER_WITH_ID);
+            throw new ActionParamsException("Couldn't get the saved layer from DB - id:" + result.layer.getId(), ERROR_NO_LAYER_WITH_ID);
         }
 
         AuditLog audit = AuditLog.user(params.getClientIp(), params.getUser())
@@ -143,15 +145,29 @@ public class LayerAdminHandler extends AbstractLayerAdminHandler {
             output.setWarn(KEY_PERMISSIONS_FAIL);
         }
 
-        if (!metadataUpdateOK && output.getWarn() == null) {
-            // Currently only single warning is supported, don't override previous warning (of higher priority)
-            output.setWarn(KEY_UPDATE_METADATA_FAIL);
+        // Currently only single warning is supported, don't override previous warning (of higher priority)
+        if (output.getWarn() == null && getRefreshMetadataWarning(metadataUpdate) != null) {
+            output.setWarn(getRefreshMetadataWarning(metadataUpdate));
         }
 
         flushLayerListCache();
         writeResponse(params, output);
     }
 
+    private static String getRefreshMetadataWarning(CSW.RefreshResult result) {
+        switch (result) {
+            case RECORD_NOT_FOUND:
+                return KEY_UPDATE_METADATA_NO_REC;
+            case GEOMETRY_NOT_FOUND:
+                return KEY_UPDATE_METADATA_NO_GEOM;
+            case FAILED:
+                return KEY_UPDATE_METADATA_FAIL;
+            case SKIPPED:
+            case OK:
+            default:
+                return null;
+        }
+    }
 
     @Override
     public void handleDelete(ActionParameters params) throws ActionException {
@@ -240,7 +256,7 @@ public class LayerAdminHandler extends AbstractLayerAdminHandler {
         OskariLayer ml = getMapLayer(params.getUser(), layer.getId());
 
         Result result = new Result();
-        result.id = ml.getId();
+        result.layer = ml;
 
         mergeInputToOskariLayer(ml, layer);
         updateCapabilities(ml);
@@ -328,7 +344,7 @@ public class LayerAdminHandler extends AbstractLayerAdminHandler {
         }
 
         Result result = new Result();
-        result.id = layerId;
+        result.layer = ml;
 
         // insert keywords
         try {
@@ -433,46 +449,8 @@ public class LayerAdminHandler extends AbstractLayerAdminHandler {
         }
     }
 
-    /**
-     * @return true if ok, false if not
-     */
-    private boolean refreshLayerMetadata(String metadataid, Map<String, Object> attributes) {
-        if (metadataid == null || metadataid.trim().isBlank()) {
-            return true;
-        }
-
-        String defaultBaseURL = PropertyUtil.getOptional(CSWService.PROP_SERVICE_URL);
-        String baseURLOverrideAttribute = GetCSWDataHandler.LAYER_ATTRIBUTE_METADATA_URL;
-
-        String baseURL = attributes.get(baseURLOverrideAttribute) != null
-            ? attributes.get(baseURLOverrideAttribute).toString()
-            : defaultBaseURL;
-        if (baseURL == null || baseURL.trim().isBlank()) {
-            return true;
-        }
-
-        String lang = PropertyUtil.getDefaultLanguage();
-        try {
-            CSWService csw = new CSWService(baseURL);
-            CSWIsoRecord rec = csw.getRecordById(metadataid, lang);
-
-            OskariLayerMetadataDto dto = new OskariLayerMetadataDto();
-            dto.metadataId = metadataid;
-            dto.json = rec.toJSON().toString();
-            dto.wkt = rec.getIdentifications().stream().findAny()
-                .map(x -> x.getExtents().getEnvelope().toText())
-                .orElse(null);
-
-            metadataDao.saveMetadata(dto);
-            return true;
-        } catch (Exception e) {
-            LOG.warn(e, "CSW metadata handling failed, baseURL", baseURL, "id", metadataid);
-            return false;
-        }
-    }
-
     private class Result {
-        int id;
+        OskariLayer layer;
         boolean permissions = true;
         boolean keywords = true;
     }

--- a/control-admin/src/test/java/fi/nls/oskari/control/admin/LayerAdminHandlerTest.java
+++ b/control-admin/src/test/java/fi/nls/oskari/control/admin/LayerAdminHandlerTest.java
@@ -1,10 +1,12 @@
 package fi.nls.oskari.control.admin;
 
+import fi.nls.oskari.csw.dao.OskariLayerMetadataDao;
 import fi.nls.oskari.domain.map.OskariLayer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
@@ -19,6 +21,7 @@ public class LayerAdminHandlerTest extends AbstractLayerAdminHandlerTest {
     @BeforeEach
     public void setup() throws Exception {
         setupMocks();
+        handler.setMetadataDao(Mockito.mock(OskariLayerMetadataDao.class));
         handler.init();
     }
 

--- a/control-base/src/main/java/fi/nls/oskari/control/data/GetCSWDataHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/data/GetCSWDataHandler.java
@@ -38,10 +38,11 @@ import static fi.nls.oskari.csw.service.CSWService.PROP_SERVICE_URL;
 public class GetCSWDataHandler extends ActionHandler {
     private final Logger log = LogFactory.getLogger(this.getClass());
     
+    public static final String LAYER_ATTRIBUTE_METADATA_URL = "metadataUrl";
+
     private static final String LANG_PARAM = "lang";
     private static final String UUID_PARAM = "uuid";
     private static final String LAYER_ID_PARAM = "layerId";
-    private static final String METADATA_URL_PARAM = "metadataUrl";
     private final String baseUrl = PropertyUtil.getOptional(PROP_SERVICE_URL);
     private final String metadataRatingType = PropertyUtil.getOptional("service.metadata.rating");
     private final String licenseUrlPrefix = PropertyUtil.getOptional("search.channel.METADATA_CATALOGUE_CHANNEL.licenseUrlPrefix");
@@ -102,8 +103,8 @@ public class GetCSWDataHandler extends ActionHandler {
             uuid = getMetadataIdForLayer(layer);
     
             try {
-                if (attributes.has(METADATA_URL_PARAM)) {
-                    url = attributes.getString(METADATA_URL_PARAM);
+                if (attributes.has(LAYER_ATTRIBUTE_METADATA_URL)) {
+                    url = attributes.getString(LAYER_ATTRIBUTE_METADATA_URL);
                 }
             } catch (Exception e) {
                 throw new ActionException("Failed to parse metadataUrl:" + e.getMessage());

--- a/control-base/src/main/java/fi/nls/oskari/control/data/GetCSWDataHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/data/GetCSWDataHandler.java
@@ -6,17 +6,16 @@ import fi.nls.oskari.control.ActionHandler;
 import fi.nls.oskari.control.ActionParameters;
 import fi.nls.oskari.control.ActionParamsException;
 import fi.nls.oskari.csw.domain.CSWIsoRecord;
-import fi.nls.oskari.csw.service.CSWService;
+import fi.nls.oskari.csw.helper.CSW;
 import org.oskari.user.Role;
 import fi.nls.oskari.domain.geo.Point;
 import fi.nls.oskari.domain.map.OskariLayer;
-import fi.nls.oskari.log.LogFactory;
-import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.map.geometry.ProjectionHelper;
 import fi.nls.oskari.map.geometry.WKTHelper;
 import fi.nls.oskari.map.layer.OskariLayerService;
 import fi.nls.oskari.rating.RatingService;
 import fi.nls.oskari.rating.RatingServiceMybatisImpl;
+import fi.nls.oskari.service.ServiceException;
 import fi.nls.oskari.util.JSONHelper;
 import fi.nls.oskari.util.PropertyUtil;
 import fi.nls.oskari.util.ResponseHelper;
@@ -25,25 +24,17 @@ import java.util.List;
 import java.util.Map;
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.oskari.capabilities.ogc.LayerCapabilitiesOGC;
 import org.oskari.service.util.ServiceFactory;
-
-import static fi.nls.oskari.csw.service.CSWService.PROP_SERVICE_URL;
-
 
 /**
  * Created by TMIKKOLAINEN on 1.9.2014.
  */
 @OskariActionRoute("GetCSWData")
 public class GetCSWDataHandler extends ActionHandler {
-    private final Logger log = LogFactory.getLogger(this.getClass());
     
-    public static final String LAYER_ATTRIBUTE_METADATA_URL = "metadataUrl";
-
     private static final String LANG_PARAM = "lang";
     private static final String UUID_PARAM = "uuid";
     private static final String LAYER_ID_PARAM = "layerId";
-    private final String baseUrl = PropertyUtil.getOptional(PROP_SERVICE_URL);
     private final String metadataRatingType = PropertyUtil.getOptional("service.metadata.rating");
     private final String licenseUrlPrefix = PropertyUtil.getOptional("search.channel.METADATA_CATALOGUE_CHANNEL.licenseUrlPrefix");
     public static final String KEY_LICENSE = "license";
@@ -85,46 +76,30 @@ public class GetCSWDataHandler extends ActionHandler {
     
     @Override
     public void handleAction(ActionParameters params) throws ActionException {
-        if (baseUrl == null) {
-            throw new ActionException("Service not configured.");
-        }
-
         String uuid = params.getHttpParam(UUID_PARAM);
         int layerId = params.getHttpParam(LAYER_ID_PARAM, -1);
-
-        if (uuid == null && layerId == -1) {
-            throw new ActionParamsException("No UUID or layer id found.");
-        }
-
-        String url = baseUrl;
-        if (layerId != -1) {
-            OskariLayer layer = layerService.find(layerId);
-            final JSONObject attributes = layer.getAttributes();
-            uuid = getMetadataIdForLayer(layer);
-    
-            try {
-                if (attributes.has(LAYER_ATTRIBUTE_METADATA_URL)) {
-                    url = attributes.getString(LAYER_ATTRIBUTE_METADATA_URL);
-                }
-            } catch (Exception e) {
-                throw new ActionException("Failed to parse metadataUrl:" + e.getMessage());
-            }
-        }
 
         // TODO use default lang if not found?
         final String lang = params.getRequiredParam(LANG_PARAM);
 
-        CSWIsoRecord record;
-        CSWService service;
-        try {
-            service = new CSWService(url);
-        } catch (Exception e) {
-            throw new ActionException("Failed to initialize CSWService:" + e.getMessage());
+        String serviceUrl;
+        String metadataid;
+        if (uuid != null) {
+            serviceUrl = CSW.getDefaultServiceBaseURL();
+            metadataid = uuid;
+        } else if (layerId != -1) {
+            OskariLayer layer = layerService.find(layerId);
+            serviceUrl = CSW.getMetadataServiceBaseURL(layer.getAttributes());
+            metadataid = CSW.getMetadataIdForLayer(layer);
+        } else {
+            throw new ActionParamsException("No UUID or layer id found.");
         }
+
+        CSWIsoRecord record;
         try {
-            record = service.getRecordById(uuid, lang);
-        } catch (Exception e) {
-            throw new ActionException("Failed to query service: " + e.getMessage());
+            record = CSW.getCSWRecord(serviceUrl, metadataid, lang);
+        } catch (ServiceException e) {
+            throw new ActionException("Unexpected exeption occurred", e);
         }
 
         JSONObject result;
@@ -146,16 +121,6 @@ public class GetCSWDataHandler extends ActionHandler {
         }
 
         ResponseHelper.writeResponse(params, result);
-    }
-
-    private String getMetadataIdForLayer(OskariLayer layer) {
-        String uuid = layer.getMetadataId();
-        if (uuid != null && !uuid.trim().isEmpty()) {
-            // override metadataid
-            return uuid;
-        }
-        // uuid from capabilities
-        return layer.getCapabilities().optString(LayerCapabilitiesOGC.METADATA_UUID, null);
     }
     
     private void prefixImageFilenames(CSWIsoRecord record, final String uuid, final String locale) {

--- a/service-csw/src/main/java/fi/nls/oskari/csw/helper/CSW.java
+++ b/service-csw/src/main/java/fi/nls/oskari/csw/helper/CSW.java
@@ -1,0 +1,104 @@
+package fi.nls.oskari.csw.helper;
+
+import org.json.JSONObject;
+import org.oskari.capabilities.ogc.LayerCapabilitiesOGC;
+
+import fi.nls.oskari.csw.dao.OskariLayerMetadataDao;
+import fi.nls.oskari.csw.domain.CSWIsoRecord;
+import fi.nls.oskari.csw.dto.OskariLayerMetadataDto;
+import fi.nls.oskari.csw.service.CSWService;
+import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.service.ServiceException;
+import fi.nls.oskari.util.PropertyUtil;
+
+public class CSW {
+
+    private static final Logger LOG = LogFactory.getLogger(CSW.class);
+
+    private static final String LAYER_ATTRIBUTE_METADATA_URL = "metadataUrl";
+
+    private CSW() {
+    }
+
+    public static RefreshResult refreshLayerMetadata(OskariLayerMetadataDao metadataDato, OskariLayer layer) {
+        String baseURL = getMetadataServiceBaseURL(layer.getAttributes());
+        String metadataid = getMetadataIdForLayer(layer);
+        String lang = PropertyUtil.getDefaultLanguage();
+
+        if (metadataid == null || metadataid.isBlank()) {
+            return RefreshResult.SKIPPED;
+        }
+
+        try {
+            CSWIsoRecord rec = getCSWRecord(baseURL, metadataid, lang);
+            if (rec == null) {
+                return RefreshResult.RECORD_NOT_FOUND;
+            }
+
+            String json = rec.toJSON().toString();
+            String wkt = rec.getIdentifications().stream().findAny()
+                    .map(x -> x.getExtents().getEnvelope().toText())
+                    .orElse(null);
+            if (wkt == null) {
+                return RefreshResult.GEOMETRY_NOT_FOUND;
+            }
+
+            OskariLayerMetadataDto dto = new OskariLayerMetadataDto();
+            dto.metadataId = metadataid;
+            dto.json = json;
+            dto.wkt = wkt;
+            metadataDato.saveMetadata(dto);
+
+            return RefreshResult.OK;
+        } catch (Exception e) {
+            LOG.warn(e, "CSW metadata handling failed, baseURL", baseURL, "id", metadataid);
+            return RefreshResult.FAILED;
+        }
+    }
+
+    public enum RefreshResult {
+        SKIPPED,
+        RECORD_NOT_FOUND,
+        GEOMETRY_NOT_FOUND,
+        OK,
+        FAILED
+    }
+
+    public static String getMetadataServiceBaseURL(JSONObject layerAttributes) {
+        return layerAttributes != null && layerAttributes.has(LAYER_ATTRIBUTE_METADATA_URL)
+                ? layerAttributes.get(LAYER_ATTRIBUTE_METADATA_URL).toString()
+                : getDefaultServiceBaseURL();
+    }
+
+    public static String getDefaultServiceBaseURL() {
+        return PropertyUtil.getOptional(CSWService.PROP_SERVICE_URL);
+    }
+
+    public static String getMetadataIdForLayer(OskariLayer layer) {
+        String uuid = layer.getMetadataId();
+        if (uuid != null && !uuid.trim().isEmpty()) {
+            // override metadataid
+            return uuid.trim();
+        }
+        // uuid from capabilities
+        return layer.getCapabilities().optString(LayerCapabilitiesOGC.METADATA_UUID, null);
+    }
+
+    public static CSWIsoRecord getCSWRecord(String serviceUrl, String metadataid, String lang) throws ServiceException {
+        CSWService service;
+        try {
+            service = new CSWService(serviceUrl);
+        } catch (Exception e) {
+            throw new ServiceException("Failed to initialize CSWService:" + e.getMessage());
+        }
+
+        try {
+            return service.getRecordById(metadataid, lang);
+        } catch (Exception e) {
+            throw new ServiceException("Failed to query service: " + e.getMessage());
+        }
+    }
+
+}

--- a/service-csw/src/main/java/fi/nls/oskari/csw/worker/CSWCoverageUpdateService.java
+++ b/service-csw/src/main/java/fi/nls/oskari/csw/worker/CSWCoverageUpdateService.java
@@ -1,18 +1,15 @@
 package fi.nls.oskari.csw.worker;
 
-import org.locationtech.jts.geom.Geometry;
 import fi.nls.oskari.annotation.Oskari;
 import fi.nls.oskari.csw.dao.OskariLayerMetadataDao;
-import fi.nls.oskari.csw.domain.CSWIsoRecord;
-import fi.nls.oskari.csw.dto.OskariLayerMetadataDto;
-import fi.nls.oskari.csw.service.CSWService;
+import fi.nls.oskari.csw.helper.CSW;
+import fi.nls.oskari.csw.helper.CSW.RefreshResult;
 import fi.nls.oskari.db.DatasourceHelper;
 import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.map.layer.OskariLayerService;
 import fi.nls.oskari.map.layer.OskariLayerServiceMybatisImpl;
-import fi.nls.oskari.util.PropertyUtil;
 import fi.nls.oskari.worker.ScheduledJob;
 
 import javax.sql.DataSource;
@@ -26,53 +23,29 @@ public class CSWCoverageUpdateService extends ScheduledJob {
     private static final Logger log = LogFactory.getLogger(CSWCoverageUpdateService.class);
 
     final OskariLayerService layerService = new OskariLayerServiceMybatisImpl();
-    final private static String PROPERTY_BASE_URL = CSWService.PROP_SERVICE_URL;
 
     @Override
     public void execute(Map<String, Object> params) {
         log.info("Starting the CSW coverage update service call...");
 
-        final String baseUrl = PropertyUtil.getOptional(PROPERTY_BASE_URL);
-        if(baseUrl == null) {
-            log.warn("Trying to get metadata for layers but property", PROPERTY_BASE_URL, "is missing - quitting!");
-            return;
-        }
-        final CSWService cswService = getCSWService(baseUrl);
-        if(cswService == null) {
-            log.warn("Couldn't get a usable CSW service - quitting!");
-            // no reason to go forward since we can't contact the service
-            return;
-        }
-
-        final Set<String> metadataIdSet = getMetadataIdSet();
-        if(metadataIdSet.isEmpty()) {
-            log.info("No layers with metadata id - quitting!");
-            return;
-        }
         final DataSource dataSource = getDatasource();
-        if(dataSource == null) {
-            log.error("Couldn't get datasource - quitting!");
+        if (dataSource == null) {
             return;
         }
         final OskariLayerMetadataDao dao = new OskariLayerMetadataDao(dataSource);
+
+        int attemptCount = 0;
         int updateCount = 0;
-        for (String metadataId : metadataIdSet) {
-            final CSWIsoRecord csw = getMetadata(cswService, metadataId);
-            final Geometry geom = getGeometry(csw);
-            if(geom == null) {
-                // no geometry on metadata, move to next
-                log.info("Couldn't get geometry for", metadataId);
-                continue;
+        for (OskariLayer layer : layerService.findAll()) {
+            RefreshResult result = CSW.refreshLayerMetadata(dao, layer);
+            if (result != RefreshResult.SKIPPED) {
+                attemptCount++;
             }
-            final OskariLayerMetadataDto dto = new OskariLayerMetadataDto();
-            dto.metadataId  = metadataId;
-            // NOTE! wkt is WGS:84
-            dto.wkt = geom.getEnvelope().toText();
-            dto.json = csw.toJSON().toString();
-            dao.saveMetadata(dto);
-            updateCount++;
+            if (result == RefreshResult.OK) {
+                updateCount++;
+            }
         }
-        log.info("Done with the CSW coverage update service call. Updated:", updateCount, "/", metadataIdSet.size(), "metadata geometries.");
+        log.info("Done with the CSW coverage update service call. Updated:", updateCount, "/", attemptCount, "metadata geometries.");
     }
 
     private DataSource getDatasource() {
@@ -85,62 +58,4 @@ public class CSWCoverageUpdateService extends ScheduledJob {
         return null;
     }
 
-    /**
-     * Returns a set of metadata ids which should be updated
-     * @return
-     */
-    public Set<String> getMetadataIdSet() {
-        final Set<String> result = new HashSet<String>();
-        // TODO: make it a query in DB rather than looping here for distinct values
-        for(OskariLayer layer : layerService.findAll()) {
-            final String uuid = layer.getMetadataId();
-            if(uuid != null && !uuid.trim().isEmpty()) {
-                result.add(layer.getMetadataId());
-            }
-        }
-        return result;
-    }
-
-
-    private CSWIsoRecord getMetadata(final CSWService cswService, final String metadataId) {
-        final String language = PropertyUtil.getDefaultLanguage();
-        try {
-            return cswService.getRecordById(metadataId, language);
-        } catch (Exception e) {
-            List<String> messages = new ArrayList<>();
-            Throwable loopEx = e;
-            messages.add(" - " + loopEx.getClass().getCanonicalName() + ": " + loopEx.getMessage());
-            while (loopEx.getCause() != null) {
-                loopEx = loopEx.getCause();
-                messages.add(loopEx.getClass().getCanonicalName() + ": " + loopEx.getMessage());
-            }
-            log.error("Error fetching metadata for id:", metadataId,
-                    "Causes:\n", String.join("\n - ", messages));
-        }
-        return null;
-    }
-
-    /**
-     * Parses the geometry from CSW record. Note! Only returns the first one!
-     * @param csw
-     * @return
-     */
-    private Geometry getGeometry(CSWIsoRecord csw) {
-        if(csw == null) {
-            return null;
-        }
-        if(!csw.getIdentifications().isEmpty()) {
-            return csw.getIdentifications().get(0).getExtents();
-        }
-        return null;
-    }
-
-    public CSWService getCSWService(final String baseUrl) {
-        try {
-            return new CSWService(baseUrl);
-        } catch (Exception e) {
-            log.error("Failed to initialize CSWService:" + e.getMessage());
-        }
-        return null;
-    }
 }

--- a/service-csw/src/main/java/fi/nls/oskari/csw/worker/CSWCoverageUpdateService.java
+++ b/service-csw/src/main/java/fi/nls/oskari/csw/worker/CSWCoverageUpdateService.java
@@ -26,7 +26,7 @@ public class CSWCoverageUpdateService extends ScheduledJob {
     private static final Logger log = LogFactory.getLogger(CSWCoverageUpdateService.class);
 
     final OskariLayerService layerService = new OskariLayerServiceMybatisImpl();
-    final private static String PROPERTY_BASE_URL = "service.metadata.url";
+    final private static String PROPERTY_BASE_URL = CSWService.PROP_SERVICE_URL;
 
     @Override
     public void execute(Map<String, Object> params) {


### PR DESCRIPTION
**Add support for LayerAdminHandler to upsert the metadata information when saving the layer.** Currently layer metadata is updated only via `CSWCoverageUpdateService` so there's a large delay after saving the layer before the information is updated. In addition there's also no immediate feedback available if there's something wrong with fetching the metadata and/or the extent based on the metadata (maybe the metadata id was wrong?).

**Add new class `CSW` that combines shared logic regarding CSW handling**. GetCSWDataHandler added support for overriding the CSW service base URL via layer attributes, but CSWCoverageUpdateService did not support this functionality. Additionally, GetCSWDataHandler also supported metadataid to exist in layers capabilities whereas CSWCoverageUpdateService ignored this as well. 