### PR TITLE
Fix myfeatures migration for appsetups using userlayers

### DIFF
--- a/content-resources/src/main/java/flyway/myfeatures_userlayer/V1_1__migrate_published_userlayers.java
+++ b/content-resources/src/main/java/flyway/myfeatures_userlayer/V1_1__migrate_published_userlayers.java
@@ -29,7 +29,7 @@ public class V1_1__migrate_published_userlayers extends BaseJavaMigration {
     public void migrate(Context ctx) throws Exception {
         DatasourceHelper helper = DatasourceHelper.getInstance();
         List<UserLayerIdToLayerId> mapping = null;
-        try (Connection c = helper.getDataSource(helper.getOskariDataSourceName("userlayer")).getConnection()) {
+        try (Connection c = helper.getDataSource(helper.getOskariDataSourceName("myfeatures")).getConnection()) {
             mapping = getMapping(c);
         }
         if (mapping.isEmpty()) {


### PR DESCRIPTION
Mapping table is in the myfeatures db, not userlayer db. Easy to miss if everything is in one db, but if user data is stored in a separate db the migration fails.