### PR TITLE
Add support for reading metadataURL for OAPIF layers

### DIFF
--- a/service-capabilities/src/main/java/org/oskari/capabilities/ogc/WFSCapabilitiesParser.java
+++ b/service-capabilities/src/main/java/org/oskari/capabilities/ogc/WFSCapabilitiesParser.java
@@ -176,6 +176,7 @@ public class WFSCapabilitiesParser extends OGCCapabilitiesParser {
     }
 
     protected List<LayerCapabilitiesWFS> getOGCAPIFeatures(OGCAPIFeaturesService service) {
+        String datasetMetadataUrl = service.getDatasetMetadataUrl();
         return service.getCollections().stream().map(collection -> {
                     String name = collection.getId();
                     String title = collection.getTitle();
@@ -187,6 +188,12 @@ public class WFSCapabilitiesParser extends OGCCapabilitiesParser {
                     featureType.setSupportedCrsURIs(service.getSupportedCrsURIs(name));
 
                     featureType.setFormats(service.getSupportedFormats(name));
+
+                    String metadataUrl = OGCAPIFeaturesService.findMetadataUrl(collection.getLinks());
+                    if (metadataUrl == null) {
+                        metadataUrl = datasetMetadataUrl;
+                    }
+                    featureType.setMetadataUrl(metadataUrl);
                     return featureType;
                 })
                 .collect(Collectors.toList());

--- a/service-capabilities/src/main/java/org/oskari/capabilities/ogc/api/OGCAPIFeaturesService.java
+++ b/service-capabilities/src/main/java/org/oskari/capabilities/ogc/api/OGCAPIFeaturesService.java
@@ -6,6 +6,8 @@ import java.net.HttpURLConnection;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import org.oskari.ogcapi.OpenAPILink;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonParseException;
@@ -137,6 +139,23 @@ public class OGCAPIFeaturesService {
 
     public List<FeaturesCollectionInfo> getCollections() {
         return new ArrayList<>(content.getCollections());
+    }
+
+    public String getDatasetMetadataUrl() {
+        return findMetadataUrl(content.getLinks());
+    }
+
+    public static String findMetadataUrl(List<OpenAPILink> links) {
+        if (links == null) {
+            return null;
+        }
+        return links.stream()
+                .filter(l -> "describedby".equalsIgnoreCase(l.getRel()))
+                .filter(l -> l.getType() != null
+                        && l.getType().toLowerCase().startsWith("application/xml"))
+                .map(OpenAPILink::getHref)
+                .findFirst()
+                .orElse(null);
     }
 
     public Optional<FeaturesCollectionInfo> getCollection(String id) {

--- a/service-capabilities/src/test/java/org/oskari/capabilities/ogc/api/OGCAPIFeaturesServiceTest.java
+++ b/service-capabilities/src/test/java/org/oskari/capabilities/ogc/api/OGCAPIFeaturesServiceTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.oskari.ogcapi.OGCAPIReqClasses;
+import org.oskari.ogcapi.OpenAPILink;
 import org.oskari.ogcapi.features.FeaturesCollectionInfo;
 import org.oskari.ogcapi.features.FeaturesContent;
 
@@ -95,6 +96,52 @@ public class OGCAPIFeaturesServiceTest {
         Collections.sort(actualList);
 
         assertIterablesEquals(expectedList, actualList);
+    }
+
+    @Test
+    public void testFixtureHasNoMetadataLinks() {
+        Assertions.assertNull(service.getDatasetMetadataUrl());
+        service.getCollections().forEach(c ->
+                Assertions.assertNull(OGCAPIFeaturesService.findMetadataUrl(c.getLinks())));
+    }
+
+    @Test
+    public void testFindMetadataUrlFiltersDescribedbyXml() {
+        String url = OGCAPIFeaturesService.findMetadataUrl(List.of(
+                new OpenAPILink("https://example.org/schema", "describedby", "application/schema+json", null, null),
+                new OpenAPILink("https://example.org/meta.xml", "DescribedBy", "application/xml", null, "iso"),
+                new OpenAPILink("https://example.org/meta2.xml", "describedby", "application/xml", null, "second")));
+        Assertions.assertEquals("https://example.org/meta.xml", url);
+    }
+
+    @Test
+    public void testFindMetadataUrlAcceptsXmlSubtype() {
+        String url = OGCAPIFeaturesService.findMetadataUrl(List.of(
+                new OpenAPILink("https://example.org/iso.xml", "describedby", "application/xml; charset=utf-8", null, null)));
+        Assertions.assertEquals("https://example.org/iso.xml", url);
+    }
+
+    @Test
+    public void testFindMetadataUrlNullWhenNoMatch() {
+        String url = OGCAPIFeaturesService.findMetadataUrl(List.of(
+                new OpenAPILink("https://example.org/x", "self", "application/xml", null, null),
+                new OpenAPILink("https://example.org/y.html", "describedby", "text/html", null, null)));
+        Assertions.assertNull(url);
+    }
+
+    @Test
+    public void testDatasetMetadataUrlFromTopLevelLinks() throws Exception {
+        FeaturesContent content = new FeaturesContent();
+        content.setLinks(List.of(
+                new OpenAPILink("https://example.org/self", "self", "application/json", null, null),
+                new OpenAPILink("https://example.org/dataset.xml", "describedby", "application/xml", null, null)));
+        content.setCollections(Collections.emptyList());
+        OGCAPIReqClasses reqClasses;
+        try (InputStream in = getClass().getResourceAsStream("OGCAPIFeatures_Conformance.json")) {
+            reqClasses = OGCAPIFeaturesService.load(in, OGCAPIReqClasses.class);
+        }
+        OGCAPIFeaturesService svc = new OGCAPIFeaturesService(reqClasses, content);
+        Assertions.assertEquals("https://example.org/dataset.xml", svc.getDatasetMetadataUrl());
     }
 
     private <T> void assertIterablesEquals(Iterable<T> expected, Iterable<T> actual) {

--- a/service-capabilities/src/test/resources/org/oskari/capabilities/ogc/WFSCapabilitiesParserTest-statfi-3_0_0-expected.json
+++ b/service-capabilities/src/test/resources/org/oskari/capabilities/ogc/WFSCapabilitiesParserTest-statfi-3_0_0-expected.json
@@ -14,5 +14,7 @@
   "desc": "INSPIRE SU AreaStatisticalUnit in Finland in 4500k scale EPSG:4326 year 2020",
   "crs-uri": [
     "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
-  ]
+  ],
+  "metadataUrl": "https://www.paikkatietohakemisto.fi/geonetwork/srv/api/records/b4693808-0f3b-4d5e-b366-c410b680ac19/formatters/xml",
+  "metadataId": "b4693808-0f3b-4d5e-b366-c410b680ac19"
 }


### PR DESCRIPTION
Try to read metadataURL from `/collections` response of OGC API Features services. Defined by recommendation `/rec/core/fc-md-descriptions` in [OGC API - Features - Part 1](https://docs.ogc.org/is/17-069r4/17-069r4.html). 