### PR TITLE
Layeradmin coverage

### DIFF
--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerAdminHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerAdminHandler.java
@@ -111,14 +111,11 @@ public class LayerAdminHandler extends AbstractLayerAdminHandler {
         boolean capabilitiesUpdated = updateCapabilities(ml);
         MapLayerAdminOutput output = getLayerForEdit(params.getUser(), ml);
         final JSONObject attributes = ml.getAttributes();
-        if (!attributes.optBoolean(LayerJSONFormatter.KEY_ATTRIBUTE_IGNORE_COVERAGE, false)) {
-            output.setCoverage(WKTHelper.transformLayerCoverage(ml.getGeometry(), srs));
-        }
-        if (!attributes.optBoolean(LayerJSONFormatter.KEY_ATTRIBUTE_IGNORE_METADATA_COVERAGE, false)) {
-            OskariLayerMetadataDto metadataDto = metadataDao.findMetadata(ml.getMetadataId());
-            if (metadataDto != null && metadataDto.wkt != null) {
-                output.setCoverageMetadata(WKTHelper.transformLayerCoverage(metadataDto.wkt, srs));
-            }
+
+        output.setCoverage(WKTHelper.transformLayerCoverage(ml.getGeometry(), srs));
+        OskariLayerMetadataDto metadataDto = metadataDao.findMetadata(ml.getMetadataId());
+        if (metadataDto != null && metadataDto.wkt != null) {
+            output.setCoverageMetadata(WKTHelper.transformLayerCoverage(metadataDto.wkt, srs));
         }
         if (!capabilitiesUpdated) {
             output.setWarn(KEY_UPDATE_CAPA_FAIL);

--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerAdminHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerAdminHandler.java
@@ -8,6 +8,7 @@ import fi.nls.oskari.control.ActionParameters;
 import fi.nls.oskari.control.ActionParamsException;
 import fi.nls.oskari.control.layer.GetMapLayerGroupsHandler;
 import fi.nls.oskari.csw.dao.OskariLayerMetadataDao;
+import fi.nls.oskari.csw.dto.OskariLayerMetadataDto;
 import fi.nls.oskari.csw.helper.CSW;
 import fi.nls.oskari.csw.helper.CSW.RefreshResult;
 import fi.nls.oskari.db.DatasourceHelper;
@@ -112,6 +113,12 @@ public class LayerAdminHandler extends AbstractLayerAdminHandler {
         final JSONObject attributes = ml.getAttributes();
         if (!attributes.optBoolean(LayerJSONFormatter.KEY_ATTRIBUTE_IGNORE_COVERAGE, false)) {
             output.setCoverage(WKTHelper.transformLayerCoverage(ml.getGeometry(), srs));
+        }
+        if (!attributes.optBoolean(LayerJSONFormatter.KEY_ATTRIBUTE_IGNORE_METADATA_COVERAGE, false)) {
+            OskariLayerMetadataDto metadataDto = metadataDao.findMetadata(ml.getMetadataId());
+            if (metadataDto != null && metadataDto.wkt != null) {
+                output.setCoverageMetadata(WKTHelper.transformLayerCoverage(metadataDto.wkt, srs));
+            }
         }
         if (!capabilitiesUpdated) {
             output.setWarn(KEY_UPDATE_CAPA_FAIL);

--- a/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerAdminHandler.java
+++ b/control-admin/src/main/java/fi/nls/oskari/control/admin/LayerAdminHandler.java
@@ -12,6 +12,8 @@ import fi.nls.oskari.csw.helper.CSW;
 import fi.nls.oskari.csw.helper.CSW.RefreshResult;
 import fi.nls.oskari.db.DatasourceHelper;
 
+import fi.nls.oskari.map.geometry.WKTHelper;
+import fi.nls.oskari.map.layer.formatters.LayerJSONFormatter;
 import org.oskari.user.User;
 import fi.nls.oskari.domain.map.DataProvider;
 import fi.nls.oskari.domain.map.OskariLayer;
@@ -47,6 +49,7 @@ public class LayerAdminHandler extends AbstractLayerAdminHandler {
     private static final Logger LOG = LogFactory.getLogger(LayerAdminHandler.class);
 
     private static final String PARAM_LAYER_ID = "id";
+    private static final String PARAM_SRS = "srs";
     private static final String KEY_LOCALIZED_NAME = "name";
     private static final String KEY_LOCALIZED_TITLE = "subtitle";
     // Response from service
@@ -102,9 +105,14 @@ public class LayerAdminHandler extends AbstractLayerAdminHandler {
     @Override
     public void handleGet(ActionParameters params) throws ActionException {
         final int layerId = params.getRequiredParamInt(PARAM_LAYER_ID);
+        String srs = params.getHttpParam(PARAM_SRS, PropertyUtil.get("oskari.native.srs", "EPSG:4326"));
         OskariLayer ml = getMapLayer(params.getUser(), layerId);
         boolean capabilitiesUpdated = updateCapabilities(ml);
         MapLayerAdminOutput output = getLayerForEdit(params.getUser(), ml);
+        final JSONObject attributes = ml.getAttributes();
+        if (!attributes.optBoolean(LayerJSONFormatter.KEY_ATTRIBUTE_IGNORE_COVERAGE, false)) {
+            output.setCoverage(WKTHelper.transformLayerCoverage(ml.getGeometry(), srs));
+        }
         if (!capabilitiesUpdated) {
             output.setWarn(KEY_UPDATE_CAPA_FAIL);
         }

--- a/service-csw/src/main/java/fi/nls/oskari/csw/dao/OskariLayerMetadataDao.java
+++ b/service-csw/src/main/java/fi/nls/oskari/csw/dao/OskariLayerMetadataDao.java
@@ -29,6 +29,22 @@ public class OskariLayerMetadataDao {
         return new SqlSessionFactoryBuilder().build(configuration);
     }
 
+    public OskariLayerMetadataDto findMetadata(String metadataId) {
+        if (metadataId == null || metadataId.isEmpty()) {
+            return null;
+        }
+        final SqlSession session = factory.openSession();
+        try {
+            final OskariLayerMetadataDto.Mapper mapper = session.getMapper(OskariLayerMetadataDto.Mapper.class);
+            return mapper.find(metadataId);
+        } catch (Exception e) {
+            log.error(e, "Error finding metadata for metadataId:", metadataId);
+            return null;
+        } finally {
+            session.close();
+        }
+    }
+
     public void saveMetadata(OskariLayerMetadataDto dto) {
         final SqlSession session = factory.openSession();
         try {

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/OskariLayerServiceMybatisImpl.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/OskariLayerServiceMybatisImpl.java
@@ -26,6 +26,7 @@ import fi.nls.oskari.domain.map.DataProvider;
 import fi.nls.oskari.domain.map.OskariLayer;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.map.layer.formatters.LayerJSONFormatter;
 import fi.nls.oskari.map.layer.group.link.OskariLayerGroupLink;
 import fi.nls.oskari.map.layer.group.link.OskariLayerGroupLinkService;
 import fi.nls.oskari.util.JSONHelper;
@@ -111,7 +112,13 @@ public class OskariLayerServiceMybatisImpl extends OskariLayerService {
         result.setUsername((String) data.get("username"));
         result.setPassword((String) data.get("password"));
 
-        result.setGeometry((String) data.get("geom"));
+        // Use metadata coverage when available unless explicitly disabled.
+        // If not set here, OskariLayer.getGeometry() falls back to capabilities geom/bbox.
+        final boolean ignoreMetadataCoverage = result.getAttributes()
+                .optBoolean(LayerJSONFormatter.KEY_ATTRIBUTE_IGNORE_METADATA_COVERAGE, false);
+        if (!ignoreMetadataCoverage) {
+            result.setGeometry((String) data.get("geom"));
+        }
 
         result.setSrs_name((String) data.get("srs_name"));
         result.setVersion((String) data.get("version"));

--- a/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
+++ b/service-map/src/main/java/fi/nls/oskari/map/layer/formatters/LayerJSONFormatter.java
@@ -32,6 +32,7 @@ public class LayerJSONFormatter {
     public static final String PROPERTY_AJAXURL = "oskari.ajax.url.prefix";
     public static final String KEY_ATTRIBUTE_FORCED_SRS = "forcedSRS";
     public static final String KEY_ATTRIBUTE_IGNORE_COVERAGE = "ignoreCoverage";
+    public static final String KEY_ATTRIBUTE_IGNORE_METADATA_COVERAGE = "ignoreMetadataCoverage";
     public static final String KEY_LEGENDS = "legends";
     public static final String KEY_GLOBAL_LEGEND = "legendImage";
     public static final String KEY_TYPE = "type";

--- a/service-map/src/main/java/org/oskari/maplayer/model/MapLayerAdminOutput.java
+++ b/service-map/src/main/java/org/oskari/maplayer/model/MapLayerAdminOutput.java
@@ -8,6 +8,7 @@ import java.util.*;
 public class MapLayerAdminOutput extends MapLayer {
 
     public String coverage;
+    public String coverageMetadata;
     private String warn;
     private Map<String, Object> capabilities;
     private Date created;
@@ -64,5 +65,13 @@ public class MapLayerAdminOutput extends MapLayer {
 
     public void setCoverage(String coverage) {
         this.coverage = coverage;
+    }
+
+    public String getCoverageMetadata() {
+        return coverageMetadata;
+    }
+
+    public void setCoverageMetadata(String coverageMetadata) {
+        this.coverageMetadata = coverageMetadata;
     }
 }

--- a/service-map/src/main/java/org/oskari/maplayer/model/MapLayerAdminOutput.java
+++ b/service-map/src/main/java/org/oskari/maplayer/model/MapLayerAdminOutput.java
@@ -7,6 +7,7 @@ import java.util.*;
  */
 public class MapLayerAdminOutput extends MapLayer {
 
+    public String coverage;
     private String warn;
     private Map<String, Object> capabilities;
     private Date created;
@@ -55,5 +56,13 @@ public class MapLayerAdminOutput extends MapLayer {
 
     public void setCapabilities_last_updated(Date capabilities_last_updated) {
         this.capabilities_last_updated = capabilities_last_updated;
+    }
+
+    public String getCoverage() {
+        return coverage;
+    }
+
+    public void setCoverage(String coverage) {
+        this.coverage = coverage;
     }
 }


### PR DESCRIPTION
* bring coverage info from layer metadata as part of LayerAdmin - action route response
* add ignoreMetadataCoverage flag which porevents using coverage info from metadata as default coverage for layer

related pr in oskari-frontend: https://github.com/oskariorg/oskari-frontend/pull/2992