### PR TITLE
Add myfeatures_feature table partitioning

### DIFF
--- a/content-resources/src/main/java/flyway/myfeatures/V1_0_5__partitioning.java
+++ b/content-resources/src/main/java/flyway/myfeatures/V1_0_5__partitioning.java
@@ -1,0 +1,100 @@
+package flyway.myfeatures;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+
+import fi.nls.oskari.db.DatasourceHelper;
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.util.PropertyUtil;
+
+/**
+ * Partition myfeatures_feature into n partitions by layer_id (hash)
+ * only if configured via property 'myfeatures.numPartitions'
+ */
+public class V1_0_5__partitioning extends BaseJavaMigration {
+
+    private static final Logger LOG = LogFactory.getLogger(V1_0_5__partitioning.class);
+
+    private static final String PROP_NUM_PARTITIONS = "myfeatures.numPartitions";
+
+    public void migrate(Context ctx) throws Exception {
+        int numPartitions = PropertyUtil.getOptional(PROP_NUM_PARTITIONS, -1);
+        if (numPartitions <= 1) {
+            LOG.info("Skipping partitioning due to nothing to do as", PROP_NUM_PARTITIONS, "=", numPartitions);
+            return;
+        }
+        checkNumPartitions(numPartitions);
+
+        LOG.info("Creating partitions using setting", PROP_NUM_PARTITIONS, "=", numPartitions);
+
+        DatasourceHelper helper = DatasourceHelper.getInstance();
+        try (Connection c = helper.getDataSource(helper.getOskariDataSourceName("myfeatures")).getConnection()) {
+            exec(c, createPartitionedTable());
+            for (int i = 0; i < numPartitions; i++) {
+                exec(c, createPartition(i, numPartitions));
+            }
+            exec(c, insertFromNonPartitioned());
+            for (int i = 0; i < numPartitions; i++) {
+                exec(c, createGeomIndex(i));
+            }
+            exec(c, dropNonPartitioned());
+            exec(c, renamePartitioned());
+        }
+    }
+
+    private static void checkNumPartitions(int numPartitions) {
+        switch (numPartitions) {
+            case 2, 4, 8, 16, 32, 64, 128, 256: break;
+            default: throw new IllegalArgumentException(PROP_NUM_PARTITIONS + " must be one of 2, 4, 8, 16, 32, 64, 128, 256!");
+        }
+    }
+
+    private static void exec(Connection c, String sql) throws SQLException {
+        try (PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.execute();
+        }
+    }
+
+    private static String createPartitionedTable() {
+        return ""
+            + "CREATE TABLE myfeatures_feature_p ("
+            + "	id bigint GENERATED ALWAYS AS IDENTITY,"
+            + "	layer_id uuid,"
+            + "	created timestamp with time zone,"
+            + "	updated timestamp with time zone,"
+            + "	geom geometry,"
+            + "	properties json,"
+            // Primary key must include partition key (layer_id)
+            + "	CONSTRAINT pk_myfeatures_feature_p PRIMARY KEY (layer_id, id),"
+            + "	CONSTRAINT myfeatures_feature_p_myfeatures_layer_fkey FOREIGN KEY (layer_id) REFERENCES myfeatures_layer(id) ON DELETE CASCADE"
+            + ")"
+            + "PARTITION BY HASH (layer_id)";
+    }
+
+    private static String createPartition(int remainder, int modulus) {
+        return String.format("CREATE TABLE myfeatures_feature_p%d PARTITION OF myfeatures_feature_p FOR VALUES WITH (MODULUS %d, REMAINDER %d)",
+            remainder, modulus, remainder);
+    }
+
+    private static String insertFromNonPartitioned() {
+        return "INSERT INTO myfeatures_feature_p (layer_id, created, updated, geom, properties)"
+            + " SELECT layer_id, created, updated, geom, properties FROM myfeatures_feature";
+    }
+
+    private static String createGeomIndex(int remainder) {
+        return String.format("CREATE INDEX myfeatures_feature_p%d_geom_idx ON myfeatures_feature_p%d USING gist (geom)", remainder, remainder);
+    }
+
+    private static String dropNonPartitioned() {
+        return "DROP TABLE myfeatures_feature";
+    }
+
+    private static String renamePartitioned() {
+        return "ALTER TABLE myfeatures_feature_p RENAME TO myfeatures_feature";
+    }
+}

--- a/service-myfeatures/src/main/java/org/oskari/map/myfeatures/service/MyFeaturesMapper.java
+++ b/service-myfeatures/src/main/java/org/oskari/map/myfeatures/service/MyFeaturesMapper.java
@@ -80,17 +80,17 @@ public interface MyFeaturesMapper {
         @Result(property="geometry", column="geom"),
         @Result(property="properties", column="properties")
     })
-    public MyFeaturesFeature findFeatureById(long featureId);
+    public MyFeaturesFeature findFeatureById(UUID layerId, long featureId);
 
     @Select("UPDATE myfeatures_feature SET " +
-            "updated = #{updated}, " +
-            "geom = #{geometry}, " +
-            "properties = #{properties}::json " +
-            "WHERE id = #{id}")
-    public void updateFeature(MyFeaturesFeature feature);
+            "updated = #{feature.updated}, " +
+            "geom = #{feature.geometry}, " +
+            "properties = #{feature.properties}::json " +
+            "WHERE layer_id = #{layerId} AND id = #{feature.id}")
+    public void updateFeature(UUID layerId, MyFeaturesFeature feature);
 
-    @Delete("DELETE FROM myfeatures_feature WHERE id = #{featureId}")
-    public void deleteFeature(long featureId);
+    @Delete("DELETE FROM myfeatures_feature WHERE layer_id = #{layerId} AND id = #{featureId}")
+    public void deleteFeature(UUID layerId, long featureId);
 
     @Select("SELECT id, created, updated, ST_AsBinary(geom) AS geom, properties FROM myfeatures_feature WHERE layer_id = #{layerId}")
     @ResultMap("MyFeaturesFeatureResult")

--- a/service-myfeatures/src/main/java/org/oskari/map/myfeatures/service/MyFeaturesServiceMybatisImpl.java
+++ b/service-myfeatures/src/main/java/org/oskari/map/myfeatures/service/MyFeaturesServiceMybatisImpl.java
@@ -126,7 +126,7 @@ public class MyFeaturesServiceMybatisImpl extends MyFeaturesService {
             return null;
         }
         try (SqlSession session = factory.openSession()) {
-            MyFeaturesFeature f = getMapper(session).findFeatureById(featureId);
+            MyFeaturesFeature f = getMapper(session).findFeatureById(layerId, featureId);
             if (f != null) {
                 setNativeSRID(f);
             }
@@ -159,7 +159,7 @@ public class MyFeaturesServiceMybatisImpl extends MyFeaturesService {
             feature.setUpdated(now);
             feature.getGeometry();
 
-            mapper.updateFeature(feature);
+            mapper.updateFeature(layerId, feature);
             mapper.refreshLayerMetadata(layerId);
 
             session.commit();
@@ -171,7 +171,7 @@ public class MyFeaturesServiceMybatisImpl extends MyFeaturesService {
         layerId = Objects.requireNonNull(layerId);
         try (SqlSession session = factory.openSession()) {
             MyFeaturesMapper mapper = getMapper(session);
-            mapper.deleteFeature(featureId);
+            mapper.deleteFeature(layerId, featureId);
             mapper.refreshLayerMetadata(layerId);
             session.commit();
         }


### PR DESCRIPTION
Currently all _myfeatures_ features are stored in a single table. With tens of thousands of layers this becomes somewhat slow/problematic. Ease the pain with table partitioning (https://www.postgresql.org/docs/current/ddl-partitioning.html).

Users can opt-in to partitioning by setting property `myfeatures.numPartitions` to an appropriate number (2, 4, 8, ..., 128, 256) of partitions to create before running this migration. A power of two is optimal for hashing. 2 is the lowest we can go and 256 is the highest we thought would make sense to anyone. If you require a higher number run these manually, you'll probably have too much data anyways to run this as a single flyway migration anyways. Sensible value for most users would probably be in the range of 16-64.

Additionally, make sure MyFeaturesMapper provides layer_id to database also when finding a feature by id, updating a feature by id or deleting the feature id. That way the database will know which partition to look at, and if there are no partitions the additional check has close to zero effect on performance.