### PR TITLE
Override newer version of micrometer (related to resilience4j)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,11 @@ The one packaged without this is 2.15.1
         https://github.com/resilience4j/resilience4j/pull/2415
          -->
         <resilience4j.version>2.4.0</resilience4j.version>
+        <!--
+        Resilience4j 2.4.0 uses vulnerable micrometer 1.16.0 version.
+        When updating resilience4j, remove micrometer from managed dependencies and try again
+         -->
+        <micrometer.version>1.16.7</micrometer.version>
         <!-- Test deps versions -->
         <mockito.version>5.19.0</mockito.version>
         <!-- https://github.com/junit-team/junit-framework/wiki/Upgrading-to-JUnit-6.0 -->
@@ -798,6 +803,11 @@ The one packaged without this is 2.15.1
                 <groupId>io.github.resilience4j</groupId>
                 <artifactId>resilience4j-all</artifactId>
                 <version>${resilience4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.micrometer</groupId>
+                <artifactId>micrometer-core</artifactId>
+                <version>${micrometer.version}</version>
             </dependency>
 
             <!-- Managed test dependencies -->


### PR DESCRIPTION
We can remove the managed dependency when Resilience4j is upgraded.