### PR TITLE
VectorFeatureWriterHandler: Handle null and non-string properties

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/feature/AbstractFeatureHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/feature/AbstractFeatureHandler.java
@@ -168,7 +168,7 @@ public abstract class AbstractFeatureHandler extends RestActionHandler {
             Iterator keys = props.keys();
             while (keys.hasNext()) {
                 String name = (String) keys.next();
-                feature.addProperty(name, props.getString(name));
+                feature.addProperty(name, props.optString(name, null));
             }
         }
         if (jsonObject.has("geometry")) {

--- a/control-base/src/main/java/fi/nls/oskari/control/feature/FeatureWFSTRequestBuilder.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/feature/FeatureWFSTRequestBuilder.java
@@ -36,9 +36,12 @@ public class FeatureWFSTRequestBuilder extends WFSTRequestBuilder {
             xsw.writeCharacters(property.getKey());
             xsw.writeEndElement();
 
-            xsw.writeStartElement(WFS, "Value");
-            xsw.writeCharacters(property.getValue());
-            xsw.writeEndElement();
+            if (property.getValue() != null) {
+                // Omitting <Value> element sets the property to null
+                xsw.writeStartElement(WFS, "Value");
+                xsw.writeCharacters(property.getValue());
+                xsw.writeEndElement();
+            }
 
             xsw.writeEndElement();
         }
@@ -61,6 +64,10 @@ public class FeatureWFSTRequestBuilder extends WFSTRequestBuilder {
         xsw.writeStartElement(feature.getLayerName());
 
         for (Map.Entry<String, String> property : feature.getProperties().entrySet()) {
+            if (property.getValue() == null) {
+                // Skip nulls
+                continue;
+            }
             xsw.writeStartElement(property.getKey());
             xsw.writeCharacters(property.getValue());
             xsw.writeEndElement();

--- a/control-base/src/test/java/fi/nls/oskari/control/feature/FeatureWFSTRequestBuilderTest.java
+++ b/control-base/src/test/java/fi/nls/oskari/control/feature/FeatureWFSTRequestBuilderTest.java
@@ -1,0 +1,74 @@
+package fi.nls.oskari.control.feature;
+
+import fi.nls.oskari.domain.map.Feature;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+public class FeatureWFSTRequestBuilderTest {
+
+    @Test
+    public void testUpdateOmitsValueElementForNullProperty() throws Exception {
+        Feature feature = new Feature();
+        feature.setLayerName("foo");
+        feature.setId("feature.1");
+        feature.addProperty("omistaja", "testi");
+        feature.addProperty("asuntoalat", null);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        FeatureWFSTRequestBuilder.updateFeature(baos, feature);
+        Document doc = parseXML(baos.toString());
+
+        NodeList properties = doc.getElementsByTagNameNS("http://www.opengis.net/wfs", "Property");
+        for (int i = 0; i < properties.getLength(); i++) {
+            NodeList children = properties.item(i).getChildNodes();
+            String name = null;
+            String value = null;
+            for (int j = 0; j < children.getLength(); j++) {
+                if ("Name".equals(children.item(j).getLocalName())) {
+                    name = children.item(j).getTextContent();
+                }
+                if ("Value".equals(children.item(j).getLocalName())) {
+                    value = children.item(j).getTextContent();
+                }
+            }
+            if ("omistaja".equals(name)) {
+                Assertions.assertEquals("testi", value);
+            } else if ("asuntoalat".equals(name)) {
+                // Value element should be omitted entirely for null
+                Assertions.assertNull(value, "Null property should not have a Value element");
+            }
+        }
+    }
+
+    @Test
+    public void testInsertOmitsNullProperty() throws Exception {
+        Feature feature = new Feature();
+        feature.setLayerName("foo");
+        feature.addProperty("omistaja", "testi");
+        feature.addProperty("asuntoalat", null);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        FeatureWFSTRequestBuilder.insertFeature(baos, feature);
+        String xml = baos.toString();
+
+        Document doc = parseXML(xml);
+        // "omistaja" element should exist
+        Assertions.assertEquals(1, doc.getElementsByTagName("omistaja").getLength());
+        // "asuntoalat" element should be omitted entirely
+        Assertions.assertEquals(0, doc.getElementsByTagName("asuntoalat").getLength());
+    }
+
+    private Document parseXML(String xml) throws Exception {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setNamespaceAware(true);
+        return dbf.newDocumentBuilder().parse(
+                new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+    }
+}

--- a/control-base/src/test/java/fi/nls/oskari/control/feature/VectorFeatureWriterHandlerTest.java
+++ b/control-base/src/test/java/fi/nls/oskari/control/feature/VectorFeatureWriterHandlerTest.java
@@ -1,6 +1,7 @@
 package fi.nls.oskari.control.feature;
 
 import fi.nls.oskari.domain.map.Feature;
+import org.json.JSONObject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.CoordinateSequence;
@@ -88,6 +89,27 @@ public class VectorFeatureWriterHandlerTest {
         Document doc = dbf.newDocumentBuilder().parse(new ByteArrayInputStream(wfsTransactionUTF8));
         String posList = doc.getElementsByTagNameNS("http://www.opengis.net/gml", "posList").item(0).getTextContent();
         return Arrays.stream(posList.split(" ")).mapToDouble(Double::parseDouble).toArray();
+    }
+
+    @Test
+    public void testNonStringPropertyInGeoJSON() throws Exception {
+        String geojson = "{\"type\":\"Feature\",\"geometry\":{\"type\":\"MultiPoint\",\"coordinates\":[[327710.84,6824632.15]]},\"properties\":{\"omistaja\":\"testi\",\"valmistumisvuosi\":2926,\"asuntoalat\":null},\"id\":\"feature.1\"}";
+
+        AbstractFeatureHandler handler = new AbstractFeatureHandler() {
+            @Override
+            protected Feature initFeatureByLayer(String layerId) {
+                Feature f = new Feature();
+                f.setLayerName("foo");
+                f.setGMLGeometryProperty("geometry");
+                return f;
+            }
+        };
+
+        Feature feature = handler.getFeature(new JSONObject(geojson), "1", "EPSG:3067", "feature.1");
+
+        Assertions.assertEquals("testi", feature.getProperties().get("omistaja"));
+        Assertions.assertEquals("2926", feature.getProperties().get("valmistumisvuosi"));
+        Assertions.assertNull(feature.getProperties().get("asuntoalat"));
     }
 
 }


### PR DESCRIPTION
Handle non-string and null property values, avoid errors such as:
```
org.json.JSONException: JSONObject["aloitusvuosi"] is not a string (class java.lang.Integer : 2024).
org.json.JSONException: JSONObject["asuntoalat"] is not a string (class org.json.JSONObject$Null : null).
        at org.json.JSONObject.wrongValueFormatException(JSONObject.java:3016)
        at org.json.JSONObject.getString(JSONObject.java:943)
        at fi.nls.oskari.control.feature.AbstractFeatureHandler.getFeature(AbstractFeatureHandler.java:171)
        at fi.nls.oskari.control.feature.VectorFeatureWriterHandler.handlePost(VectorFeatureWriterHandler.java:71)
```