### PR TITLE
Ignore charset when comparing content type header value

### DIFF
--- a/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
@@ -447,12 +447,13 @@ public class IOHelper {
         }
 
         if (expectedContentType != null) {
-            String contentType = conn.getContentType();
+            String contentType = getContentType(conn.getContentType());
             if (contentType != null && !expectedContentType.equals(contentType)) {
                 throw new ServiceRuntimeException("Unexpected content type " + contentType);
             }
         }
     }
+
     /**
      * If logger is set to debug this method reads the input stream, prints the response as text
      * and wraps it to another input stream for further consumption.
@@ -471,6 +472,14 @@ public class IOHelper {
 
         final ByteArrayInputStream debug = new ByteArrayInputStream(response);
         return debug;
+    }
+
+    public static String getContentType(final String contentType) {
+        if (contentType == null) {
+            return null;
+        }
+        final String[] values = contentType.split(";");
+        return values[0].trim();
     }
 
     public static String getCharset(final HttpURLConnection con) {

--- a/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
+++ b/service-base/src/main/java/fi/nls/oskari/util/IOHelper.java
@@ -448,7 +448,7 @@ public class IOHelper {
 
         if (expectedContentType != null) {
             String contentType = getContentType(conn.getContentType());
-            if (contentType != null && !expectedContentType.equals(contentType)) {
+            if (contentType != null && !expectedContentType.equalsIgnoreCase(contentType)) {
                 throw new ServiceRuntimeException("Unexpected content type " + contentType);
             }
         }

--- a/service-base/src/test/java/fi/nls/oskari/util/IOHelperTest.java
+++ b/service-base/src/test/java/fi/nls/oskari/util/IOHelperTest.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Created with IntelliJ IDEA.
@@ -155,5 +156,13 @@ public class IOHelperTest {
     @Test
     public void testUserAgent() {
         assertEquals("Oskari/0.0", IOHelper.getUserAgent(), "Test that the default version is returned when we don't have a MANIFEST.MF");
+    }
+
+    @Test
+    public void testGetContentType() {
+        assertEquals("application/geo+json", IOHelper.getContentType("application/geo+json; charset=utf-8"), "Test that charset from header value isn't returned");
+        assertEquals("application/geo+json", IOHelper.getContentType("application/geo+json"), "Test that ct without charset works");
+        assertEquals("test", IOHelper.getContentType("test"), "Test that random ct works");
+        assertNull(IOHelper.getContentType(null), "Test that null value is returned as null");
     }
 }


### PR DESCRIPTION
There's a similar method in IOHelper to get the charset from content-type header so this is mostly a copy of that one. Not sure if we should throw an exception if content-type is missing, but decided to return it as null if it's not included.

This fixes an issue where https://github.com/oskariorg/oskari-server/blob/3.3.0/service-wfs3/src/main/java/org/oskari/service/wfs3/OskariWFS3Client.java#L133 tries to check the content-type but fails if the charset is included:
<img width="529" height="31" alt="ade085b0-ec62-47f8-a5a1-73d8bedef216" src="https://github.com/user-attachments/assets/0ffb548c-0ac4-40b4-b271-fff68362d446" />
