### PR TITLE
Bump geotools, tomcat, commons-io versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,12 +77,12 @@
 
 <!-- This will override commons-io to be packaged with version 2.18.0, otherwise
 https://mvnrepository.com/artifact/org.apache.poi/poi-ooxml/5.4.0
-- geotools 32.1 uses 2.17.0 (https://github.com/geotools/geotools/blob/32.1/pom.xml#L942-L944)
+- geotools 34.2 uses 2.21.0 (https://github.com/geotools/geotools/blob/34.x/platform-dependencies/pom.xml#L26)
 - fileupload 2.0.0-M2 uses 2.15.1 (https://commons.apache.org/proper/commons-fileupload/commons-fileupload2-jakarta-servlet6/dependency-management.html)
 - poi-ooxml 5.4.0 uses 2.18.0 (https://github.com/apache/poi/blob/REL_5_4_0/build.gradle#L124)
 The one packaged without this is 2.15.1
   -->
-        <commons-io.version>2.20.0</commons-io.version>
+        <commons-io.version>2.21.0</commons-io.version>
         <commons-csv.version>1.14.1</commons-csv.version>
         <xmlgraphics-fop.version>2.11</xmlgraphics-fop.version>
         <poi-ooxml.version>5.4.1</poi-ooxml.version>
@@ -94,7 +94,7 @@ The one packaged without this is 2.15.1
         <jackson-annotations.version>2.20</jackson-annotations.version>
         <fi.mml.nameregister.version>1.0</fi.mml.nameregister.version>
 
-        <tomcat.version>10.1.47</tomcat.version>
+        <tomcat.version>10.1.50</tomcat.version>
         <mybatis.version>3.5.19</mybatis.version>
         <flyway.version>11.12.0</flyway.version>
         <postgresql.version>42.7.7</postgresql.version>
@@ -107,7 +107,7 @@ The one packaged without this is 2.15.1
 
         <quartz-scheduler.version>2.5.0</quartz-scheduler.version>
 
-        <geotools.version>33.2</geotools.version>
+        <geotools.version>34.2</geotools.version>
         <jts.version>1.20.0</jts.version>
         <!-- https://github.com/ElectronicChartCentre/java-vector-tile -->
         <mvt.version>1.4.1</mvt.version>


### PR DESCRIPTION
Probably works, but hasn't been tested -> draft for now. GeoTools dependency declarations have been moved and can be seen here on version 34+:  https://github.com/geotools/geotools/blob/34.x/platform-dependencies/pom.xml