### PR TITLE
Derive MVT feature id from the feature id instead of a per-tile counter

### DIFF
--- a/service-mvt/src/main/java/org/oskari/service/mvt/SimpleFeaturesMVTEncoder.java
+++ b/service-mvt/src/main/java/org/oskari/service/mvt/SimpleFeaturesMVTEncoder.java
@@ -1,5 +1,6 @@
 package org.oskari.service.mvt;
 
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 import no.ecc.vectortile.VectorTileEncoder;
@@ -28,6 +29,9 @@ public class SimpleFeaturesMVTEncoder {
 
     private static final GeometryFactory GF = new GeometryFactory();
 
+    private static final long FNV_OFFSET_BASIS = 0xcbf29ce484222325L;
+    private static final long FNV_PRIME = 0x100000001b3L;
+
     public static byte[] encodeToByteArray(SimpleFeatureCollection sfc,
             String layer, double[] bbox, int extent, int buffer) {
 
@@ -37,9 +41,28 @@ public class SimpleFeaturesMVTEncoder {
                 .map(geom -> SimpleFeatureConverter.fromGeometry(geom))
                 .filter(Optional::isPresent)
                 .map(Optional::get)
-                .forEach(f -> encoder.addFeature(layer, f.properties, f.geom));
+                .forEach(f -> encoder.addFeature(layer, f.properties, f.geom, toNumericId(f.id)));
 
         return encoder.encode();
+    }
+
+    /**
+     * Hashes the string id of the source feature to the uint64 the MVT feature id is. The
+     * same feature appears in several tiles (tiles are encoded with a buffer) and the client
+     * relies on the id to recognize those as one feature, so the hash must be stable.
+     */
+    static long toNumericId(String id) {
+        if (id == null) {
+            // VectorTileEncoder writes no id at all for a negative one
+            return -1L;
+        }
+        long hash = FNV_OFFSET_BASIS;
+        for (byte b : id.getBytes(StandardCharsets.UTF_8)) {
+            hash ^= (b & 0xff);
+            hash *= FNV_PRIME;
+        }
+        // Keep it non-negative, see above
+        return hash & Long.MAX_VALUE;
     }
 
     public static List<Geometry> asMVTGeoms(SimpleFeatureCollection sfc, double[] bbox, int extent, int buffer) {

--- a/service-mvt/src/test/java/org/oskari/service/mvt/SimpleFeaturesMVTEncoderTest.java
+++ b/service-mvt/src/test/java/org/oskari/service/mvt/SimpleFeaturesMVTEncoderTest.java
@@ -1,12 +1,14 @@
 package org.oskari.service.mvt;
 
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import no.ecc.vectortile.VectorTileDecoder;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.feature.DefaultFeatureCollection;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
@@ -30,6 +32,10 @@ import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygon;
 
 public class SimpleFeaturesMVTEncoderTest {
+
+    private static final int EXTENT = 4096;
+    private static final int BUFFER = 256;
+    private static final String LAYER = "test";
 
     @Test
     public void pointFeaturesInBufferZoneWontBeRemoved() throws Exception {
@@ -304,13 +310,13 @@ public class SimpleFeaturesMVTEncoderTest {
 */
         double[] bbox = grid.getTileExtent(new TileCoord(7, 50, 102));
         List<Geometry> mvtGeoms = SimpleFeaturesMVTEncoder.asMVTGeoms(sfc, bbox, 4096, 256);
-        Assertions.assertEquals(175, mvtGeoms.size()); // wdtinc & no.ecc both 33063 bytes (~200ms)
+        Assertions.assertEquals(175, mvtGeoms.size()); // wdtinc & no.ecc both 33063 bytes (~200ms), 34813 since feature ids are written
 
         long start = System.currentTimeMillis();
         byte[] bytes = SimpleFeaturesMVTEncoder.encodeToByteArray(sfc, "test", bbox, 4096, 256);
         long duration = System.currentTimeMillis() - start;
         System.out.println(duration + "ms -> " + bytes.length);
-        Assertions.assertEquals(33063, bytes.length, "Check size");
+        Assertions.assertEquals(34813, bytes.length, "Check size");
         Assertions.assertTrue(duration < 400, "Check time"); // Should be around ~200ms but CI might be slower
     }
     @Test
@@ -328,14 +334,14 @@ public class SimpleFeaturesMVTEncoderTest {
 
         double[] bbox = grid.getTileExtent(new TileCoord(10, 456, 826));
         List<Geometry> mvtGeoms = SimpleFeaturesMVTEncoder.asMVTGeoms(sfc, bbox, 4096, 256);
-        Assertions.assertEquals(28, mvtGeoms.size()); // wdtinc 3941bytes (~300ms) / no.ecc 4539bytes (~300ms)
+        Assertions.assertEquals(28, mvtGeoms.size()); // wdtinc 3941bytes (~300ms) / no.ecc 4819bytes (~300ms)
 
         long start = System.currentTimeMillis();
         byte[] bytes = SimpleFeaturesMVTEncoder.encodeToByteArray(sfc, "test", bbox, 4096, 256);
 
         long duration = System.currentTimeMillis() - start;
         System.out.println(duration + "ms -> " + bytes.length);
-        Assertions.assertEquals(4539, bytes.length, "Check size");
+        Assertions.assertEquals(4819, bytes.length, "Check size");
         Assertions.assertTrue(duration < 500, "Check time"); // Should be around ~300ms but CI might be slower
     }
     @Test
@@ -352,15 +358,59 @@ public class SimpleFeaturesMVTEncoderTest {
         SimpleFeatureCollection sfc = GeoJSONReader2.toFeatureCollection(json, schema);
         double[] bbox = grid.getTileExtent(new TileCoord(10, 459, 838));
         List<Geometry> mvtGeoms = SimpleFeaturesMVTEncoder.asMVTGeoms(sfc, bbox, 4096, 256);
-        Assertions.assertEquals(284, mvtGeoms.size()); // wdtinc 3941bytes (~300ms) / no.ecc 32083bytes (~300ms)
+        Assertions.assertEquals(284, mvtGeoms.size()); // wdtinc 3941bytes (~300ms) / no.ecc 34908bytes (~300ms)
 
         long start = System.currentTimeMillis();
         byte[] bytes = SimpleFeaturesMVTEncoder.encodeToByteArray(sfc, "test", bbox, 4096, 256);
 
         long duration = System.currentTimeMillis() - start;
         System.out.println(duration + "ms -> " + bytes.length);
-        Assertions.assertEquals(32083, bytes.length, "Check size");
+        Assertions.assertEquals(34908, bytes.length, "Check size");
         Assertions.assertTrue(duration < 500, "Check time"); // Should be around ~300ms but CI might be slower
 
     }
+
+    @Test
+    public void featureKeepsItsIdAcrossAdjacentTiles() throws Exception {
+        GeometryFactory gf = new GeometryFactory();
+
+        SimpleFeatureTypeBuilder tBuilder = new SimpleFeatureTypeBuilder();
+        tBuilder.setName("test");
+        tBuilder.add("geom", Point.class);
+        SimpleFeatureType featureType = tBuilder.buildFeatureType();
+        SimpleFeatureBuilder fBuilder = new SimpleFeatureBuilder(featureType);
+
+        // A point right on the shared edge of two vertically adjacent tiles,
+        // so it falls within the buffer of both
+        Point p = gf.createPoint(new Coordinate(50, 100));
+        fBuilder.set("geom", p);
+        DefaultFeatureCollection fc = new DefaultFeatureCollection("test", featureType);
+        fc.add(fBuilder.buildFeature("EP_KOHDE.210791"));
+
+        byte[] lower = SimpleFeaturesMVTEncoder.encodeToByteArray(
+                fc, LAYER, new double[] { 0, 0, 100, 100 }, EXTENT, BUFFER);
+        byte[] upper = SimpleFeaturesMVTEncoder.encodeToByteArray(
+                fc, LAYER, new double[] { 0, 100, 100, 200 }, EXTENT, BUFFER);
+
+        List<VectorTileDecoder.Feature> inLower = decode(lower);
+        List<VectorTileDecoder.Feature> inUpper = decode(upper);
+
+        Assertions.assertEquals(1, inLower.size(), "feature is in the lower tile");
+        Assertions.assertEquals(1, inUpper.size(), "feature is in the upper tile");
+        Assertions.assertEquals(inLower.get(0).getId(), inUpper.get(0).getId(),
+                "same feature must have the same id in both tiles");
+        Assertions.assertEquals(SimpleFeaturesMVTEncoder.toNumericId("EP_KOHDE.210791"), inLower.get(0).getId(),
+                "id is derived from the feature id");
+        Assertions.assertEquals("EP_KOHDE.210791", inLower.get(0).getAttributes().get("_oid"),
+                "_oid property is still written");
+    }
+
+    private static List<VectorTileDecoder.Feature> decode(byte[] tile) throws Exception {
+        List<VectorTileDecoder.Feature> features = new ArrayList<>();
+        for (VectorTileDecoder.Feature f : new VectorTileDecoder().decode(tile)) {
+            features.add(f);
+        }
+        return features;
+    }
+
 }


### PR DESCRIPTION
Fixes features not being recognized as the same feature across tile boundaries.

VectorTileEncoder was left to assign the MVT feature id, which it does from a counter scoped to one tile. This is clearly problematic for features extending to multiple tiles (even points do due to tile buffers). Instead use a stable hash function to construct the MVT feature id from the original String id. The chance for hash collisions with full 63 bit space is low. (_You mean 64, not 63?_ Nope, go read `toNumericId((String id)`) 

The downsize: Tiles grow by up to 10 bytes per feature: a full-range id varint where the old counter cost one. The three byte-size assertions in SimpleFeaturesMVTEncoderTest are updated accordingly

`_oid` is unchanged. Alternatively this could probably have been solved at frontend level with MVT Format option idProperty, but that has it's own problems as it also deletes the property it hoists to id and frontend expects `_oid` property to exist at multiple other places.