### PR TITLE
Add indicator if GetWFSFeatures/GetWFSVectorTile has more features

### DIFF
--- a/control-base/src/main/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandler.java
+++ b/control-base/src/main/java/fi/nls/oskari/control/feature/GetWFSFeaturesHandler.java
@@ -32,6 +32,7 @@ public class GetWFSFeaturesHandler extends AbstractWFSFeaturesHandler {
 
     protected static final String ERR_BBOX_INVALID = "Invalid bbox";
     protected static final String ERR_GEOJSON_ENCODE_FAIL = "Failed to write GeoJSON";
+    protected static final String HEADER_HAS_MORE_FEATURES = "X-Maybe-Has-More-Features";
 
     private static final String PARAM_BBOX = "bbox";
 
@@ -69,6 +70,14 @@ public class GetWFSFeaturesHandler extends AbstractWFSFeaturesHandler {
             OutputStreamWriter writer = new OutputStreamWriter(baos, StandardCharsets.UTF_8);
             int decimals = GeoJSONUtil.getNumDecimals(ProjectionHelper.isUnitDegrees(targetCRS));
             new FeatureJSON(new GeometryJSON(decimals)).writeFeatureCollection(fc, writer);
+            // Oskari-specific layers (userlayer/myplaces/myfeatures) don't apply maxFeatures limit
+            int maxFeatures = contentProcessor.isPresent()
+                ? Integer.MAX_VALUE
+                : OskariWFSClient.getMaxFeatures(layer);
+            // fc should be an in-memory collection by this point, so size() should be cheap
+            if (fc.size() >= maxFeatures) {
+                params.getResponse().setHeader(HEADER_HAS_MORE_FEATURES, "true");
+            }
             ResponseHelper.writeResponse(params, 200, GEOJSON_CONTENT_TYPE, baos);
         } catch (IOException e) {
             throw new ActionCommonException(ERR_GEOJSON_ENCODE_FAIL, e);

--- a/control-mvt/src/main/java/org/oskari/control/mvt/GetWFSVectorTileHandler.java
+++ b/control-mvt/src/main/java/org/oskari/control/mvt/GetWFSVectorTileHandler.java
@@ -41,14 +41,18 @@ import fi.nls.oskari.service.ServiceRuntimeException;
 import fi.nls.oskari.util.IOHelper;
 import fi.nls.oskari.util.ResponseHelper;
 import org.oskari.service.mvt.WFSTileGridProperties;
+import org.oskari.service.wfs.client.OskariWFSClient;
 
 @OskariActionRoute("GetWFSVectorTile")
 public class GetWFSVectorTileHandler extends AbstractWFSFeaturesHandler {
 
     protected static final String MVT_CONTENT_TYPE = "application/vnd.mapbox-vector-tile";
+    protected static final String HEADER_HAS_MORE_FEATURES = "X-Maybe-Has-More-Features";
     protected static final String PARAM_Z = "z";
     protected static final String PARAM_X = "x";
     protected static final String PARAM_Y = "y";
+
+    private record TileResult(byte[] bytes, boolean hasMore) {}
 
     // Resolution (metres per px) we are aiming for with the WFS requests
     // This value is used to find the zoom level that is closest to the resolution specified here
@@ -71,7 +75,7 @@ public class GetWFSVectorTileHandler extends AbstractWFSFeaturesHandler {
     private static final int CACHE_LIMIT = 256;
     private static final long CACHE_EXPIRATION = TimeUnit.MINUTES.toMillis(5);
 
-    private ComputeOnceCache<byte[]> tileCache;
+    private ComputeOnceCache<TileResult> tileCache;
     private WFSTileGridProperties tileGridProperties;
     private Map<String, Integer> cacheZLevels;
 
@@ -119,7 +123,7 @@ public class GetWFSVectorTileHandler extends AbstractWFSFeaturesHandler {
         }
 
         final String cacheKey = getCacheKey(id, srs, z, x, y);
-        final byte[] resp;
+        final TileResult resp;
         try {
             if (contentProcessor.isPresent() && contentProcessor.get().isUserContentLayer(id)) {
                 // Don't cache user content tiles
@@ -132,7 +136,10 @@ public class GetWFSVectorTileHandler extends AbstractWFSFeaturesHandler {
         }
         params.getResponse().addHeader("Access-Control-Allow-Origin", "*");
         params.getResponse().addHeader("Content-Encoding", "gzip");
-        ResponseHelper.writeResponse(params, 200, MVT_CONTENT_TYPE, resp);
+        if (resp.hasMore()) {
+            params.getResponse().setHeader(HEADER_HAS_MORE_FEATURES, "true");
+        }
+        ResponseHelper.writeResponse(params, 200, MVT_CONTENT_TYPE, resp.bytes());
     }
 
     private void setGridToModifiers (WFSVectorLayerPluginViewModifier handler, String srsName, WFSTileGrid grid) {
@@ -207,14 +214,20 @@ public class GetWFSVectorTileHandler extends AbstractWFSFeaturesHandler {
      * @return an MVT tile as a GZipped byte array
      * @throws ActionException
      */
-    private byte[] createTile(String id, OskariLayer layer, CoordinateReferenceSystem crs,
+    private TileResult createTile(String id, OskariLayer layer, CoordinateReferenceSystem crs,
             WFSTileGrid grid, int targetZ, int z, int x, int y,
             Optional<UserLayerService> contentProcessor) {
         List<TileCoord> tilesToLoad = getTilesToLoad(targetZ, z, x, y);
 
+        // Oskari-specific layers (userlayer/myplaces/myfeatures) don't apply maxFeatures limit
+        int maxFeatures = contentProcessor.isPresent() ? Integer.MAX_VALUE : OskariWFSClient.getMaxFeatures(layer);
+        boolean hasMore = false;
         DefaultFeatureCollection sfc = new DefaultFeatureCollection();
         for (TileCoord tile : tilesToLoad) {
             SimpleFeatureCollection tileFeatures = getFeatures(id, layer, crs, grid, tile, contentProcessor);
+            if (!hasMore && tileFeatures.size() >= maxFeatures) {
+                hasMore = true;
+            }
             sfc.addAll(tileFeatures);
         }
 
@@ -225,7 +238,7 @@ public class GetWFSVectorTileHandler extends AbstractWFSFeaturesHandler {
 
         byte[] encoded = SimpleFeaturesMVTEncoder.encodeToByteArray(sfc, mvtLayer, bbox, extent, buffer);
         try {
-            return IOHelper.gzip(encoded).toByteArray();
+            return new TileResult(IOHelper.gzip(encoded).toByteArray(), hasMore);
         } catch (IOException e) {
             throw new ServiceRuntimeException("Unexpected IOException occured");
         }

--- a/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFSClient.java
+++ b/service-wfs-client/src/main/java/org/oskari/service/wfs/client/OskariWFSClient.java
@@ -186,7 +186,7 @@ public class OskariWFSClient {
         }
         return true;
     }
-    protected static int getMaxFeatures(OskariLayer layer) {
+    public static int getMaxFeatures(OskariLayer layer) {
         int maxFeatures = layer.getAttributes().optInt(WFSLayerAttributes.KEY_MAXFEATURES, -1);
         if (maxFeatures > 0) {
             return maxFeatures;


### PR DESCRIPTION
Set HTTP header `X-Maybe-Has-More-Features` to `true` if there are potentially (but not necessarily) more features to load. There's no way for client to "request more" (via offset or pagination etc) so this is just an indicator of the fact. However, an indicator is enough to let the client decide if an area is fully loaded or if subsequent requests should be made when zooming in for example.

More recent implementations of user generated content (myplaces/userlayer/myfeatures) do not restrict the number of features returned per request => do not use `OskariWFSClient.getMaxFeatures` to determine the maximum for those layers.